### PR TITLE
fix(config): preserve unknown fields on host-block saveConfig writes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ All notable changes to claude-honcho will be documented in this file.
 - Spinner degrades gracefully without a TTY — Claude Code >=2.1.139 runs hooks without a controlling terminal, so `/dev/tty` fails; probe for a real terminal and fall back to a single clean line when none is available.
 - `sessionStart` hook now runs async (#43).
 - Preserve a host-scoped `apiKey` already on disk when rewriting config — no longer drops `hosts.<host>.apiKey` on save.
+
 ## [0.2.4] - 2026-04-01
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to claude-honcho will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- `saveConfig()` no longer strips unknown fields from the current host's config block on every write. Previously, any field added to `hosts.<host>.*` that isn't declared on the `HostConfig` interface (e.g. the documented `linkedHosts` field) was silently removed the next time the plugin persisted config — typically on every directory change via `setSessionForPath()`. The new host entry is now seeded with unknown fields from the existing entry before the known-field write logic runs, so user-added config survives round-trips.
+
 ## [0.2.5] - 2026-06-02
 
 ### Added
@@ -24,7 +28,6 @@ All notable changes to claude-honcho will be documented in this file.
 - Spinner degrades gracefully without a TTY — Claude Code >=2.1.139 runs hooks without a controlling terminal, so `/dev/tty` fails; probe for a real terminal and fall back to a single clean line when none is available.
 - `sessionStart` hook now runs async (#43).
 - Preserve a host-scoped `apiKey` already on disk when rewriting config — no longer drops `hosts.<host>.apiKey` on save.
-
 ## [0.2.4] - 2026-04-01
 
 ### Added

--- a/plugins/honcho/src/config.ts
+++ b/plugins/honcho/src/config.ts
@@ -92,6 +92,27 @@ export interface HostConfig {
   endpoint?: HonchoEndpointConfig;
 }
 
+type HostConfigOnDisk = HostConfig & Record<string, unknown>;
+
+const HOST_CONFIG_KEYS = [
+  "workspace",
+  "aiPeer",
+  "apiKey",
+  "enabled",
+  "logging",
+  "saveMessages",
+  "sessionStrategy",
+  "sessionPeerPrefix",
+  "reasoningLevel",
+  "observationMode",
+  "messageUpload",
+  "contextRefresh",
+  "localContext",
+  "endpoint",
+] as const satisfies readonly (keyof HostConfig)[];
+
+const KNOWN_HOST_KEYS: ReadonlySet<string> = new Set(HOST_CONFIG_KEYS);
+
 let _detectedHost: HonchoHost | null = null;
 
 export function setDetectedHost(host: HonchoHost): void {
@@ -131,6 +152,60 @@ export function getDefaultWorkspace(host?: HonchoHost): string {
 
 export function getDefaultAiPeer(host?: HonchoHost): string {
   return DEFAULT_AI_PEER[host ?? getDetectedHost()];
+}
+
+/**
+ * Return the canonical host key plus legacy hyphen/underscore aliases in
+ * resolve precedence order.
+ */
+function getHostConfigKeys(host: HonchoHost): string[] {
+  return Array.from(new Set([
+    host,
+    host.replace(/_/g, "-"),
+    host.replace(/-/g, "_"),
+  ]));
+}
+
+/**
+ * Resolve a host block using the same alias fallback rules for read and write
+ * paths.
+ */
+function getHostBlock(
+  hosts: Record<string, HostConfigOnDisk> | undefined,
+  host: HonchoHost
+): HostConfigOnDisk | undefined {
+  if (!hosts) return undefined;
+  for (const hostKey of getHostConfigKeys(host)) {
+    const hostBlock = hosts[hostKey];
+    if (hostBlock != null) return hostBlock;
+  }
+  return undefined;
+}
+
+/**
+ * Preserve user-defined on-disk host fields that the plugin does not parse.
+ */
+function copyUnknownHostFields(
+  target: HostConfigOnDisk,
+  source: HostConfigOnDisk | undefined
+): void {
+  if (!source) return;
+  for (const [key, value] of Object.entries(source)) {
+    if (!KNOWN_HOST_KEYS.has(key)) {
+      target[key] = value;
+    }
+  }
+}
+
+/**
+ * Assign a declared host field without hiding the surrounding on-disk shape.
+ */
+function setKnownHostField<K extends keyof HostConfig>(
+  target: HostConfig,
+  key: K,
+  value: HostConfig[K]
+): void {
+  target[key] = value;
 }
 
 // Stdin cache: entry points read stdin once via initHook(),
@@ -186,7 +261,7 @@ interface HonchoFileConfig {
   observationMode?: ObservationMode;
   /** Memory statusLine visibility: "on" (default) · "off" */
   statusline?: StatuslineMode;
-  hosts?: Record<string, HostConfig>;
+  hosts?: Record<string, HostConfigOnDisk>;
   /** When true, flat workspace/aiPeer fields apply to ALL hosts,
    *  ignoring host-specific blocks. When false (default), each host
    *  uses its own block and flat fields are fallbacks only. */
@@ -291,10 +366,11 @@ export function loadConfig(host?: HonchoHost): HonchoCLAUDEConfig | null {
   return loadConfigFromEnv(resolvedHost);
 }
 
+/**
+ * Resolve file-backed config for one host before applying runtime env toggles.
+ */
 function resolveConfig(raw: HonchoFileConfig, host: HonchoHost): HonchoCLAUDEConfig | null {
-  const hostBlock = raw.hosts?.[host]
-    ?? raw.hosts?.[host.replace(/_/g, "-")]
-    ?? raw.hosts?.[host.replace(/-/g, "_")];
+  const hostBlock = getHostBlock(raw.hosts, host);
 
   // Resolution order: env var > host-scoped apiKey > root apiKey.
   const apiKey = process.env.HONCHO_API_KEY || hostBlock?.apiKey || raw.apiKey;
@@ -456,10 +532,21 @@ export function saveConfig(config: HonchoCLAUDEConfig): void {
   // into new host overrides. This preserves root fallback behavior.
   const host = getDetectedHost();
   if (!existing.hosts) existing.hosts = {};
-  const existingHost: HostConfig = existing.hosts[host] ?? {};
+  const hosts = existing.hosts;
+  const existingHost: HostConfigOnDisk = getHostBlock(hosts, host) ?? {};
 
-  const hostEntry: HostConfig = {};
+  // Seed with unknown fields from host aliases so the write below doesn't
+  // strip user-added config the plugin doesn't parse (e.g. `linkedHosts`).
+  // Alias entries are copied first so canonical host fields win conflicts.
+  const hostEntry: HostConfigOnDisk = {};
+  for (const hostKey of [...getHostConfigKeys(host)].reverse()) {
+    copyUnknownHostFields(hostEntry, hosts[hostKey]);
+  }
 
+  /**
+   * Persist a declared host field only when it is already host-local or differs
+   * from its root fallback.
+   */
   const setHostIfExplicit = <K extends keyof HostConfig>(
     key: K,
     value: HostConfig[K],
@@ -468,7 +555,7 @@ export function saveConfig(config: HonchoCLAUDEConfig): void {
     if (value === undefined) return;
     const hasHostOverride = Object.prototype.hasOwnProperty.call(existingHost, key);
     if (hasHostOverride || !deepEqual(value, rootValue)) {
-      hostEntry[key] = value;
+      setKnownHostField(hostEntry, key, value);
     }
   };
 
@@ -508,7 +595,7 @@ export function saveConfig(config: HonchoCLAUDEConfig): void {
     hostEntry.apiKey = existingHost.apiKey;
   }
 
-  existing.hosts[host] = hostEntry;
+  hosts[host] = hostEntry;
 
   writeFileSync(CONFIG_FILE, JSON.stringify(existing, null, 2));
 }

--- a/plugins/honcho/src/config.ts
+++ b/plugins/honcho/src/config.ts
@@ -112,7 +112,6 @@ const HOST_CONFIG_KEYS = [
 ] as const satisfies readonly (keyof HostConfig)[];
 
 const KNOWN_HOST_KEYS: ReadonlySet<string> = new Set(HOST_CONFIG_KEYS);
-
 let _detectedHost: HonchoHost | null = null;
 
 export function setDetectedHost(host: HonchoHost): void {
@@ -207,7 +206,6 @@ function setKnownHostField<K extends keyof HostConfig>(
 ): void {
   target[key] = value;
 }
-
 // Stdin cache: entry points read stdin once via initHook(),
 // handlers consume from cache via getCachedStdin().
 let _stdinText: string | null = null;


### PR DESCRIPTION
## Summary

`saveConfig()` silently dropped any field on `hosts.<host>.*` that is not declared on the `HostConfig` TypeScript interface. The documented `linkedHosts` option was the main victim: it can exist in user config but is not parsed by the plugin, so every config write rebuilt the current host block and erased it.

This PR preserves unknown per-host fields across `saveConfig()` round-trips, including legacy host alias blocks such as `hosts["claude-code"]` that `resolveConfig()` already accepts.

## Root cause

Before this change, `saveConfig()` rebuilt the current host entry from scratch and assigned it back over the existing on-disk entry:

```ts
const hostEntry: HostConfig = {};
// setHostIfExplicit(...) repopulates only declared HostConfig fields
existing.hosts[host] = hostEntry;
```

Other host blocks were preserved, but the current host block was replaced wholesale. Fields outside the declared `HostConfig` shape evaporated. The first fix preserved unknown fields from the canonical block; review then caught that alias-only fields could still be lost when loading from `claude-code` and saving to `claude_code`.

## Fix

- Model on-disk host blocks as `HostConfigOnDisk = HostConfig & Record<string, unknown>`.
- Keep the known host key list typed with `satisfies readonly (keyof HostConfig)[]`.
- Centralize host alias resolution so read and write paths use the same `claude_code` / `claude-code` fallback behavior.
- Seed the saved canonical host entry with unknown fields from alias and canonical host blocks before writing known fields, with canonical values winning conflicts.
- Remove the assignment cast that hid the intentional on-disk shape.

Known-field semantics are unchanged: root-default fallback and host-override persistence still flow through the existing `setHostIfExplicit()` behavior.

## Test plan

- [x] TypeScript typecheck: `bunx tsc --noEmit`
- [x] Whitespace/diff check: `git diff --check -- plugins/honcho/src/config.ts CHANGELOG.md`
- [x] Smoke test with temporary `HOME`: seed `hosts["claude-code"].linkedHosts`, call `loadConfig()` + `saveConfig()`, verify the saved `hosts.claude_code.linkedHosts` and other unknown alias fields survive
- [x] Conflict regression with temporary `HOME`: seed both `hosts["claude-code"]` and `hosts.claude_code`, verify unknown fields from both are merged and canonical unknown fields win conflicts

## Related

The `linkedHosts` field is documented in the [Claude Code integration guide](https://docs.honcho.dev/v3/guides/integrations/claude-code#linking-hosts-for-cross-tool-context), but the plugin source currently has zero references to it. This PR only fixes config preservation; implementing cross-workspace read fan-out is out of scope.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Per-host configuration now preserves custom and previously unrecognized fields when saving, preventing user-added data from being dropped across saves and directory/session switches.
* **Documentation**
  * Updated the changelog with an **Unreleased** entry describing the improved persistence behavior for per-host custom fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
