### PR TITLE
feat: make HTTP client timeout configurable via config and env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -424,6 +424,7 @@ Environment variables work for initial bootstrap (before a config file exists). 
 | `HONCHO_ENABLED`       | No       | `true`        | Set to `false` to disable                                         |
 | `HONCHO_SAVE_MESSAGES` | No       | `true`        | Set to `false` to stop saving messages                            |
 | `HONCHO_LOGGING`       | No       | `true`        | Set to `false` to disable file logging to `~/.honcho/`            |
+| `HONCHO_CLIENT_TIMEOUT_MS` | No   | `8000`        | HTTP client timeout in milliseconds. Increase to `20000`–`30000` for self-hosted instances with large knowledge graphs or VPN/Tailscale routing. |
 
 ## How It Works
 
@@ -496,6 +497,17 @@ Or via env var:
 export HONCHO_ENDPOINT="local"  # Uses localhost:8000
 # or
 export HONCHO_ENDPOINT="http://your-server:8000/v3"
+```
+
+**Tip for self-hosted instances:** Large knowledge graphs (100k+ documents) or VPN/Tailscale routing can cause `context()` fetches to exceed the default 8-second timeout, resulting in sessions starting without memory context. Increase the client timeout:
+
+```bash
+export HONCHO_CLIENT_TIMEOUT_MS="20000"  # 20 seconds
+```
+
+Or in `~/.honcho/config.json`:
+```json
+{ "clientTimeoutMs": 20000 }
 ```
 
 ### Temporarily disabling memory

--- a/plugins/honcho/src/config.ts
+++ b/plugins/honcho/src/config.ts
@@ -183,6 +183,13 @@ interface HonchoFileConfig {
   // Legacy flat fields (read-only fallbacks when no hosts block)
   cursorPeer?: string;
   claudePeer?: string;
+  /**
+   * HTTP client timeout in milliseconds for all Honcho API requests.
+   * Default: 8000 (8 seconds). Self-hosted instances with large knowledge
+   * graphs or Tailscale routing should use 20000–30000.
+   * Can also be set via HONCHO_CLIENT_TIMEOUT_MS env var.
+   */
+  clientTimeoutMs?: number;
 }
 
 /** Resolved runtime config consumed by all other code.
@@ -228,6 +235,13 @@ export interface HonchoCLAUDEConfig {
   logging?: boolean;
   /** When true, flat workspace/aiPeer fields apply to ALL hosts */
   globalOverride?: boolean;
+  /**
+   * HTTP client timeout in milliseconds for all Honcho API requests.
+   * Default: 8000 (8 seconds). Self-hosted instances with large knowledge
+   * graphs or Tailscale/VPN routing should use 20000–30000.
+   * Can also be set via HONCHO_CLIENT_TIMEOUT_MS env var.
+   */
+  clientTimeoutMs?: number;
 }
 
 function deepEqual(a: unknown, b: unknown): boolean {
@@ -334,6 +348,7 @@ function resolveConfig(raw: HonchoFileConfig, host: HonchoHost): HonchoCLAUDECon
     enabled: hostBlock?.enabled ?? raw.enabled,
     logging: hostBlock?.logging ?? raw.logging,
     globalOverride: raw.globalOverride,
+    clientTimeoutMs: raw.clientTimeoutMs,
   };
 
   return mergeWithEnvVars(config);
@@ -367,6 +382,7 @@ export function loadConfigFromEnv(host?: HonchoHost): HonchoCLAUDEConfig | null 
     saveMessages: process.env.HONCHO_SAVE_MESSAGES !== "false",
     enabled: process.env.HONCHO_ENABLED !== "false",
     logging: process.env.HONCHO_LOGGING !== "false",
+    ...(process.env.HONCHO_CLIENT_TIMEOUT_MS && { clientTimeoutMs: parseInt(process.env.HONCHO_CLIENT_TIMEOUT_MS, 10) || undefined }),
   };
 
   if (endpoint) {
@@ -400,6 +416,10 @@ function mergeWithEnvVars(config: HonchoCLAUDEConfig): HonchoCLAUDEConfig {
   }
   if (process.env.HONCHO_LOGGING === "false") {
     config.logging = false;
+  }
+  if (process.env.HONCHO_CLIENT_TIMEOUT_MS) {
+    const parsed = parseInt(process.env.HONCHO_CLIENT_TIMEOUT_MS, 10);
+    if (!isNaN(parsed) && parsed > 0) config.clientTimeoutMs = parsed;
   }
   return config;
 }
@@ -697,7 +717,7 @@ export function getHonchoClientOptions(config: HonchoCLAUDEConfig): HonchoClient
     apiKey: config.apiKey,
     baseURL: getHonchoBaseUrl(config),
     workspaceId: config.workspace,
-    timeout: 8000,
+    timeout: config.clientTimeoutMs ?? 8000,
     maxRetries: 1,
   };
 }

--- a/plugins/honcho/src/mcp/server.ts
+++ b/plugins/honcho/src/mcp/server.ts
@@ -47,6 +47,7 @@ const ENV_SHADOW_MAP: Record<string, string> = {
   saveMessages: "HONCHO_SAVE_MESSAGES",
   "endpoint.baseUrl": "HONCHO_ENDPOINT",
   "endpoint.environment": "HONCHO_ENDPOINT",
+  clientTimeoutMs: "HONCHO_CLIENT_TIMEOUT_MS",
 };
 
 // Fields that require confirm=true to change


### PR DESCRIPTION
## Summary

The Honcho SDK client timeout is currently hardcoded at 8000ms in `getHonchoClientOptions()`. For self-hosted Honcho instances, this is frequently too short:

- **Large knowledge graphs** (100k+ documents/embeddings) can take >8s for `context()` queries, especially on first hit after server startup
- **VPN or Tailscale routing** adds network overhead that eats into the timeout budget
- **Concurrent deriver activity** on the same Postgres instance can slow vector search

The failure mode is silent: the `Promise.allSettled` in the session-start hook resolves with `status: "rejected"`, and the session starts with no memory context injected. No error is shown to the user.

## Changes

**`plugins/honcho/src/config.ts`**
- Add `clientTimeoutMs?: number` to `HonchoFileConfig` (raw JSON shape on disk)
- Add `clientTimeoutMs?: number` to `HonchoCLAUDEConfig` (resolved runtime config)  
- Pass `clientTimeoutMs` through `resolveConfig()` from raw config
- Read `HONCHO_CLIENT_TIMEOUT_MS` env var in `loadConfigFromEnv()`
- Apply env var override in `mergeWithEnvVars()`
- Use `config.clientTimeoutMs ?? 8000` in `getHonchoClientOptions()` (default unchanged for backwards compatibility)

**`plugins/honcho/src/mcp/server.ts`**
- Add `clientTimeoutMs` to `ENV_SHADOW_MAP` so the `get_config` tool surfaces it and warns when the env var shadows the config file value

**`README.md`**
- Add `HONCHO_CLIENT_TIMEOUT_MS` to the environment variables reference table
- Add a "Tip for self-hosted instances" block in the self-hosted section explaining when and how to increase the timeout

## Configuration

Via `~/.honcho/config.json`:
```json
{ "clientTimeoutMs": 20000 }
```

Via environment variable:
```bash
export HONCHO_CLIENT_TIMEOUT_MS=20000
```

## Backwards Compatibility

The default remains **8000ms** (unchanged). No existing behavior changes. Users who need a longer timeout opt in explicitly.

## Recommended values

| Scenario | Suggested `clientTimeoutMs` |
|---|---|
| Honcho SaaS (default) | 8000 (no change) |
| Self-hosted, <10k documents | 8000–12000 |
| Self-hosted, 10k–100k documents | 15000–20000 |
| Self-hosted, >100k documents or VPN routing | 20000–30000 |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable HTTP client timeout setting via environment variable or config file, with an 8000ms default.
  * Extended documentation with guidance for self-hosted deployments, including examples for increasing timeout when context fetches exceed the default limit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->