### PR TITLE
fix: dedup injected conclusions per session to prevent context bloat

### DIFF
--- a/plugins/honcho/src/cache.ts
+++ b/plugins/honcho/src/cache.ts
@@ -123,6 +123,7 @@ interface ContextCache {
   summaries?: { data: any; fetchedAt: number };
   messageCount?: number; // Track messages since last refresh
   lastRefreshMessageCount?: number; // Message count at last knowledge graph refresh
+  injectedHashesBySession?: Record<string, { hashes: string[]; turnCount: number; updatedAt: string }>;
 }
 
 // These are now configurable via config.json, with defaults in getContextRefreshConfig()
@@ -138,7 +139,7 @@ function getMessageRefreshThreshold(): number {
 
 // Known keys in ContextCache — anything else is a ghost from older versions
 const CONTEXT_CACHE_KNOWN_KEYS = new Set([
-  "userContext", "claudeContext", "summaries", "messageCount", "lastRefreshMessageCount",
+  "userContext", "claudeContext", "summaries", "messageCount", "lastRefreshMessageCount", "injectedHashesBySession",
 ]);
 
 export function loadContextCache(): ContextCache {
@@ -243,6 +244,57 @@ export function resetMessageCount(): void {
   cache.messageCount = 0;
   cache.lastRefreshMessageCount = 0;
   saveContextCache(cache);
+}
+
+export function getInjectedHashesForSession(sessionId: string): Set<string> {
+  const cache = loadContextCache();
+  const entry = cache.injectedHashesBySession?.[sessionId];
+  if (!entry) {
+    return new Set();
+  }
+  return new Set(entry.hashes);
+}
+
+export function recordInjectedHashes(sessionId: string, newHashes: string[]): void {
+  const cache = loadContextCache();
+  if (!cache.injectedHashesBySession) {
+    cache.injectedHashesBySession = {};
+  }
+  const existing = cache.injectedHashesBySession[sessionId];
+  const mergedHashes = existing
+    ? [...new Set([...existing.hashes, ...newHashes])]
+    : [...newHashes];
+  cache.injectedHashesBySession[sessionId] = {
+    hashes: mergedHashes,
+    turnCount: (existing?.turnCount || 0) + 1,
+    updatedAt: new Date().toISOString(),
+  };
+
+  // Inline GC: drop >20 sessions (LRU by updatedAt) and any older than 7 days
+  const entries = Object.entries(cache.injectedHashesBySession);
+  if (entries.length > 20) {
+    entries.sort((a, b) => a[1].updatedAt.localeCompare(b[1].updatedAt));
+    const toDrop = entries.length - 20;
+    for (let i = 0; i < toDrop; i = i + 1) {
+      delete cache.injectedHashesBySession[entries[i][0]];
+    }
+  }
+  const sevenDaysAgo = Date.now() - 7 * 24 * 60 * 60 * 1000;
+  for (const [id, data] of Object.entries(cache.injectedHashesBySession)) {
+    if (new Date(data.updatedAt).getTime() < sevenDaysAgo) {
+      delete cache.injectedHashesBySession[id];
+    }
+  }
+
+  saveContextCache(cache);
+}
+
+export function clearInjectedHashesForSession(sessionId: string): void {
+  const cache = loadContextCache();
+  if (cache.injectedHashesBySession) {
+    delete cache.injectedHashesBySession[sessionId];
+    saveContextCache(cache);
+  }
 }
 
 // ============================================

--- a/plugins/honcho/src/dedup.ts
+++ b/plugins/honcho/src/dedup.ts
@@ -19,16 +19,18 @@ export function pickFresh(
   const fresh: string[] = [];
   const freshHashes: string[] = [];
   let droppedCount = 0;
+  const seen = new Set(alreadyHashed);
 
   for (const line of lines) {
     const normalized = normalizeLine(line);
     const hash = hashLine(normalized);
-    if (alreadyHashed.has(hash)) {
+    if (seen.has(hash)) {
       droppedCount = droppedCount + 1;
       continue;
     }
     fresh.push(line);
     freshHashes.push(hash);
+    seen.add(hash);
     if (fresh.length >= limit) {
       break;
     }

--- a/plugins/honcho/src/dedup.ts
+++ b/plugins/honcho/src/dedup.ts
@@ -1,0 +1,38 @@
+export function normalizeLine(line: string): string {
+  return line
+    .replace(/^\[.*?\]\s*/, "")
+    .replace(/^- /, "")
+    .toLowerCase()
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+export function hashLine(normalized: string): string {
+  return Bun.hash(normalized).toString(36);
+}
+
+export function pickFresh(
+  lines: string[],
+  alreadyHashed: Set<string>,
+  limit: number,
+): { fresh: string[]; freshHashes: string[]; droppedCount: number } {
+  const fresh: string[] = [];
+  const freshHashes: string[] = [];
+  let droppedCount = 0;
+
+  for (const line of lines) {
+    const normalized = normalizeLine(line);
+    const hash = hashLine(normalized);
+    if (alreadyHashed.has(hash)) {
+      droppedCount = droppedCount + 1;
+      continue;
+    }
+    fresh.push(line);
+    freshHashes.push(hash);
+    if (fresh.length >= limit) {
+      break;
+    }
+  }
+
+  return { fresh, freshHashes, droppedCount };
+}

--- a/plugins/honcho/src/hooks/pre-compact.ts
+++ b/plugins/honcho/src/hooks/pre-compact.ts
@@ -1,5 +1,6 @@
 import { Honcho } from "@honcho-ai/sdk";
 import { loadConfig, getSessionForPath, getSessionName, getHonchoClientOptions, isPluginEnabled, getCachedStdin, getObservationMode } from "../config.js";
+import { clearInjectedHashesForSession } from "../cache.js";
 import { Spinner } from "../spinner.js";
 import { logHook, logApiCall, setLogContext } from "../log.js";
 import { formatVerboseBlock, formatVerboseList } from "../visual.js";
@@ -107,6 +108,7 @@ export async function handlePreCompact(): Promise<void> {
   }
 
   const cwd = hookInput.workspace_roots?.[0] || hookInput.cwd || process.cwd();
+  const claudeInstanceId = hookInput.session_id;
   const trigger = hookInput.trigger || "auto";
 
   // Set log context
@@ -121,6 +123,8 @@ export async function handlePreCompact(): Promise<void> {
   }
 
   try {
+    if (claudeInstanceId) clearInjectedHashesForSession(claudeInstanceId);
+
     const honcho = new Honcho(getHonchoClientOptions(config));
     const sessionName = getSessionName(cwd);
     const observationMode = getObservationMode(config);

--- a/plugins/honcho/src/hooks/session-start.ts
+++ b/plugins/honcho/src/hooks/session-start.ts
@@ -8,6 +8,7 @@ import {
   getCachedGitState,
   setCachedGitState,
   detectGitChanges,
+  clearInjectedHashesForSession,
 } from "../cache.js";
 import { Spinner } from "../spinner.js";
 import { captureGitState, getRecentCommits, isGitRepo, inferFeatureContext } from "../git.js";
@@ -63,6 +64,7 @@ export async function handleSessionStart(): Promise<void> {
 
   // Reset message count for this session (for threshold-based knowledge graph refresh)
   resetMessageCount();
+  if (claudeInstanceId) clearInjectedHashesForSession(claudeInstanceId);
 
   // Capture git state (before any API calls for speed)
   const previousGitState = getCachedGitState(cwd);

--- a/plugins/honcho/src/hooks/user-prompt.ts
+++ b/plugins/honcho/src/hooks/user-prompt.ts
@@ -1,5 +1,5 @@
 import { Honcho } from "@honcho-ai/sdk";
-import { loadConfig, getSessionName, getHonchoClientOptions, isPluginEnabled, getCachedStdin, getObservationMode } from "../config.js";
+import { loadConfig, getSessionName, getHonchoClientOptions, isPluginEnabled, getCachedStdin, getObservationMode, isLoggingEnabled } from "../config.js";
 import {
   getCachedUserContext,
   getStaleCachedUserContext,
@@ -11,9 +11,12 @@ import {
   markKnowledgeGraphRefreshed,
   getInstanceIdForCwd,
   queueMessage,
+  getInjectedHashesForSession,
+  recordInjectedHashes,
 } from "../cache.js";
 import { logHook, logApiCall, logCache, setLogContext } from "../log.js";
 import { visContextLine, visSkipMessage, addSystemMessage, verboseApiResult, verboseList } from "../visual.js";
+import { pickFresh } from "../dedup.js";
 import { honchoSessionUrl } from "../styles.js";
 
 interface HookInput {
@@ -106,6 +109,7 @@ export async function handleUserPrompt(): Promise<void> {
   const prompt = hookInput.prompt || "";
   const cwd = hookInput.workspace_roots?.[0] || hookInput.cwd || process.cwd();
   const instanceId = hookInput.session_id || getInstanceIdForCwd(cwd);
+  const dedupSessionId = hookInput.session_id;
   const sessionName = getSessionName(cwd, instanceId || undefined);
 
   setLogContext(cwd, sessionName);
@@ -149,7 +153,7 @@ export async function handleUserPrompt(): Promise<void> {
     verboseApiResult("peer.context() -> representation (cached)", cachedContext?.representation);
     verboseList("peer.context() -> peerCard (cached)", cachedContext?.peerCard);
 
-    serveContext(config.peerName, cachedContext, true, sessionLink);
+    serveContext(config.peerName, cachedContext, true, sessionLink, dedupSessionId);
     process.exit(0);
   }
 
@@ -167,7 +171,7 @@ export async function handleUserPrompt(): Promise<void> {
       markKnowledgeGraphRefreshed();
     }
     if (context) {
-      serveContext(config.peerName, context, false, sessionLink);
+      serveContext(config.peerName, context, false, sessionLink, dedupSessionId);
       process.exit(0);
     }
   }
@@ -176,7 +180,7 @@ export async function handleUserPrompt(): Promise<void> {
   const staleContext = getStaleCachedUserContext();
   if (staleContext) {
     logHook("user-prompt", "Serving stale cache after timeout");
-    serveContext(config.peerName, staleContext, true, sessionLink);
+    serveContext(config.peerName, staleContext, true, sessionLink, dedupSessionId);
   }
   // No cache at all — exit silently, context will arrive after session-start completes
 
@@ -191,8 +195,9 @@ function serveContext(
   context: any,
   cached: boolean,
   sessionLink?: string,
+  dedupSessionId?: string,
 ): void {
-  const { parts: contextParts } = formatCachedContext(context, peerName);
+  const { parts: contextParts } = formatCachedContext(context, peerName, dedupSessionId);
   if (contextParts.length === 0) return;
 
   const visMsg = visContextLine("user-prompt", { cached });
@@ -255,22 +260,56 @@ async function fetchFreshContext(config: any, prompt: string): Promise<{ context
   return { context: contextResult };
 }
 
-function formatCachedContext(context: any, peerName: string): { parts: string[]; conclusionCount: number } {
+function formatCachedContext(context: any, peerName: string, dedupSessionId?: string): { parts: string[]; conclusionCount: number } {
   const parts: string[] = [];
   let conclusionCount = 0;
+  let totalDropped = 0;
   const rep = context?.representation;
 
   if (typeof rep === "string" && rep.trim()) {
     const lines = rep.split("\n").filter((l: string) => l.trim() && !l.startsWith("#"));
-    const selected = lines.slice(0, 5);
-    conclusionCount = selected.length;
+    let selected: string[];
+    if (dedupSessionId) {
+      const alreadyHashed = getInjectedHashesForSession(dedupSessionId);
+      const result = pickFresh(lines, alreadyHashed, 5);
+      selected = result.fresh;
+      conclusionCount = result.fresh.length;
+      totalDropped = totalDropped + result.droppedCount;
+      if (result.freshHashes.length > 0) {
+        recordInjectedHashes(dedupSessionId, result.freshHashes);
+      }
+      for (const h of result.freshHashes) {
+        alreadyHashed.add(h);
+      }
+    } else {
+      selected = lines.slice(0, 5);
+      conclusionCount = selected.length;
+    }
     const summary = selected.map((l: string) => l.replace(/^\[.*?\]\s*/, "").replace(/^- /, "")).join("; ");
     if (summary) parts.push(`Relevant conclusions: ${summary}`);
   }
 
   const peerCard = context?.peerCard;
   if (peerCard?.length) {
-    parts.push(`Profile: ${peerCard.join("; ")}`);
+    let selectedPeerCard: string[];
+    if (dedupSessionId) {
+      const alreadyHashed = getInjectedHashesForSession(dedupSessionId);
+      const result = pickFresh(peerCard, alreadyHashed, peerCard.length);
+      selectedPeerCard = result.fresh;
+      totalDropped = totalDropped + result.droppedCount;
+      if (result.freshHashes.length > 0) {
+        recordInjectedHashes(dedupSessionId, result.freshHashes);
+      }
+    } else {
+      selectedPeerCard = peerCard;
+    }
+    if (selectedPeerCard.length > 0) {
+      parts.push(`Profile: ${selectedPeerCard.join("; ")}`);
+    }
+  }
+
+  if (totalDropped > 0 && isLoggingEnabled()) {
+    logHook("user-prompt", `Dedup dropped ${totalDropped} already-injected line(s) for session ${dedupSessionId}`);
   }
 
   return { parts, conclusionCount };


### PR DESCRIPTION
Resolves #39

## Summary

- Track injected conclusion hashes per session so identical conclusions are not re-emitted on every turn
- Reset the per-session dedup state on `SessionStart` (new session) and `PreCompact` (auto-compaction clears old `additionalContext` from context, so previously injected conclusions must be re-emitted)
- New `dedup.ts` module contains the hash helpers; session hash cache lives in `cache.ts`

## How it works

`user-prompt.ts` now filters each conclusion through `isAlreadyInjected()` before including it in the output. First time a conclusion is seen in a session it passes through; subsequent turns it is skipped. On compaction or a new session the set is cleared so conclusions flow again into the fresh context window.

## Test plan

- [x] Start a fresh Claude Code session with the honcho plugin — verify conclusions appear on the first prompt
- [x] Send two more prompts — verify `additionalContext` no longer repeats the same conclusions
- [x] Trigger auto-compaction (or simulate a `PreCompact` hook event) — verify conclusions re-appear on the next turn after compaction
- [x] Start a new session — verify conclusions appear fresh again

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed duplicate content being injected across sessions by implementing deduplication logic.

* **Chores**
  * Improved cache management to track and clear session-specific data between runs.
  * Enhanced context caching efficiency by preventing redundant content storage and retrieval.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/plastic-labs/claude-honcho/pull/40)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->