### PR TITLE
fix: suppress cloud GUI session URL for local/custom endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to claude-honcho will be documented in this file.
 
+## [Unreleased]
+
+### Fixed
+
+- `honchoSessionUrl` no longer prints `https://app.honcho.dev/...` for local or custom self-hosted endpoints — the hosted GUI only exists for `production`, so pointing users at a cloud workspace that does not contain their sessions was misleading. The `user-prompt` hook now suppresses the "view your session in honcho GUI" line on non-production endpoints; `get_config` and `set_config` MCP responses omit `sessionUrl` in the same cases.
+
 ## [0.2.4] - 2026-04-01
 
 ### Added

--- a/plugins/honcho/src/hooks/user-prompt.ts
+++ b/plugins/honcho/src/hooks/user-prompt.ts
@@ -126,10 +126,12 @@ export async function handleUserPrompt(): Promise<void> {
   incrementMessageCount();
   const shouldShowSessionLink = messageCountBefore === 0;
 
-  // Build session link lazily — only materialized on first message
-  const sessionLink = shouldShowSessionLink
-    ? formatSessionLink(honchoSessionUrl(config.workspace, sessionName))
-    : undefined;
+  // Build session link lazily — only materialized on first message, and only
+  // when running against the hosted GUI (local/custom endpoints have none).
+  const sessionUrl = shouldShowSessionLink
+    ? honchoSessionUrl(config.workspace, sessionName, config.endpoint)
+    : null;
+  const sessionLink = sessionUrl ? formatSessionLink(sessionUrl) : undefined;
 
   // Skip trivial prompts — no context needed for "y", "ok", etc.
   if (shouldSkipContextRetrieval(prompt)) {

--- a/plugins/honcho/src/mcp/server.ts
+++ b/plugins/honcho/src/mcp/server.ts
@@ -121,7 +121,9 @@ function handleGetConfig(cwd: string) {
     ? endpointInfo.type === "production" ? "platform" : endpointInfo.type
     : null;
 
-  const sessionUrl = cfg && sessionName ? honchoSessionUrl(cfg.workspace, sessionName, cfg.endpoint) : null;
+  const sessionUrl = cfg && sessionName
+    ? (honchoSessionUrl(cfg.workspace, sessionName, cfg.endpoint) ?? undefined)
+    : undefined;
 
   const current = cfg ? {
     workspace: cfg.workspace,

--- a/plugins/honcho/src/mcp/server.ts
+++ b/plugins/honcho/src/mcp/server.ts
@@ -121,7 +121,7 @@ function handleGetConfig(cwd: string) {
     ? endpointInfo.type === "production" ? "platform" : endpointInfo.type
     : null;
 
-  const sessionUrl = cfg && sessionName ? honchoSessionUrl(cfg.workspace, sessionName) : null;
+  const sessionUrl = cfg && sessionName ? honchoSessionUrl(cfg.workspace, sessionName, cfg.endpoint) : null;
 
   const current = cfg ? {
     workspace: cfg.workspace,
@@ -487,7 +487,7 @@ function handleSetConfig(args: Record<string, unknown>) {
   // Include session URL when session-affecting fields change
   const cwd = getLastActiveCwd() || process.cwd();
   const newSessionName = SESSION_AFFECTING_FIELDS.has(field) ? getSessionName(cwd) : undefined;
-  const sessionUrl = newSessionName ? honchoSessionUrl(cfg.workspace, newSessionName) : undefined;
+  const sessionUrl = newSessionName ? (honchoSessionUrl(cfg.workspace, newSessionName, cfg.endpoint) ?? undefined) : undefined;
 
   return {
     content: [{

--- a/plugins/honcho/src/styles.ts
+++ b/plugins/honcho/src/styles.ts
@@ -181,7 +181,7 @@ export function sessionLine(
   endpoint?: HonchoEndpointConfig,
 ): string {
   const url = honchoSessionUrl(workspace, sessionName, endpoint);
-  const label = `${colors.dim}Honcho session:${colors.reset}`;
+  const labelText = `${colors.dim}Honcho session:${colors.reset}`;
   const name = `${colors.skyBlue}${sessionName}${colors.reset}`;
-  return url ? `${label} ${hyperlink(url, name)}` : `${label} ${name}`;
+  return url ? `${labelText} ${hyperlink(url, name)}` : `${labelText} ${name}`;
 }

--- a/plugins/honcho/src/styles.ts
+++ b/plugins/honcho/src/styles.ts
@@ -6,6 +6,7 @@
  * - Orange to pale light blue gradient
  * - Consistent hierarchy: headers, labels, values, dim text
  */
+import type { HonchoEndpointConfig } from "./config.js";
 
 // ANSI color codes - orange to pale light blue gradient
 export const colors = {
@@ -147,9 +148,20 @@ export function highlight(text: string): string {
 }
 
 /**
- * Build a Honcho app URL for a session
+ * Build a Honcho app URL for a session.
+ *
+ * The hosted GUI at app.honcho.dev only exists for the production endpoint.
+ * For local or custom self-hosted deployments there is no web frontend, so
+ * returning a cloud URL would point users at a workspace that does not exist
+ * in their instance. Returns null in those cases so callers can suppress the
+ * link entirely.
  */
-export function honchoSessionUrl(workspace: string, sessionName: string): string {
+export function honchoSessionUrl(
+  workspace: string,
+  sessionName: string,
+  endpoint?: HonchoEndpointConfig,
+): string | null {
+  if (endpoint?.baseUrl || endpoint?.environment === "local") return null;
   return `https://app.honcho.dev/explore?workspace=${encodeURIComponent(workspace)}&view=sessions&session=${encodeURIComponent(sessionName)}`;
 }
 
@@ -161,9 +173,15 @@ export function hyperlink(url: string, text: string): string {
 }
 
 /**
- * Styled session line with clickable hyperlink to Honcho app
+ * Styled session line with clickable hyperlink to Honcho app (when available)
  */
-export function sessionLine(workspace: string, sessionName: string): string {
-  const url = honchoSessionUrl(workspace, sessionName);
-  return `${colors.dim}Honcho session:${colors.reset} ${hyperlink(url, `${colors.skyBlue}${sessionName}${colors.reset}`)}`;
+export function sessionLine(
+  workspace: string,
+  sessionName: string,
+  endpoint?: HonchoEndpointConfig,
+): string {
+  const url = honchoSessionUrl(workspace, sessionName, endpoint);
+  const label = `${colors.dim}Honcho session:${colors.reset}`;
+  const name = `${colors.skyBlue}${sessionName}${colors.reset}`;
+  return url ? `${label} ${hyperlink(url, name)}` : `${label} ${name}`;
 }


### PR DESCRIPTION
## Summary

`honchoSessionUrl()` in `plugins/honcho/src/styles.ts` always returned a cloud URL (`https://app.honcho.dev/explore?...`), regardless of whether the plugin was configured to talk to the hosted API or a self-hosted instance.

For self-hosted deployments (`endpoint.environment = "local"`, or a custom `endpoint.baseUrl`) there is no web frontend shipped with the Honcho server - the repo is API + deriver + Postgres + Redis only. So the printed URL pointed users at a cloud workspace that did not contain their actual sessions.

The `user-prompt` hook surfaces this most visibly: on the first message of every session it prints

```
view your session in honcho GUI: https://app.honcho.dev/explore?workspace=...&session=...
```

which is misleading against a local/custom endpoint. The `get_config` and `set_config` MCP responses embed the same URL.

## Fix

- `honchoSessionUrl(workspace, sessionName, endpoint?)` now returns `string | null`. It returns the cloud URL only when `endpoint` resolves to production (no `baseUrl` and `environment !== "local"`). For local or custom baseUrl endpoints it returns `null`.
- `user-prompt` hook skips the session-link log line when the URL is `null`.
- `get_config` and `set_config` MCP handlers omit `sessionUrl` from their response when `null`.
- `sessionLine()` falls back to a plain styled label (no hyperlink) when no URL is available.

No change in behavior for production users - they still see the same link as before.

## Test plan

- [x] `bunx tsc --noEmit -p plugins/honcho/tsconfig.json` passes.
- [x] Manually verified against a self-hosted Honcho at `http://localhost:8000` with `~/.honcho/config.json` containing `"endpoint": { "environment": "local" }` - the `view your session in honcho GUI: ...` line no longer appears on first message, and `get_config` no longer embeds the cloud URL.
- [x] Production path unchanged - `honchoSessionUrl("ws", "sess", undefined)` and `honchoSessionUrl("ws", "sess", { environment: "production" })` both return the `app.honcho.dev` URL.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Session GUI links are no longer shown for local or custom self‑hosted endpoints, avoiding broken cloud GUI links in those environments.
  * The user prompt will omit the “view your session in honcho GUI” line for non‑production endpoints.
  * MCP get/set responses omit the session URL for non‑production/local endpoints.

* **Documentation**
  * Unreleased changelog entry documenting the behavior changes above.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->