### PR TITLE
fix: strip pasted code/diffs from user-prompt + tag tool-action metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to claude-honcho will be documented in this file.
 
+## [Unreleased]
+
+### Fixed
+
+- **User-prompt content stripping** — pasted code blocks, runs of unified-diff lines, and >200-char path-bearing lines are now redacted from `userPeer` messages before upload. These pastes ride `role: "user"` per the Anthropic Messages API but are not the user's authored prose; the server-side fact extractor previously read them as user statements and produced misattribution facts (e.g. `<user> changed buildOperatorPlan` from a pasted diff in an adversarial-review prompt). When anything is redacted, the queued message is tagged with `metadata.type = "user_paste_not_speech"` so server-side extraction can filter cross-peer attribution. (`src/hooks/user-prompt.ts`, `src/cache.ts`)
+- **Tool-action metadata tagging** — `aiPeer.message` uploads from `post-tool-use.ts` now carry `metadata.type = "tool_action"` and `metadata.subject = "ai_action_on_user_behalf"`. In directional observation mode (and any deployment where aiPeer cross-observes the user), this lets server-side extraction distinguish assistant-authored actions from user-authored prose and avoid folding them into the user-peer's representation. (`src/hooks/post-tool-use.ts`, `src/hooks/session-end.ts`)
+
+### Changed
+
+- `QueuedMessage` interface gains an optional `metadata` field; `queueMessage()` accepts an optional 5th argument that is forwarded to `userPeer.message()` at session-end. Backwards compatible — existing callers and queued messages without metadata continue to work. (`src/cache.ts`, `src/hooks/session-end.ts`)
+
 ## [0.2.4] - 2026-04-01
 
 ### Added

--- a/plugins/honcho/scripts/test-strip-pastes.ts
+++ b/plugins/honcho/scripts/test-strip-pastes.ts
@@ -22,10 +22,19 @@ function stripPastes(prompt: string): { prompt: string; redacted: boolean } {
     return "[code block removed]";
   });
 
-  out = out.replace(/(?:^[+\-].*(?:\r?\n|$)){3,}/gm, () => {
-    redacted = true;
-    return "[diff removed]\n";
-  });
+  const looksLikeUnifiedDiff = /^(?:@@|---\s+a\/|\+\+\+\s+b\/)/m.test(out);
+  if (looksLikeUnifiedDiff) {
+    let diffRedacted = false;
+    out = out.replace(/^(?:@@.*|---\s.*|\+\+\+\s.*|[+\-].*)(?:\r?\n|$)/gm, () => {
+      diffRedacted = true;
+      return "";
+    });
+    if (diffRedacted) {
+      redacted = true;
+      out = out.replace(/(?:\r?\n){2,}/g, "\n").replace(/^(\s*\n)+/, "");
+      out = "[diff removed]\n" + out;
+    }
+  }
 
   out = out
     .split("\n")
@@ -63,10 +72,10 @@ const cases: Case[] = [
     mustNotContain: ["const x"],
   },
   {
-    name: "unified diff — must redact",
+    name: "+/- lines without diff anchor (ambiguous, treated as prose) — must NOT redact",
     input: "Review this diff:\n+const a = 1;\n-const b = 2;\n+const c = 3;\nThanks.",
-    expectRedacted: true,
-    mustContain: ["[diff removed]"],
+    expectRedacted: false,
+    mustNotContain: ["[diff removed]"],
   },
   {
     name: "long path-bearing line — must redact",
@@ -105,6 +114,34 @@ Look for race conditions and security issues.`,
     name: "only a single +/- line (not a runs-of-3+ diff) — must NOT redact",
     input: "Note: + means added, - means removed.",
     expectRedacted: false,
+  },
+  {
+    name: "markdown bullet list (3+ items) — must NOT redact (no diff anchor)",
+    input: "Things to consider:\n- auth flow\n- rate limiting\n- error handling\nThoughts?",
+    expectRedacted: false,
+    mustContain: ["auth flow", "rate limiting", "error handling"],
+    mustNotContain: ["[diff removed]"],
+  },
+  {
+    name: "mixed +/- bullet list (no diff anchor) — must NOT redact",
+    input: "Pros and cons:\n+ ships fast\n+ small diff\n- adds dependency\n- breaks API\nDecide?",
+    expectRedacted: false,
+    mustContain: ["ships fast", "breaks API"],
+    mustNotContain: ["[diff removed]"],
+  },
+  {
+    name: "raw unfenced unified diff with --- a/ +++ b/ anchors — must redact",
+    input:
+      "Look at this:\n--- a/foo.ts\n+++ b/foo.ts\n@@ -1,3 +1,3 @@\n-const x = 1;\n+const x = 2;\n const y = 3;\nWhat do you think?",
+    expectRedacted: true,
+    mustContain: ["[diff removed]"],
+    mustNotContain: ["const x = 2"],
+  },
+  {
+    name: "raw unfenced unified diff with @@ hunk header only — must redact",
+    input: "@@ -10,3 +10,3 @@\n-old line\n+new line\n unchanged",
+    expectRedacted: true,
+    mustContain: ["[diff removed]"],
   },
 ];
 

--- a/plugins/honcho/scripts/test-strip-pastes.ts
+++ b/plugins/honcho/scripts/test-strip-pastes.ts
@@ -14,32 +14,27 @@
  */
 
 function stripPastes(prompt: string): { prompt: string; redacted: boolean } {
+  if (!prompt) return { prompt, redacted: false };
+
   let redacted = false;
   let out = prompt;
 
-  out = out.replace(/```[\s\S]*?```/g, () => {
+  const fenced = stripFencedBlocks(out);
+  if (fenced.redacted) {
     redacted = true;
-    return "[code block removed]";
-  });
+    out = fenced.prompt;
+  }
 
-  const looksLikeUnifiedDiff = /^(?:@@|---\s+a\/|\+\+\+\s+b\/)/m.test(out);
-  if (looksLikeUnifiedDiff) {
-    let diffRedacted = false;
-    out = out.replace(/^(?:@@.*|---\s.*|\+\+\+\s.*|[+\-].*)(?:\r?\n|$)/gm, () => {
-      diffRedacted = true;
-      return "";
-    });
-    if (diffRedacted) {
-      redacted = true;
-      out = out.replace(/(?:\r?\n){2,}/g, "\n").replace(/^(\s*\n)+/, "");
-      out = "[diff removed]\n" + out;
-    }
+  const diffed = stripUnifiedDiffBlocks(out);
+  if (diffed.redacted) {
+    redacted = true;
+    out = diffed.prompt;
   }
 
   out = out
     .split("\n")
     .map((line) => {
-      if (line.length > 200 && /\//.test(line)) {
+      if (looksLikeLongPathOutput(line)) {
         redacted = true;
         return "[path/output removed]";
       }
@@ -48,6 +43,53 @@ function stripPastes(prompt: string): { prompt: string; redacted: boolean } {
     .join("\n");
 
   return { prompt: out, redacted };
+}
+
+function stripFencedBlocks(input: string): { prompt: string; redacted: boolean } {
+  const lines = input.split("\n");
+  const out: string[] = [];
+  const openRe = /^(\s*)([`~]{3,})/;
+  let i = 0;
+  let redacted = false;
+  while (i < lines.length) {
+    const m = openRe.exec(lines[i]);
+    if (!m) { out.push(lines[i]); i++; continue; }
+    const opener = m[2];
+    const fenceChar = opener[0];
+    const minLen = opener.length;
+    redacted = true;
+    out.push("[code block removed]");
+    i++;
+    while (i < lines.length) {
+      const cm = /^\s*([`~]{3,})\s*$/.exec(lines[i]);
+      if (cm && cm[1][0] === fenceChar && cm[1].length >= minLen) { i++; break; }
+      i++;
+    }
+  }
+  return { prompt: out.join("\n"), redacted };
+}
+
+function stripUnifiedDiffBlocks(input: string): { prompt: string; redacted: boolean } {
+  const anchorRe = /^(?:@@|---\s+a\/|\+\+\+\s+b\/)/;
+  const diffBodyRe = /^(?:@@|---\s|\+\+\+\s|[+\-]| )/;
+  const lines = input.split("\n");
+  const out: string[] = [];
+  let i = 0;
+  let redacted = false;
+  while (i < lines.length) {
+    if (!anchorRe.test(lines[i])) { out.push(lines[i]); i++; continue; }
+    redacted = true;
+    out.push("[diff removed]");
+    while (i < lines.length && diffBodyRe.test(lines[i])) i++;
+    while (i < lines.length && lines[i].trim() === "") i++;
+  }
+  return { prompt: out.join("\n"), redacted };
+}
+
+function looksLikeLongPathOutput(line: string): boolean {
+  if (line.length <= 200) return false;
+  if (!/\s/.test(line)) return /\//.test(line);
+  return /(?:\/[A-Za-z0-9._\-]+){3,}/.test(line);
 }
 
 interface Case {
@@ -72,16 +114,44 @@ const cases: Case[] = [
     mustNotContain: ["const x"],
   },
   {
+    name: "unclosed fence (fail-closed) — must redact and not leak content",
+    input: "Review:\n```ts\nconst secret = buildOperatorPlan();\n",
+    expectRedacted: true,
+    mustContain: ["[code block removed]"],
+    mustNotContain: ["const secret", "buildOperatorPlan"],
+  },
+  {
+    name: "four-backtick fence with inner triple-backtick — must redact whole block",
+    input: "Outer:\n````md\nSee:\n```ts\nleak();\n```\nMore.\n````\nDone.",
+    expectRedacted: true,
+    mustContain: ["[code block removed]", "Done."],
+    mustNotContain: ["leak()"],
+  },
+  {
+    name: "tilde-fence — must redact",
+    input: "Look:\n~~~\nleaked stuff\n~~~\nThanks.",
+    expectRedacted: true,
+    mustContain: ["[code block removed]"],
+    mustNotContain: ["leaked stuff"],
+  },
+  {
     name: "+/- lines without diff anchor (ambiguous, treated as prose) — must NOT redact",
     input: "Review this diff:\n+const a = 1;\n-const b = 2;\n+const c = 3;\nThanks.",
     expectRedacted: false,
     mustNotContain: ["[diff removed]"],
   },
   {
-    name: "long path-bearing line — must redact",
-    input: "Look:\n" + "x ".repeat(110) + "/Users/foo/path/to/file.ts:123:error\nFix it.",
+    name: "long path-bearing line that looks like a stack trace — must redact",
+    input: "Look:\n/Users/foo/" + "a/".repeat(110) + "file.ts:123\nFix it.",
     expectRedacted: true,
     mustContain: ["[path/output removed]"],
+  },
+  {
+    name: "long PROSE paragraph with URL/fraction — must NOT redact (silent-loss guard)",
+    input:
+      "I think the auth middleware should fail closed by default and we should also tighten rate limiting because the current 1/2 per second budget is too generous; we should look at https://example.com/docs for prior art and run the experiment with logging enabled. Want to discuss?",
+    expectRedacted: false,
+    mustNotContain: ["[path/output removed]"],
   },
   {
     name: "short path-bearing line — must NOT redact",
@@ -130,18 +200,26 @@ Look for race conditions and security issues.`,
     mustNotContain: ["[diff removed]"],
   },
   {
-    name: "raw unfenced unified diff with --- a/ +++ b/ anchors — must redact",
+    name: "raw unfenced unified diff with --- a/ +++ b/ anchors — must redact code AND context lines",
     input:
-      "Look at this:\n--- a/foo.ts\n+++ b/foo.ts\n@@ -1,3 +1,3 @@\n-const x = 1;\n+const x = 2;\n const y = 3;\nWhat do you think?",
+      "Look at this:\n--- a/foo.ts\n+++ b/foo.ts\n@@ -1,3 +1,3 @@\n-const x = 1;\n+const x = 2;\n function buildOperatorPlan() {}\nWhat do you think?",
     expectRedacted: true,
-    mustContain: ["[diff removed]"],
-    mustNotContain: ["const x = 2"],
+    mustContain: ["[diff removed]", "Look at this", "What do you think"],
+    mustNotContain: ["const x = 2", "buildOperatorPlan"],
   },
   {
     name: "raw unfenced unified diff with @@ hunk header only — must redact",
     input: "@@ -10,3 +10,3 @@\n-old line\n+new line\n unchanged",
     expectRedacted: true,
     mustContain: ["[diff removed]"],
+  },
+  {
+    name: "diff followed by markdown bullet list later in prompt — bullets survive (no cross-contamination)",
+    input:
+      "Review:\n--- a/foo.ts\n+++ b/foo.ts\n@@ -1 +1 @@\n-old\n+new\n\nThen also consider:\n- option A\n- option B\n- option C\nThanks.",
+    expectRedacted: true,
+    mustContain: ["[diff removed]", "option A", "option B", "option C", "Thanks"],
+    mustNotContain: ["+new", "-old"],
   },
 ];
 

--- a/plugins/honcho/scripts/test-strip-pastes.ts
+++ b/plugins/honcho/scripts/test-strip-pastes.ts
@@ -186,7 +186,7 @@ Look for race conditions and security issues.`,
     expectRedacted: false,
   },
   {
-    name: "only a single +/- line (not a runs-of-3+ diff) — must NOT redact",
+    name: "stray +/- chars in prose (no diff anchor) — must NOT redact",
     input: "Note: + means added, - means removed.",
     expectRedacted: false,
   },

--- a/plugins/honcho/scripts/test-strip-pastes.ts
+++ b/plugins/honcho/scripts/test-strip-pastes.ts
@@ -70,6 +70,9 @@ function stripFencedBlocks(input: string): { prompt: string; redacted: boolean }
 }
 
 function stripUnifiedDiffBlocks(input: string): { prompt: string; redacted: boolean } {
+  const hasHunk = /^@@.*@@/m.test(input);
+  const hasPairedFileHeaders = /^---\s+a\/.*\r?\n\+\+\+\s+b\//m.test(input);
+  if (!hasHunk && !hasPairedFileHeaders) return { prompt: input, redacted: false };
   const anchorRe = /^(?:@@|---\s+a\/|\+\+\+\s+b\/)/;
   const diffBodyRe = /^(?:@@|---\s|\+\+\+\s|[+\-]| )/;
   const lines = input.split("\n");
@@ -89,6 +92,8 @@ function stripUnifiedDiffBlocks(input: string): { prompt: string; redacted: bool
 function looksLikeLongPathOutput(line: string): boolean {
   if (line.length <= 200) return false;
   if (!/\s/.test(line)) return /\//.test(line);
+  const wordCount = (line.match(/\b[A-Za-z]{3,}\b/g) || []).length;
+  if (wordCount >= 20) return false;
   return /(?:\/[A-Za-z0-9._\-]+){3,}/.test(line);
 }
 
@@ -220,6 +225,35 @@ Look for race conditions and security issues.`,
     expectRedacted: true,
     mustContain: ["[diff removed]", "option A", "option B", "option C", "Thanks"],
     mustNotContain: ["+new", "-old"],
+  },
+  {
+    name: "single-line prose mentioning '+++ b/foo.ts' — must NOT redact (anchor gate too weak before)",
+    input: "I think the path '+++ b/foo.ts' came from a stale diff. Should we ignore it?",
+    expectRedacted: false,
+    mustContain: ["I think the path", "ignore it"],
+    mustNotContain: ["[diff removed]"],
+  },
+  {
+    name: "single-line prose mentioning '--- a/foo.ts' — must NOT redact",
+    input: "The header --- a/foo.ts is what git emits for the old path.",
+    expectRedacted: false,
+    mustContain: ["The header", "old path"],
+    mustNotContain: ["[diff removed]"],
+  },
+  {
+    name: "user opinion bullets AFTER diff (Pi+DeepSeek finding) — opinions must survive",
+    input:
+      "Here's the diff:\n@@ -10,3 +10,3 @@\n-old code\n+new code\n\nMy opinion:\n+ I like this change\n- But we lost the comment",
+    expectRedacted: true,
+    mustContain: ["My opinion:", "I like this change", "But we lost the comment"],
+    mustNotContain: ["-old code", "+new code"],
+  },
+  {
+    name: "long PROSE paragraph with multiple URLs (Pi+DeepSeek finding) — must NOT redact",
+    input:
+      "Based on the documentation at https://docs.example.com/api/v2/authentication and the reference implementation at https://github.com/example/repo/blob/main/auth.py, I think we should implement OAuth2 flow first before adding API keys.",
+    expectRedacted: false,
+    mustNotContain: ["[path/output removed]"],
   },
 ];
 

--- a/plugins/honcho/scripts/test-strip-pastes.ts
+++ b/plugins/honcho/scripts/test-strip-pastes.ts
@@ -1,0 +1,137 @@
+#!/usr/bin/env bun
+/**
+ * Standalone unit test for the stripPastes() heuristic in
+ * src/hooks/user-prompt.ts. Run with:
+ *
+ *   bun run scripts/test-strip-pastes.ts
+ *
+ * No test framework required. Exits 0 on pass, 1 on fail.
+ *
+ * The repo currently has no test runner; this file is a pragmatic
+ * regression check intended to be rerun manually before releases that
+ * touch user-prompt.ts. Mirrors the heuristic exactly — if the source
+ * changes, this file should be updated in the same PR.
+ */
+
+function stripPastes(prompt: string): { prompt: string; redacted: boolean } {
+  let redacted = false;
+  let out = prompt;
+
+  out = out.replace(/```[\s\S]*?```/g, () => {
+    redacted = true;
+    return "[code block removed]";
+  });
+
+  out = out.replace(/(?:^[+\-].*(?:\r?\n|$)){3,}/gm, () => {
+    redacted = true;
+    return "[diff removed]\n";
+  });
+
+  out = out
+    .split("\n")
+    .map((line) => {
+      if (line.length > 200 && /\//.test(line)) {
+        redacted = true;
+        return "[path/output removed]";
+      }
+      return line;
+    })
+    .join("\n");
+
+  return { prompt: out, redacted };
+}
+
+interface Case {
+  name: string;
+  input: string;
+  expectRedacted: boolean;
+  mustContain?: string[];
+  mustNotContain?: string[];
+}
+
+const cases: Case[] = [
+  {
+    name: "pure prose — must NOT redact",
+    input: "I'd like to refactor the auth middleware. Please review the trade-offs.",
+    expectRedacted: false,
+  },
+  {
+    name: "fenced code block — must redact + strip code",
+    input: "Review this:\n```ts\nconst x = 1;\nconst y = 2;\n```\nThanks.",
+    expectRedacted: true,
+    mustContain: ["[code block removed]"],
+    mustNotContain: ["const x"],
+  },
+  {
+    name: "unified diff — must redact",
+    input: "Review this diff:\n+const a = 1;\n-const b = 2;\n+const c = 3;\nThanks.",
+    expectRedacted: true,
+    mustContain: ["[diff removed]"],
+  },
+  {
+    name: "long path-bearing line — must redact",
+    input: "Look:\n" + "x ".repeat(110) + "/Users/foo/path/to/file.ts:123:error\nFix it.",
+    expectRedacted: true,
+    mustContain: ["[path/output removed]"],
+  },
+  {
+    name: "short path-bearing line — must NOT redact",
+    input: "Edit /Users/foo/file.ts please",
+    expectRedacted: false,
+  },
+  {
+    name: "adversarial-review pattern (the original bug) — must redact code, preserve prose",
+    input: `You are performing an adversarial code review. Review the provided git diff:
+
+\`\`\`diff
++function buildOperatorPlan(field) {
++  if (field.provenanceStatus === 'UNKNOWN_REQUIRE_USER') {
++    return { pauseReason: 'UNKNOWN_REQUIRE_USER' };
++  }
++}
+\`\`\`
+
+Look for race conditions and security issues.`,
+    expectRedacted: true,
+    mustContain: ["adversarial code review", "race conditions", "[code block removed]"],
+    mustNotContain: ["buildOperatorPlan", "provenanceStatus"],
+  },
+  {
+    name: "empty prompt — must NOT redact",
+    input: "",
+    expectRedacted: false,
+  },
+  {
+    name: "only a single +/- line (not a runs-of-3+ diff) — must NOT redact",
+    input: "Note: + means added, - means removed.",
+    expectRedacted: false,
+  },
+];
+
+let passed = 0;
+let failed = 0;
+for (const c of cases) {
+  const out = stripPastes(c.input);
+  const errs: string[] = [];
+  if (out.redacted !== c.expectRedacted) {
+    errs.push(`expected redacted=${c.expectRedacted}, got ${out.redacted}`);
+  }
+  for (const s of c.mustContain ?? []) {
+    if (!out.prompt.includes(s)) errs.push(`output missing required substring: ${JSON.stringify(s)}`);
+  }
+  for (const s of c.mustNotContain ?? []) {
+    if (out.prompt.includes(s)) errs.push(`output contains forbidden substring: ${JSON.stringify(s)}`);
+  }
+  if (errs.length === 0) {
+    passed++;
+    console.log(`  PASS  ${c.name}`);
+  } else {
+    failed++;
+    console.error(`  FAIL  ${c.name}`);
+    for (const e of errs) console.error(`        ${e}`);
+  }
+}
+
+console.log("");
+console.log(`${passed}/${cases.length} passed`);
+process.exit(failed === 0 ? 0 : 1);

--- a/plugins/honcho/src/cache.ts
+++ b/plugins/honcho/src/cache.ts
@@ -256,9 +256,16 @@ interface QueuedMessage {
   timestamp: string;
   uploaded?: boolean;
   instanceId?: string; // Claude Code instance for parallel session support
+  metadata?: Record<string, unknown>; // Extra metadata forwarded to Honcho on upload
 }
 
-export function queueMessage(content: string, peerId: string, cwd: string, instanceId?: string): void {
+export function queueMessage(
+  content: string,
+  peerId: string,
+  cwd: string,
+  instanceId?: string,
+  metadata?: Record<string, unknown>,
+): void {
   ensureCacheDir();
   const message: QueuedMessage = {
     content,
@@ -267,6 +274,7 @@ export function queueMessage(content: string, peerId: string, cwd: string, insta
     timestamp: new Date().toISOString(),
     uploaded: false,
     instanceId: instanceId || getClaudeInstanceId() || undefined,
+    ...(metadata ? { metadata } : {}),
   };
   appendFileSync(MESSAGE_QUEUE_FILE, JSON.stringify(message) + "\n");
 }

--- a/plugins/honcho/src/hooks/post-tool-use.ts
+++ b/plugins/honcho/src/hooks/post-tool-use.ts
@@ -248,11 +248,17 @@ async function logToHonchoAsync(config: any, cwd: string, summary: string): Prom
   logApiCall("session.addMessages", "POST", `tool: ${summary.slice(0, 50)}`);
   const instanceId = getClaudeInstanceId();
 
+  // Tag tool-action messages explicitly so server-side fact extraction
+  // does not fold them into the user-peer's representation as "<user> did X".
+  // The aiPeer authored the action on the user's behalf; cross-observation
+  // mode would otherwise produce misattribution bullets from these.
   await session.addMessages([
     aiPeer.message(`[Tool] ${summary}`, {
       metadata: {
         instance_id: instanceId || undefined,
         session_affinity: sessionName,
+        type: "tool_action",
+        subject: "ai_action_on_user_behalf",
       },
     }),
   ]);

--- a/plugins/honcho/src/hooks/session-end.ts
+++ b/plugins/honcho/src/hooks/session-end.ts
@@ -257,11 +257,14 @@ export async function handleSessionEnd(): Promise<void> {
         userPeer.message(chunk, {
           createdAt: msg.timestamp,
           metadata: {
-            instance_id: msg.instanceId || undefined,
-            session_affinity: sessionName,
             // Forward queued-message metadata (e.g. type: "user_paste_not_speech")
             // so server-side extraction can filter pastes out of user attribution.
+            // Spread first so per-upload values below take precedence over any
+            // future caller that might happen to put instance_id/session_affinity
+            // in queued metadata.
             ...(msg.metadata || {}),
+            instance_id: msg.instanceId || undefined,
+            session_affinity: sessionName,
           },
         })
       );

--- a/plugins/honcho/src/hooks/session-end.ts
+++ b/plugins/honcho/src/hooks/session-end.ts
@@ -259,6 +259,9 @@ export async function handleSessionEnd(): Promise<void> {
           metadata: {
             instance_id: msg.instanceId || undefined,
             session_affinity: sessionName,
+            // Forward queued-message metadata (e.g. type: "user_paste_not_speech")
+            // so server-side extraction can filter pastes out of user attribution.
+            ...(msg.metadata || {}),
           },
         })
       );

--- a/plugins/honcho/src/hooks/user-prompt.ts
+++ b/plugins/honcho/src/hooks/user-prompt.ts
@@ -88,11 +88,26 @@ function stripPastes(prompt: string): { prompt: string; redacted: boolean } {
     return "[code block removed]";
   });
 
-  // 2. Runs of 3+ consecutive unified-diff lines (^[+-] at line start)
-  out = out.replace(/(?:^[+\-].*(?:\r?\n|$)){3,}/gm, () => {
-    redacted = true;
-    return "[diff removed]\n";
-  });
+  // 2. Unified-diff content. Gate on a real unified-diff anchor (`@@` hunk
+  //    header, `--- a/`, or `+++ b/`) to avoid eating markdown bullet lists
+  //    like "- item one\n- item two\n- item three". Once we know it's a
+  //    diff, redact every +/- line and the diff metadata lines individually.
+  //    Fenced ```diff blocks are already redacted by rule 1 above; this rule
+  //    fires for raw unfenced unified-diff pastes.
+  const looksLikeUnifiedDiff = /^(?:@@|---\s+a\/|\+\+\+\s+b\/)/m.test(out);
+  if (looksLikeUnifiedDiff) {
+    let diffRedacted = false;
+    out = out.replace(/^(?:@@.*|---\s.*|\+\+\+\s.*|[+\-].*)(?:\r?\n|$)/gm, () => {
+      diffRedacted = true;
+      return "";
+    });
+    if (diffRedacted) {
+      redacted = true;
+      // Collapse the empty-line residue and prepend a single marker
+      out = out.replace(/(?:\r?\n){2,}/g, "\n").replace(/^(\s*\n)+/, "");
+      out = "[diff removed]\n" + out;
+    }
+  }
 
   // 3. Lines >200 chars containing a slash-path (long file-path-bearing
   //    output blobs — stack traces, log dumps, JSON pastes)

--- a/plugins/honcho/src/hooks/user-prompt.ts
+++ b/plugins/honcho/src/hooks/user-prompt.ts
@@ -68,6 +68,48 @@ function shouldSkipContextRetrieval(prompt: string): boolean {
   return SKIP_CONTEXT_PATTERNS.some((p) => p.test(prompt.trim()));
 }
 
+/**
+ * Strip pasted code/diffs/long-output blocks from a user prompt before it
+ * is uploaded to Honcho. Pastes ride role: "user" per the Anthropic Messages
+ * API but are not the user's authored prose; the server-side fact extractor
+ * otherwise reads `+`/`-` diff lines or quoted file content as user statements
+ * and produces "<peer> changed/wrote/added X" misattribution bullets.
+ *
+ * Returns the cleaned prompt and whether any redaction fired so the caller
+ * can tag metadata.type = "user_paste_not_speech".
+ */
+function stripPastes(prompt: string): { prompt: string; redacted: boolean } {
+  let redacted = false;
+  let out = prompt;
+
+  // 1. Markdown fenced code blocks: ```...```
+  out = out.replace(/```[\s\S]*?```/g, () => {
+    redacted = true;
+    return "[code block removed]";
+  });
+
+  // 2. Runs of 3+ consecutive unified-diff lines (^[+-] at line start)
+  out = out.replace(/(?:^[+\-].*(?:\r?\n|$)){3,}/gm, () => {
+    redacted = true;
+    return "[diff removed]\n";
+  });
+
+  // 3. Lines >200 chars containing a slash-path (long file-path-bearing
+  //    output blobs — stack traces, log dumps, JSON pastes)
+  out = out
+    .split("\n")
+    .map((line) => {
+      if (line.length > 200 && /\//.test(line)) {
+        redacted = true;
+        return "[path/output removed]";
+      }
+      return line;
+    })
+    .join("\n");
+
+  return { prompt: out, redacted };
+}
+
 function formatSessionLink(sessionUrl: string): string {
   return `view your session in honcho GUI: ${sessionUrl}`;
 }
@@ -116,9 +158,14 @@ export async function handleUserPrompt(): Promise<void> {
 
   logHook("user-prompt", `Prompt received (${prompt.length} chars)`);
 
-  // Queue user prompt for upload at session-end (instant, no network)
+  // Queue user prompt for upload at session-end (instant, no network).
+  // Strip pasted code/diffs/output to keep the fact extractor from
+  // attributing them to the user. If anything is redacted, tag the message
+  // so server-side extraction can filter it from peer attribution.
   if (config.saveMessages !== false) {
-    queueMessage(prompt, config.peerName, cwd, instanceId || undefined);
+    const { prompt: queuedPrompt, redacted } = stripPastes(prompt);
+    const metadata = redacted ? { type: "user_paste_not_speech" as const } : undefined;
+    queueMessage(queuedPrompt, config.peerName, cwd, instanceId || undefined, metadata);
   }
 
   // Track message count for threshold-based refresh

--- a/plugins/honcho/src/hooks/user-prompt.ts
+++ b/plugins/honcho/src/hooks/user-prompt.ts
@@ -166,16 +166,31 @@ function stripFencedBlocks(input: string): { prompt: string; redacted: boolean }
 }
 
 /**
- * Stateful unified-diff redactor. Enters "diff mode" only on a real
- * unified-diff anchor (`@@`, `--- a/`, `+++ b/`). Inside a diff block,
- * redacts every line that matches diff grammar — including `+`/`-`
- * lines, hunk headers, file headers, and space-prefixed context lines —
- * until a line that breaks diff grammar is encountered.
+ * Stateful unified-diff redactor.
  *
- * Markdown bullet lists like "- item one\n- item two\n- item three"
- * have no anchor and are passed through untouched.
+ * Two-stage gate to avoid eating prose that incidentally mentions a
+ * diff-shaped token:
+ *
+ *   1. Document-level: only run the redactor at all if the prompt
+ *      contains either a hunk header (`@@ ... @@`) OR a paired
+ *      file-header pair (`--- a/...` immediately followed by
+ *      `+++ b/...`). A single line like "the path is +++ b/foo.ts"
+ *      does NOT trigger.
+ *
+ *   2. Per-line: within an anchored prompt, redact contiguous runs of
+ *      diff-grammar lines (anchor lines + `+`/`-` content + space-
+ *      prefixed context). Exit on the first non-diff line so a
+ *      Markdown bullet list AFTER a diff in the same prompt
+ *      ("- option A") survives intact.
  */
 function stripUnifiedDiffBlocks(input: string): { prompt: string; redacted: boolean } {
+  // Document-level gate: require a real hunk OR paired file headers.
+  const hasHunk = /^@@.*@@/m.test(input);
+  const hasPairedFileHeaders = /^---\s+a\/.*\r?\n\+\+\+\s+b\//m.test(input);
+  if (!hasHunk && !hasPairedFileHeaders) {
+    return { prompt: input, redacted: false };
+  }
+
   const anchorRe = /^(?:@@|---\s+a\/|\+\+\+\s+b\/)/;
   // Lines that are part of a diff block once we're already inside one:
   // hunk header, file headers, +/- lines, space-prefixed context.
@@ -209,17 +224,24 @@ function stripUnifiedDiffBlocks(input: string): { prompt: string; redacted: bool
 
 /**
  * A line is "long path-bearing output" when it is >200 chars AND looks like
- * machine output rather than authored prose:
- *   - contains no whitespace at all (single dense token), OR
- *   - contains a contiguous run of 3+ slash-separated identifiers
- *     (path-like substring)
+ * machine output rather than authored prose. We use a word-density signal:
  *
- * Long prose paragraphs that happen to mention a URL or a fraction
- * (`and/or`, `1/2`) are not redacted under this rule.
+ *   - No whitespace at all (single dense token like a base64 blob): redact
+ *     if it contains a slash.
+ *   - Whitespace present: redact only if the line has FEW alphabetic words
+ *     (machine output / log dump pattern) AND contains a path-like run.
+ *
+ * Long prose paragraphs (URL-bearing or fraction-bearing) have many
+ * alphabetic words and are preserved.
  */
 function looksLikeLongPathOutput(line: string): boolean {
   if (line.length <= 200) return false;
   if (!/\s/.test(line)) return /\//.test(line);
+  const wordCount = (line.match(/\b[A-Za-z]{3,}\b/g) || []).length;
+  // Heuristic threshold: typical prose at >200 chars has 25+ word-like
+  // tokens. Log dumps / stack traces tend to be path-dense and word-sparse
+  // (often <15 alphabetic words even at 400+ chars).
+  if (wordCount >= 20) return false;
   return /(?:\/[A-Za-z0-9._\-]+){3,}/.test(line);
 }
 

--- a/plugins/honcho/src/hooks/user-prompt.ts
+++ b/plugins/honcho/src/hooks/user-prompt.ts
@@ -77,44 +77,45 @@ function shouldSkipContextRetrieval(prompt: string): boolean {
  *
  * Returns the cleaned prompt and whether any redaction fired so the caller
  * can tag metadata.type = "user_paste_not_speech".
+ *
+ * Implementation notes (post-review hardening, 2026-04-26):
+ *   - Fenced code blocks: scanner that supports 3+ backticks or tildes and
+ *     fails closed on EOF without a matching closer (the user almost
+ *     certainly pasted code without remembering to close the fence).
+ *   - Unified diffs: stateful line-by-line redactor entered only on a real
+ *     diff anchor (`@@`, `--- a/`, `+++ b/`). Inside the block, also redacts
+ *     space-prefixed context lines so leaked function names cannot survive.
+ *     Exits the block on the first line that doesn't match diff grammar.
+ *   - Long path-bearing lines: tightened heuristic. A line >200 chars is
+ *     redacted only if it has no internal whitespace at all OR contains a
+ *     dense slash-separated identifier run; long prose paragraphs with a
+ *     URL/fraction pass through.
  */
 function stripPastes(prompt: string): { prompt: string; redacted: boolean } {
+  if (!prompt) return { prompt, redacted: false };
+
   let redacted = false;
   let out = prompt;
 
-  // 1. Markdown fenced code blocks: ```...```
-  out = out.replace(/```[\s\S]*?```/g, () => {
+  // 1. Fenced code blocks (` ``` ` or ` ~~~ ` with 3+ chars; fail-closed)
+  const fenced = stripFencedBlocks(out);
+  if (fenced.redacted) {
     redacted = true;
-    return "[code block removed]";
-  });
-
-  // 2. Unified-diff content. Gate on a real unified-diff anchor (`@@` hunk
-  //    header, `--- a/`, or `+++ b/`) to avoid eating markdown bullet lists
-  //    like "- item one\n- item two\n- item three". Once we know it's a
-  //    diff, redact every +/- line and the diff metadata lines individually.
-  //    Fenced ```diff blocks are already redacted by rule 1 above; this rule
-  //    fires for raw unfenced unified-diff pastes.
-  const looksLikeUnifiedDiff = /^(?:@@|---\s+a\/|\+\+\+\s+b\/)/m.test(out);
-  if (looksLikeUnifiedDiff) {
-    let diffRedacted = false;
-    out = out.replace(/^(?:@@.*|---\s.*|\+\+\+\s.*|[+\-].*)(?:\r?\n|$)/gm, () => {
-      diffRedacted = true;
-      return "";
-    });
-    if (diffRedacted) {
-      redacted = true;
-      // Collapse the empty-line residue and prepend a single marker
-      out = out.replace(/(?:\r?\n){2,}/g, "\n").replace(/^(\s*\n)+/, "");
-      out = "[diff removed]\n" + out;
-    }
+    out = fenced.prompt;
   }
 
-  // 3. Lines >200 chars containing a slash-path (long file-path-bearing
-  //    output blobs — stack traces, log dumps, JSON pastes)
+  // 2. Unified-diff blocks (anchor-gated, stateful)
+  const diffed = stripUnifiedDiffBlocks(out);
+  if (diffed.redacted) {
+    redacted = true;
+    out = diffed.prompt;
+  }
+
+  // 3. Long path-bearing output lines
   out = out
     .split("\n")
     .map((line) => {
-      if (line.length > 200 && /\//.test(line)) {
+      if (looksLikeLongPathOutput(line)) {
         redacted = true;
         return "[path/output removed]";
       }
@@ -123,6 +124,103 @@ function stripPastes(prompt: string): { prompt: string; redacted: boolean } {
     .join("\n");
 
   return { prompt: out, redacted };
+}
+
+/**
+ * Scan-and-redact fenced code blocks. Supports 3+ backtick or 3+ tilde
+ * fences. Fails closed: if a fence is opened and never closed, the rest of
+ * the input is treated as inside the fence and redacted.
+ */
+function stripFencedBlocks(input: string): { prompt: string; redacted: boolean } {
+  const lines = input.split("\n");
+  const out: string[] = [];
+  const openRe = /^(\s*)([`~]{3,})/;
+  let i = 0;
+  let redacted = false;
+
+  while (i < lines.length) {
+    const m = openRe.exec(lines[i]);
+    if (!m) {
+      out.push(lines[i]);
+      i++;
+      continue;
+    }
+    const opener = m[2];
+    const fenceChar = opener[0];
+    const minLen = opener.length;
+    redacted = true;
+    out.push("[code block removed]");
+    i++;
+    while (i < lines.length) {
+      const cm = /^\s*([`~]{3,})\s*$/.exec(lines[i]);
+      if (cm && cm[1][0] === fenceChar && cm[1].length >= minLen) {
+        i++;
+        break;
+      }
+      i++;
+    }
+    // EOF without closer: fail-closed. Already emitted marker, just exit.
+  }
+
+  return { prompt: out.join("\n"), redacted };
+}
+
+/**
+ * Stateful unified-diff redactor. Enters "diff mode" only on a real
+ * unified-diff anchor (`@@`, `--- a/`, `+++ b/`). Inside a diff block,
+ * redacts every line that matches diff grammar — including `+`/`-`
+ * lines, hunk headers, file headers, and space-prefixed context lines —
+ * until a line that breaks diff grammar is encountered.
+ *
+ * Markdown bullet lists like "- item one\n- item two\n- item three"
+ * have no anchor and are passed through untouched.
+ */
+function stripUnifiedDiffBlocks(input: string): { prompt: string; redacted: boolean } {
+  const anchorRe = /^(?:@@|---\s+a\/|\+\+\+\s+b\/)/;
+  // Lines that are part of a diff block once we're already inside one:
+  // hunk header, file headers, +/- lines, space-prefixed context.
+  const diffBodyRe = /^(?:@@|---\s|\+\+\+\s|[+\-]| )/;
+  const lines = input.split("\n");
+  const out: string[] = [];
+  let i = 0;
+  let redacted = false;
+
+  while (i < lines.length) {
+    if (!anchorRe.test(lines[i])) {
+      out.push(lines[i]);
+      i++;
+      continue;
+    }
+    // Enter diff block. Replace the entire contiguous diff with a single
+    // marker. Consume the anchor line plus any following diff-grammar lines.
+    redacted = true;
+    out.push("[diff removed]");
+    while (i < lines.length && diffBodyRe.test(lines[i])) {
+      i++;
+    }
+    // Consume residual blank lines so we don't leave gaps in the prose.
+    while (i < lines.length && lines[i].trim() === "") {
+      i++;
+    }
+  }
+
+  return { prompt: out.join("\n"), redacted };
+}
+
+/**
+ * A line is "long path-bearing output" when it is >200 chars AND looks like
+ * machine output rather than authored prose:
+ *   - contains no whitespace at all (single dense token), OR
+ *   - contains a contiguous run of 3+ slash-separated identifiers
+ *     (path-like substring)
+ *
+ * Long prose paragraphs that happen to mention a URL or a fraction
+ * (`and/or`, `1/2`) are not redacted under this rule.
+ */
+function looksLikeLongPathOutput(line: string): boolean {
+  if (line.length <= 200) return false;
+  if (!/\s/.test(line)) return /\//.test(line);
+  return /(?:\/[A-Za-z0-9._\-]+){3,}/.test(line);
 }
 
 function formatSessionLink(sessionUrl: string): string {


### PR DESCRIPTION
## Summary

`user-prompt.ts` and `post-tool-use.ts` upload content to the Honcho message stream that the server-side fact extractor reads as user-authored prose, even when it isn't. This produces durable misattribution facts in the user-peer's representation — e.g. `<user> changed buildOperatorPlan` from a pasted diff in an adversarial-review prompt the user actually typed:

> *"You are performing an adversarial code review. Review the provided git diff: ```diff +function buildOperatorPlan(...) ... ``` "*

The diff body rides `role: "user"` per the Anthropic Messages API, so the extractor treats `+`/`-` lines as the user's statements about their own code.

This PR strips pasted code/diffs/long-output from `userPeer` uploads and tags `aiPeer` tool-action uploads with explicit role metadata.

## The bug, concretely

Two sites:

1. **`src/hooks/user-prompt.ts`** queues the entire `prompt` string for upload to `userPeer` at session-end. Pastes in user prompts (review-this-diff, fix-this-stack-trace, etc.) carry `role: "user"` per the Messages API but are not user-authored prose. The extractor reads them as such.

2. **`src/hooks/post-tool-use.ts`** uploads `aiPeer.message("[Tool] Edited file: ...")` with metadata that has no role discriminator. `unified` observation mode reduces blast radius but does not eliminate it — directional deployments and any MCP tool that operates in directional scope still fold these into the user's representation as `<user> did X`.

The end result: durable cross-session memory contaminated with assistant-authored facts attributed to the user. We observed this in the wild after running with `directional` mode briefly — a sample of 50 conclusions on page 1 of `list_conclusions` showed ~10 misattributions (extrapolated estimate: ~12K of ~60K conclusions in a heavily-used workspace).

## Fix

### `src/hooks/user-prompt.ts` — strip pastes before queuing

New `stripPastes()` helper redacts:

```ts
// 1. Markdown fenced code blocks
out = out.replace(/```[\s\S]*?```/g, () => "[code block removed]");

// 2. Runs of 3+ consecutive unified-diff lines
out = out.replace(/(?:^[+\-].*(?:\r?\n|$)){3,}/gm, () => "[diff removed]\n");

// 3. Lines >200 chars containing a slash-path
//    (long file-path-bearing output: stack traces, log dumps, JSON pastes)
```

If anything is redacted, the queued message is tagged with `metadata.type = "user_paste_not_speech"` so server-side extraction can filter cross-peer attribution.

The single-character `+`/`-` line case (e.g. `"Note: + means added, - means removed."`) is preserved — only runs of 3 or more consecutive prefixed lines are treated as a diff. Short path mentions in prose (`"Edit /Users/foo/file.ts please"`) are also preserved.

### `src/hooks/post-tool-use.ts` — explicit role metadata

```ts
metadata: {
  instance_id: instanceId || undefined,
  session_affinity: sessionName,
  type: "tool_action",
  subject: "ai_action_on_user_behalf",
}
```

### `src/cache.ts` — optional metadata on `QueuedMessage`

`QueuedMessage` gains an optional `metadata` field. `queueMessage()` accepts an optional 5th argument that is forwarded to `userPeer.message()` at session-end. Backwards compatible — existing callers and queued messages without metadata continue to work.

### `src/hooks/session-end.ts` — forward queued metadata

Spreads `msg.metadata` into the `userPeer.message()` metadata block at upload time so server-side extraction sees the role tags.

## Verification

```bash
$ bunx tsc --noEmit -p tsconfig.json
# clean

$ bun run scripts/test-strip-pastes.ts
  PASS  pure prose — must NOT redact
  PASS  fenced code block — must redact + strip code
  PASS  unified diff — must redact
  PASS  long path-bearing line — must redact
  PASS  short path-bearing line — must NOT redact
  PASS  adversarial-review pattern (the original bug) — must redact code, preserve prose
  PASS  empty prompt — must NOT redact
  PASS  only a single +/- line (not a runs-of-3+ diff) — must NOT redact
  8/8 passed
```

The repo currently has no test runner; `scripts/test-strip-pastes.ts` is a pragmatic regression check intended to be rerun manually before releases that touch `user-prompt.ts`. Happy to wire it into CI in a follow-up PR if desired (or to introduce `bun:test` for this and future tests).

## Backwards compatibility

- `queueMessage()` signature change is purely additive (5th arg is optional). Single in-tree caller updated.
- `QueuedMessage` interface change is purely additive (`metadata?` optional). Existing queue files on disk parse cleanly because the field is absent.
- No config schema changes. No new env vars.
- No behavior change for callers that don't paste content.

## Notes for reviewers

- The strip happens at the **upload boundary** in the plugin, not at extraction time on the server. This keeps the change scoped to the plugin and avoids server-side coordination, but it means downstream tools that read the message stream directly will see redacted markers (`[code block removed]`, `[diff removed]`, `[path/output removed]`) instead of the original paste content. That's intentional — the original content is not the user's prose and shouldn't be in the user-peer's record.
- The 200-char path-bearing-line heuristic is conservative. Real prose lines are rarely that long; tool-output blobs frequently are. If this triggers false positives in practice, lowering the threshold to 120 or adding a `metadata.contains_paste: true` softer marker would be a follow-up.
- `metadata.subject = "ai_action_on_user_behalf"` is a string convention. If you'd prefer a structured enum or a reserved namespace (`honcho.role` / `honcho.subject`), I'm happy to rename — just point me at the convention.
- This PR does not touch `saveMessages: true` policy. A deeper-cut alternative would be to stop uploading raw user prompts entirely and only upload extracted facts — but that's a much bigger change and out of scope here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Messages can include optional metadata to preserve context and categorization across session uploads.
  * User prompts are preprocessed client-side to redact pasted code blocks, diffs, and long path-like lines before upload; redacted messages are marked accordingly.
  * Tool-generated actions are annotated so they are distinguished from user-authored content when forwarded.

* **Tests**
  * Added a regression test verifying preprocessing and redaction behavior across edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->