### PR TITLE
fix(session-end): skip end marker for empty sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to claude-honcho will be documented in this file.
 
+## [Unreleased]
+
+### Fixed
+
+- `session-end` hook: skip the `[Session ended]` marker for empty sessions (`transcriptMessages.length === 0`). Empty sessions previously emitted a session-lifecycle marker that the Honcho deriver dutifully extracted as durable memory observations (e.g. "session ended at X UTC", "session contained zero messages") — burning deriver tokens on transcript-exhaust facts with no future-recall value. Side-channel queued messages still upload; only the marker is gated.
+
 ## [0.2.4] - 2026-04-01
 
 ### Added

--- a/plugins/honcho/src/hooks/session-end.ts
+++ b/plugins/honcho/src/hooks/session-end.ts
@@ -281,24 +281,30 @@ export async function handleSessionEnd(): Promise<void> {
         })
       : [];
 
-    const endMarker = aiPeer.message(
-      `[Session ended] Reason: ${reason}, Messages: ${transcriptMessages.length}, Time: ${new Date().toISOString()}`,
-      {
-        createdAt: new Date().toISOString(),
-        metadata: {
-          instance_id: instanceId || undefined,
-          session_affinity: sessionName,
-        },
-      }
-    );
+    // Skip the [Session ended] marker for empty sessions — they emit
+    // useless "transcript exhaust" memory observations costing deriver tokens
+    // (e.g. "session ended at X with 0 messages" extracted as a durable fact).
+    // Side-channel queued messages still upload; only the marker is gated.
+    const endMarker = transcriptMessages.length > 0
+      ? aiPeer.message(
+          `[Session ended] Reason: ${reason}, Messages: ${transcriptMessages.length}, Time: ${new Date().toISOString()}`,
+          {
+            createdAt: new Date().toISOString(),
+            metadata: {
+              instance_id: instanceId || undefined,
+              session_affinity: sessionName,
+            },
+          }
+        )
+      : null;
 
     // Single addMessages call with everything — one round trip instead of three.
-    const allMessages = [...userMessages, ...aiMessages, endMarker];
+    const allMessages = [...userMessages, ...aiMessages, ...(endMarker ? [endMarker] : [])];
 
     if (allMessages.length > 0) {
       const meaningfulCount = assistantMessages.filter(m => m.isMeaningful).length;
       logApiCall("session.addMessages", "POST",
-        `${userMessages.length} user + ${aiMessages.length} assistant (${meaningfulCount} meaningful) + 1 marker`);
+        `${userMessages.length} user + ${aiMessages.length} assistant (${meaningfulCount} meaningful)${endMarker ? " + 1 marker" : " (no marker, empty session)"}`);
 
       // Start API upload immediately; run animation concurrently.
       const uploadPromise = session.addMessages(allMessages);


### PR DESCRIPTION
## Summary

The `session-end` hook unconditionally posts a `[Session ended] Reason: ${reason}, Messages: ${count}, Time: ${iso}` marker to Honcho on every termination, including sessions with **zero transcript messages** (e.g. resumed but never used). Honcho's deriver then extracts these markers as durable memory observations, e.g.:

  - "&lt;peer&gt;'s session ended on May 7, 2026, at 00:18:47 UTC"
  - "The session &lt;peer&gt; ended on May 7, 2026, contained zero messages"

These have no future-recall value — they're session-plumbing exhaust extracted as user/AI facts — and each one costs deriver LLM tokens.

## What this changes

Gates `endMarker` creation behind `transcriptMessages.length > 0` in `plugins/honcho/src/hooks/session-end.ts`.

- Side-channel queued messages (e.g. `[Git External]` from session-start, queued user prompts) still upload normally — only the lifecycle marker is suppressed.
- The existing `if (allMessages.length > 0)` guard handles the fully-empty case and skips the upload entirely.
- API-call log line now reflects whether a marker was included or skipped.

## Why minimal

The fix is intentionally narrow. Non-empty sessions still get their end markers (preserves session-end timestamps in memory). Only the zero-message lifecycle artifact — the one with no signal at all — is dropped.

## Test plan

- [x] `bunx tsc --noEmit` clean
- [x] Manual smoke test on local install (multi-profile Hermes setup with frequent Claude Code resumes)
- [ ] Reviewer to validate against any test additions in stacked PRs (this branch is based directly on `main` and ships no new tests; `config.test.ts` is added by #33/#36)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Session-end hook now skips emitting the session-ended marker when sessions contain no transcript messages, while continuing to upload other queued messages as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->