### PR TITLE
fix(session-end): never block exit — move upload to a detached worker

### DIFF
--- a/plugins/honcho/src/hooks/session-end-worker.ts
+++ b/plugins/honcho/src/hooks/session-end-worker.ts
@@ -1,0 +1,173 @@
+#!/usr/bin/env bun
+/**
+ * Detached SessionEnd upload worker.
+ *
+ * Spawned (detached, stdio-ignored, unref'd) by the SessionEnd hook so the hook
+ * itself can return in milliseconds and never block Claude Code's exit. This
+ * process outlives the parent and performs ONLY the network upload to Honcho.
+ *
+ * Contract:
+ *   - upload-only: it must NOT write claude-context.md (the parent already saved
+ *     the local summary) and must NEVER write to /dev/tty (it would clobber the
+ *     user's shell prompt after Claude Code has exited).
+ *   - input comes from a payload file whose path is in HONCHO_SESSION_END_PAYLOAD.
+ *   - it is self-bounded: a hung API can only delay it up to the SDK timeout, and
+ *     an unref'd hard-stop timer is a final backstop.
+ */
+import { Honcho } from "@honcho-ai/sdk";
+import { readFileSync, unlinkSync, opendirSync, statSync } from "fs";
+import { join, dirname } from "path";
+import {
+  loadConfig,
+  getHonchoClientOptions,
+  setDetectedHost,
+  type HonchoHost,
+} from "../config.js";
+import { chunkContent } from "../cache.js";
+import { logHook, logApiCall, setLogContext } from "../log.js";
+
+export interface SessionEndPayloadMessage {
+  content: string;
+  timestamp?: string;
+  isMeaningful?: boolean;
+}
+
+export interface SessionEndPayload {
+  host: HonchoHost;
+  cwd: string;
+  sessionName: string;
+  instanceId?: string;
+  reason: string;
+  transcriptCount: number;
+  messages: SessionEndPayloadMessage[];
+}
+
+/** prune leftover payload files older than the TTL; best-effort, never throws.
+ *  streams the directory (opendir) and stops after MAX_SCAN of our own `payload-*`
+ *  entries, so a blown-up queue dir can't force an unbounded listing or scan. */
+function pruneStalePayloads(queueDir: string, ttlMs = 10 * 60_000): void {
+  const MAX_SCAN = 1000;
+  let dir;
+  try {
+    dir = opendirSync(queueDir);
+  } catch {
+    return; // queue dir may not exist — nothing to prune
+  }
+  try {
+    const now = Date.now();
+    let scanned = 0;
+    let entry;
+    while ((entry = dir.readSync()) !== null) {
+      if (!entry.name.startsWith("payload-")) continue;
+      if (++scanned > MAX_SCAN) break;
+      const p = join(queueDir, entry.name);
+      try {
+        if (now - statSync(p).mtimeMs > ttlMs) unlinkSync(p);
+      } catch {
+        // ignore individual file errors
+      }
+    }
+  } finally {
+    try {
+      dir.closeSync();
+    } catch {
+      // already closed
+    }
+  }
+}
+
+export async function runUploadWorker(payloadPath: string): Promise<void> {
+  // outer finally guarantees the payload (which holds conversation text) is
+  // removed on EVERY exit path — malformed, config-disabled, success, or error.
+  try {
+    let payload: SessionEndPayload;
+    try {
+      payload = JSON.parse(readFileSync(payloadPath, "utf-8")) as SessionEndPayload;
+    } catch {
+      return; // unreadable/malformed — cleaned up by the outer finally
+    }
+
+    // resolve config exactly like the hook would (host drives workspace/aiPeer).
+    setDetectedHost(payload.host);
+    const config = loadConfig();
+    if (!config || config.enabled === false) return;
+
+    setLogContext(payload.cwd, payload.sessionName);
+    logHook("session-end-worker", "Uploading session memory", { reason: payload.reason });
+
+    try {
+      const honcho = new Honcho(getHonchoClientOptions(config));
+      const [session, aiPeer] = await Promise.all([
+        honcho.session(payload.sessionName),
+        honcho.peer(config.aiPeer),
+      ]);
+
+      const includeAssistant = config.saveMessages !== false && payload.messages.length > 0;
+      const aiMessages = includeAssistant
+        ? payload.messages.flatMap((msg) =>
+            chunkContent(msg.content).map((chunk) =>
+              aiPeer.message(chunk, {
+                createdAt: msg.timestamp,
+                metadata: {
+                  instance_id: payload.instanceId || undefined,
+                  type: msg.isMeaningful ? "assistant_prose" : "assistant_brief",
+                  meaningful: msg.isMeaningful || false,
+                  session_affinity: payload.sessionName,
+                },
+              }),
+            ),
+          )
+        : [];
+
+      const endMarker = aiPeer.message(
+        `[Session ended] Reason: ${payload.reason}, Messages: ${payload.transcriptCount}, Time: ${new Date().toISOString()}`,
+        {
+          createdAt: new Date().toISOString(),
+          metadata: {
+            instance_id: payload.instanceId || undefined,
+            session_affinity: payload.sessionName,
+          },
+        },
+      );
+
+      const meaningfulCount = payload.messages.filter((m) => m.isMeaningful).length;
+      logApiCall(
+        "session.addMessages",
+        "POST",
+        `${aiMessages.length} assistant (${meaningfulCount} meaningful) + 1 marker`,
+      );
+      await session.addMessages([...aiMessages, endMarker]);
+      logHook("session-end-worker", "Session memory uploaded");
+    } catch (error) {
+      logHook("session-end-worker", `Upload failed: ${error}`, { error: String(error) });
+    }
+  } finally {
+    try {
+      unlinkSync(payloadPath);
+    } catch {
+      // already gone
+    }
+    pruneStalePayloads(dirname(payloadPath));
+  }
+}
+
+if (import.meta.main) {
+  const payloadPath = process.env.HONCHO_SESSION_END_PAYLOAD;
+  // final backstop: never let a hung socket keep this process alive forever.
+  // force-exit bypasses runUploadWorker's finally, so unlink the payload here too.
+  const hardStop = setTimeout(() => {
+    if (payloadPath) {
+      try {
+        unlinkSync(payloadPath);
+      } catch {
+        // already gone
+      }
+    }
+    process.exit(0);
+  }, 20_000);
+  hardStop.unref();
+  if (payloadPath) {
+    await runUploadWorker(payloadPath);
+  }
+  process.exit(0);
+}

--- a/plugins/honcho/src/hooks/session-end.ts
+++ b/plugins/honcho/src/hooks/session-end.ts
@@ -1,15 +1,33 @@
-import { Honcho } from "@honcho-ai/sdk";
-import { loadConfig, getSessionName, getHonchoClientOptions, isPluginEnabled, getCachedStdin } from "../config.js";
-import { existsSync, readFileSync } from "fs";
+import {
+  existsSync,
+  readFileSync,
+  mkdirSync,
+  chmodSync,
+  writeFileSync,
+  renameSync,
+  unlinkSync,
+  openSync,
+  fstatSync,
+  readSync,
+  closeSync,
+} from "fs";
+import { join } from "path";
+import {
+  loadConfig,
+  getSessionName,
+  isPluginEnabled,
+  getCachedStdin,
+  getConfigDir,
+  getDetectedHost,
+} from "../config.js";
 import {
   generateClaudeSummary,
   saveClaudeLocalContext,
   loadClaudeLocalContext,
   getInstanceIdForCwd,
-  chunkContent,
 } from "../cache.js";
-import { playCooldown } from "../spinner.js";
-import { logHook, logApiCall, setLogContext } from "../log.js";
+import { logHook, setLogContext } from "../log.js";
+import type { SessionEndPayload } from "./session-end-worker.js";
 
 
 interface HookInput {
@@ -67,6 +85,40 @@ function isMeaningfulAssistantContent(content: string): boolean {
   return content.length >= 200;
 }
 
+// cap how much of a transcript we read on the exit critical path. recent
+// messages (what the tail-based summary/upload need) live at the end of the
+// jsonl file, so reading only the last slice bounds work on huge transcripts
+// and keeps the hook from re-blocking the exit it is meant to free.
+const TRANSCRIPT_TAIL_CAP = 4 * 1024 * 1024; // 4 MB
+
+/** read at most the last `cap` bytes of a (possibly huge) transcript. when the
+ *  window starts mid-line, the partial first line is dropped so JSON.parse never
+ *  sees half a line; when it already starts on a line boundary nothing is lost. */
+export function readTranscriptTail(transcriptPath: string, cap = TRANSCRIPT_TAIL_CAP): string {
+  const fd = openSync(transcriptPath, "r");
+  try {
+    const size = fstatSync(fd).size;
+    if (size <= cap) {
+      return readFileSync(transcriptPath, "utf-8");
+    }
+    const start = size - cap;
+    // peek the byte before the window: if it's a newline the window already
+    // begins on a clean line boundary, so the first line is complete — keep it.
+    const prev = Buffer.allocUnsafe(1);
+    readSync(fd, prev, 0, 1, start - 1);
+    const cutMidLine = prev[0] !== 0x0a; // 0x0a = "\n"
+
+    const buf = Buffer.allocUnsafe(cap);
+    const read = readSync(fd, buf, 0, cap, start);
+    const text = buf.toString("utf-8", 0, read);
+    if (!cutMidLine) return text;
+    const nl = text.indexOf("\n");
+    return nl >= 0 ? text.slice(nl + 1) : text;
+  } finally {
+    closeSync(fd);
+  }
+}
+
 function parseTranscript(transcriptPath: string): Array<{ role: string; content: string; isMeaningful?: boolean; timestamp?: string }> {
   const messages: Array<{ role: string; content: string; isMeaningful?: boolean; timestamp?: string }> = [];
 
@@ -75,7 +127,7 @@ function parseTranscript(transcriptPath: string): Array<{ role: string; content:
   }
 
   try {
-    const content = readFileSync(transcriptPath, "utf-8");
+    const content = readTranscriptTail(transcriptPath);
     const lines = content.split("\n").filter((line) => line.trim());
 
     for (const line of lines) {
@@ -165,12 +217,77 @@ function extractWorkItems(assistantMessages: string[]): string[] {
 }
 
 /**
- * SessionEnd hook — structured for resilience against cancellation.
+ * Hand the Honcho upload to a detached background worker so the hook returns in
+ * milliseconds. SessionEnd runs while Claude Code is tearing down; any network
+ * I/O on the critical path risks blowing the exit budget and getting cancelled.
+ * The worker is fully detached (new session via setsid, stdio ignored, unref'd)
+ * so it outlives this process and uploads out-of-band. Best-effort: a failure to
+ * dispatch never blocks exit — the local summary was already saved in phase 1.
+ */
+function dispatchUploadWorker(payload: SessionEndPayload): void {
+  // track only files WE created, so failure-cleanup can never unlink another
+  // process's payload (filenames are unique, but stay defensive).
+  let createdTmp: string | undefined;
+  let createdFinal: string | undefined;
+  try {
+    const stateDir = getConfigDir();
+    const queueDir = join(stateDir, "session-end-queue");
+    // 0700 dir + 0600 file: the payload holds transcript-derived conversation
+    // text, so keep it private even under a permissive umask. mkdir's mode only
+    // applies on creation, so also chmod (best-effort) to tighten a queue dir
+    // that a prior build may have created with looser permissions.
+    mkdirSync(queueDir, { recursive: true, mode: 0o700 });
+    try {
+      chmodSync(queueDir, 0o700);
+    } catch {
+      // best-effort: a chmod failure must never block the upload dispatch
+    }
+
+    const finalPath = join(
+      queueDir,
+      `payload-${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2)}.json`,
+    );
+    const tmpPath = `${finalPath}.tmp`;
+    // atomic publish: exclusive-create the tmp file, then rename so the worker
+    // never sees a partial file (rename preserves the 0600 mode).
+    writeFileSync(tmpPath, JSON.stringify(payload), { mode: 0o600, flag: "wx" });
+    createdTmp = tmpPath;
+    renameSync(tmpPath, finalPath);
+    createdTmp = undefined;
+    createdFinal = finalPath;
+
+    const workerPath = join(import.meta.dir, "session-end-worker.ts");
+    const proc = Bun.spawn([process.execPath, "run", workerPath], {
+      detached: true,
+      stdio: ["ignore", "ignore", "ignore"],
+      cwd: process.cwd(),
+      env: {
+        ...process.env,
+        HONCHO_SESSION_END_PAYLOAD: finalPath,
+      },
+    });
+    // the worker now owns the payload and will unlink it.
+    createdFinal = undefined;
+    proc.unref();
+  } catch (error) {
+    logHook("session-end", `Failed to dispatch upload worker: ${error}`, { error: String(error) });
+    // best-effort: never leave an unpublished/un-owned payload (conversation text) behind.
+    for (const p of [createdTmp, createdFinal]) {
+      if (!p) continue;
+      try {
+        unlinkSync(p);
+      } catch {
+        // already gone
+      }
+    }
+  }
+}
+
+/**
+ * SessionEnd hook — returns instantly, never blocks Claude Code's exit.
  *
- * Priority order (most critical first):
- *   1. Local summary (instant, zero risk — survives any cancellation)
- *   2. Parallel: cooldown animation + API uploads (critical data first)
- *   3. Session end marker (nice-to-have metadata)
+ *   1. Phase 1: local summary (synchronous, zero risk — guaranteed before exit)
+ *   2. Phase 2: dispatch a detached worker for the Honcho upload, then exit 0
  */
 export async function handleSessionEnd(): Promise<void> {
   const config = loadConfig();
@@ -232,106 +349,30 @@ export async function handleSessionEnd(): Promise<void> {
   saveClaudeLocalContext(newSummary + recentActivity);
 
   // =========================================================
-  // Phase 2: PARALLEL API UPLOADS + ANIMATION
-  // Cooldown animation runs concurrently with network I/O
-  // so we don't waste budget on cosmetics before critical work.
+  // Phase 2: DISPATCH (instant, non-blocking)
+  // Hand the Honcho upload to a detached background worker and return. The
+  // worker outlives this process and uploads out-of-band, so the exit is never
+  // delayed by network I/O. The end marker is always sent; assistant messages
+  // are included unless saveMessages is disabled (the worker enforces that).
   // =========================================================
-  try {
-    const honcho = new Honcho(getHonchoClientOptions(config));
+  dispatchUploadWorker({
+    host: getDetectedHost(),
+    cwd,
+    sessionName,
+    instanceId: instanceId || undefined,
+    reason,
+    transcriptCount: transcriptMessages.length,
+    messages: assistantMessages.map((m) => ({
+      content: m.content,
+      timestamp: m.timestamp,
+      isMeaningful: m.isMeaningful,
+    })),
+  });
 
-    const [session, aiPeer] = await Promise.all([
-      honcho.session(sessionName),
-      honcho.peer(config.aiPeer),
-    ]);
-
-    logHook("session-end", `Processing ${assistantMessages.length} assistant msgs`);
-
-    const aiMessages = (config.saveMessages !== false && assistantMessages.length > 0)
-      ? assistantMessages.flatMap((msg) => {
-          const chunks = chunkContent(msg.content);
-          return chunks.map(chunk =>
-            aiPeer.message(chunk, {
-              createdAt: msg.timestamp,
-              metadata: {
-                instance_id: instanceId || undefined,
-                type: msg.isMeaningful ? 'assistant_prose' : 'assistant_brief',
-                meaningful: msg.isMeaningful || false,
-                session_affinity: sessionName,
-              },
-            })
-          );
-        })
-      : [];
-
-    const endMarker = aiPeer.message(
-      `[Session ended] Reason: ${reason}, Messages: ${transcriptMessages.length}, Time: ${new Date().toISOString()}`,
-      {
-        createdAt: new Date().toISOString(),
-        metadata: {
-          instance_id: instanceId || undefined,
-          session_affinity: sessionName,
-        },
-      }
-    );
-
-    // Single addMessages call with everything — one round trip instead of three.
-    const allMessages = [...aiMessages, endMarker];
-
-    if (allMessages.length > 0) {
-      const meaningfulCount = assistantMessages.filter(m => m.isMeaningful).length;
-      logApiCall("session.addMessages", "POST",
-        `${aiMessages.length} assistant (${meaningfulCount} meaningful) + 1 marker`);
-
-      // Start API upload immediately; run animation concurrently.
-      const uploadPromise = session.addMessages(allMessages);
-
-      // Trap SIGTERM/SIGINT to prevent default termination while upload
-      // is in flight. The handler is a no-op — its only purpose is to
-      // keep the process alive. Cooldown's own exit handler cleans up
-      // the cursor if the process exits unexpectedly.
-      const sigHandler = () => {};
-      process.on("SIGINT", sigHandler);
-      if (process.platform === "win32") {
-        process.on("SIGBREAK", sigHandler);
-      } else {
-        process.on("SIGTERM", sigHandler);
-      }
-
-      const removeSigHandlers = () => {
-        process.removeListener("SIGINT", sigHandler);
-        if (process.platform === "win32") {
-          process.removeListener("SIGBREAK", sigHandler);
-        } else {
-          process.removeListener("SIGTERM", sigHandler);
-        }
-      };
-
-      // Hard safety net: if the upload hangs beyond SDK timeout + margin,
-      // force exit. Local summary was already saved in phase 1.
-      const hardTimeout = setTimeout(() => {
-        logHook("session-end", "Hard timeout reached — forcing exit");
-        removeSigHandlers();
-        process.exit(0);
-      }, 12_000);
-      hardTimeout.unref();
-
-      await Promise.all([
-        uploadPromise.finally(() => {
-          clearTimeout(hardTimeout);
-          removeSigHandlers();
-        }),
-        playCooldown("saving memory"),
-      ]);
-    } else {
-      await playCooldown("saving memory");
-    }
-
-    const meaningfulCount = assistantMessages.filter(m => m.isMeaningful).length;
-    logHook("session-end", `Session saved: ${assistantMessages.length} assistant msgs (${meaningfulCount} meaningful)`);
-    process.exit(0);
-  } catch (error) {
-    logHook("session-end", `Error: ${error}`, { error: String(error) });
-    // Local summary was already saved in phase 1 — not a total loss.
-    process.exit(0);
-  }
+  const meaningfulCount = assistantMessages.filter((m) => m.isMeaningful).length;
+  logHook(
+    "session-end",
+    `Dispatched upload worker: ${assistantMessages.length} assistant msgs (${meaningfulCount} meaningful)`,
+  );
+  process.exit(0);
 }

--- a/plugins/honcho/src/session-end-nonblocking.e2e.test.ts
+++ b/plugins/honcho/src/session-end-nonblocking.e2e.test.ts
@@ -1,0 +1,255 @@
+import { describe, expect, test, afterAll } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync, existsSync, statSync, readdirSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { readTranscriptTail } from "./hooks/session-end.js";
+
+// e2e contract for the SessionEnd hook: it must NOT block Claude Code's exit and
+// must NOT hang waiting on the Honcho API. We spawn the real hook entry point in a
+// child process pointed at a black-hole mock API (every request is received but the
+// response is held open forever), under a throwaway HOME (so all state lands in
+// $HOME/.honcho). No real network, no real Honcho.
+//
+// The fix moves the network upload into a detached background worker, so the hook
+// itself returns in milliseconds while the upload is delivered out-of-band. These
+// tests are RED against the old blocking implementation (which awaits the upload
+// up to the SDK timeout) and GREEN once the worker is in place.
+
+// the real production entry that hooks.json runs: the thin hooks/session-end.ts
+// wrapper (initHook() + handleSessionEnd()), NOT the src/hooks/ logic module
+// (which only exports handleSessionEnd and does nothing when run directly). this
+// is one dir up from src/, on purpose, so the e2e exercises the full hook exactly
+// as Claude Code invokes it.
+const HOOK = join(import.meta.dir, "..", "hooks", "session-end.ts");
+
+// hook must return well under this; the old code blocks ~8s on the hung endpoint.
+const RETURN_BUDGET_MS = 3000;
+
+interface MockApi {
+  url: string;
+  requestCount(): number;
+  waitForRequest(timeoutMs: number): Promise<boolean>;
+  stop(): void;
+}
+
+/** A Honcho API stand-in that records every request then holds the response open
+ *  forever, emulating a slow / unreachable endpoint. One mock per hook run, so a
+ *  request arriving here can only come from THIS run's detached worker. */
+function startMockApi(): MockApi {
+  const requests: { at: number; path: string }[] = [];
+  const waiters = new Set<() => void>();
+
+  const server = Bun.serve({
+    port: 0,
+    idleTimeout: 0,
+    async fetch(req) {
+      requests.push({ at: Date.now(), path: new URL(req.url).pathname });
+      for (const w of [...waiters]) w();
+      // hang forever — never resolve. The caller's own client timeout bounds it.
+      await new Promise<void>(() => {});
+      return new Response("{}", { headers: { "content-type": "application/json" } });
+    },
+  });
+
+  return {
+    url: `http://127.0.0.1:${server.port}`,
+    requestCount: () => requests.length,
+    waitForRequest(timeoutMs) {
+      if (requests.length > 0) return Promise.resolve(true);
+      return new Promise<boolean>((resolve) => {
+        const onReq = () => {
+          cleanup();
+          resolve(true);
+        };
+        const timer = setTimeout(() => {
+          cleanup();
+          resolve(false);
+        }, timeoutMs);
+        function cleanup() {
+          waiters.delete(onReq);
+          clearTimeout(timer);
+        }
+        waiters.add(onReq);
+      });
+    },
+    stop: () => server.stop(true),
+  };
+}
+
+const tmps: string[] = [];
+const mocks: MockApi[] = [];
+function freshDir(tag: string): string {
+  const d = mkdtempSync(join(tmpdir(), `se-${tag}-`));
+  tmps.push(d);
+  return d;
+}
+
+afterAll(() => {
+  for (const m of mocks) m.stop();
+  for (const d of tmps) rmSync(d, { recursive: true, force: true });
+});
+
+/** Minimal Claude-transcript JSONL with a meaningful assistant message so the hook
+ *  has something to summarize locally and to upload. */
+function writeTranscript(dir: string): string {
+  const p = join(dir, "transcript.jsonl");
+  const lines = [
+    { type: "user", timestamp: "2026-06-01T00:00:00.000Z", message: { role: "user", content: "please fix the session-end hook" } },
+    {
+      type: "assistant",
+      timestamp: "2026-06-01T00:00:01.000Z",
+      message: {
+        role: "assistant",
+        content: [
+          {
+            type: "text",
+            text: "I implemented the fix and resolved the bug in the session-end hook. The problem was that it blocked on a network upload; I refactored it to a detached background worker so the exit is never delayed.",
+          },
+        ],
+      },
+    },
+  ];
+  writeFileSync(p, lines.map((l) => JSON.stringify(l)).join("\n") + "\n");
+  return p;
+}
+
+interface HookRun {
+  timedOut: boolean;
+  exitCode: number | null;
+  wallMs: number;
+  stateDir: string;
+  mock: MockApi;
+}
+
+/** Spawn the real SessionEnd hook against a fresh mock API and race its exit
+ *  against a hard budget. On timeout we SIGKILL (the old code traps SIGTERM, so a
+ *  plain kill would not stop it) and report timedOut. */
+async function runHook(): Promise<HookRun> {
+  const home = freshDir("home");
+  const stateDir = join(home, ".honcho");
+  const transcriptPath = writeTranscript(freshDir("tx"));
+  const mock = startMockApi();
+  mocks.push(mock);
+
+  const hookInput = {
+    session_id: "e2e-session",
+    transcript_path: transcriptPath,
+    cwd: home,
+    reason: "exit",
+  };
+
+  const childEnv: Record<string, string> = {
+    PATH: process.env.PATH ?? "",
+    HOME: home,
+    HONCHO_API_KEY: "test-key",
+    HONCHO_ENDPOINT: mock.url,
+    HONCHO_SAVE_MESSAGES: "true",
+  };
+
+  const start = Date.now();
+  const proc = Bun.spawn([process.execPath, "run", HOOK], {
+    env: childEnv,
+    stdin: Buffer.from(JSON.stringify(hookInput)),
+    stdout: "ignore",
+    stderr: "ignore",
+  });
+
+  const raced = await Promise.race([
+    proc.exited.then((code) => ({ kind: "exit" as const, code })),
+    Bun.sleep(RETURN_BUDGET_MS).then(() => ({ kind: "timeout" as const })),
+  ]);
+
+  const wallMs = Date.now() - start;
+  if (raced.kind === "timeout") {
+    proc.kill("SIGKILL");
+    return { timedOut: true, exitCode: null, wallMs, stateDir, mock };
+  }
+  return { timedOut: false, exitCode: raced.code, wallMs, stateDir, mock };
+}
+
+describe("SessionEnd hook does not block exit (e2e)", () => {
+  test(
+    "returns within the budget and exits 0 even when the Honcho API hangs",
+    async () => {
+      const run = await runHook();
+      expect(run.timedOut, `hook blocked > ${RETURN_BUDGET_MS}ms on a hung API (wall=${run.wallMs}ms)`).toBe(false);
+      expect(run.exitCode).toBe(0);
+    },
+    20_000,
+  );
+
+  test(
+    "still writes the local summary (claude-context.md) before returning",
+    async () => {
+      const run = await runHook();
+      expect(run.timedOut).toBe(false);
+      expect(existsSync(join(run.stateDir, "claude-context.md"))).toBe(true);
+    },
+    20_000,
+  );
+
+  test(
+    "delivers the memory upload out-of-band (detached worker reaches the API after the hook returned)",
+    async () => {
+      const run = await runHook();
+      // hook must have returned promptly...
+      expect(run.timedOut, `hook blocked > ${RETURN_BUDGET_MS}ms (wall=${run.wallMs}ms)`).toBe(false);
+      expect(run.exitCode).toBe(0);
+      // ...and the upload must still happen, from THIS run's detached worker, after exit.
+      const delivered = await run.mock.waitForRequest(10_000);
+      expect(delivered, "no upload request reached the API — the worker did not run").toBe(true);
+    },
+    25_000,
+  );
+
+  test.skipIf(process.platform === "win32")(
+    "writes the queued payload privately (0700 dir, 0600 file)",
+    async () => {
+      const run = await runHook();
+      expect(run.timedOut).toBe(false);
+      // the parent writes the payload before exit; the worker is hung on the mock,
+      // so the payload is still on disk here.
+      const queueDir = join(run.stateDir, "session-end-queue");
+      expect(existsSync(queueDir)).toBe(true);
+      // the dir is 0700 (private + traversable); payload files must be exactly
+      // 0600 — private AND non-executable. they must NOT inherit the dir's exec
+      // bit: chmod is applied to the directory only, never recursively to files.
+      expect(statSync(queueDir).mode & 0o777, "queue dir must be exactly 0700").toBe(0o700);
+      const payloads = readdirSync(queueDir).filter((n) => n.startsWith("payload-") && n.endsWith(".json"));
+      expect(payloads.length).toBeGreaterThan(0);
+      for (const name of payloads) {
+        const mode = statSync(join(queueDir, name)).mode & 0o777;
+        expect(mode, `${name} must be exactly 0600 (private, not executable)`).toBe(0o600);
+      }
+    },
+    20_000,
+  );
+});
+
+describe("readTranscriptTail", () => {
+  test("returns the full file when under the cap", () => {
+    const dir = freshDir("tail");
+    const p = join(dir, "t.jsonl");
+    const body = "line-a\nline-b\nline-c\n";
+    writeFileSync(p, body);
+    expect(readTranscriptTail(p, 1024)).toBe(body);
+  });
+
+  test("reads only the tail and drops the partial first line when over the cap", () => {
+    const dir = freshDir("tail");
+    const p = join(dir, "big.jsonl");
+    const lines: string[] = [];
+    for (let i = 0; i < 2000; i++) lines.push(`{"type":"assistant","i":${i}}`);
+    const body = lines.join("\n") + "\n";
+    writeFileSync(p, body);
+
+    const cap = 200;
+    const tail = readTranscriptTail(p, cap);
+    // bounded: never returns more than the cap...
+    expect(tail.length).toBeLessThanOrEqual(cap);
+    // ...starts on a clean line boundary (no half a line)...
+    expect(tail.startsWith("{")).toBe(true);
+    // ...and still contains the most recent (last) line.
+    expect(tail.includes(lines[lines.length - 1])).toBe(true);
+  });
+});


### PR DESCRIPTION
## Problem

On session exit, Claude Code prints `SessionEnd hook [...] failed: Hook cancelled` and the exit hangs.

`src/hooks/session-end.ts` runs the Honcho upload on the critical path — `session.addMessages()` (up to the 8s SDK timeout) plus a ~1s cooldown animation — and installs a no-op `SIGINT`/`SIGTERM` handler to "stay alive" while the upload is in flight. SessionEnd runs while Claude Code is tearing down, so the hook overruns its budget and the harness cancels it; the signal trap makes that cancellation janky.

## Fix

Move the network upload into a fully detached background worker so the hook returns in milliseconds and never blocks the exit:

- **`src/hooks/session-end.ts`** — Phase 1 (local `claude-context.md` summary) stays synchronous and guaranteed. Phase 2 writes the payload atomically to `<configDir>/session-end-queue/` and spawns the worker detached (`Bun.spawn(..., { detached: true, stdio: ["ignore", "ignore", "ignore"] }); proc.unref()`), then exits 0. Removed the `SIGINT`/`SIGTERM` trap, the 12s hard timeout, and the blocking cooldown animation.
- **`src/hooks/session-end-worker.ts`** (new) — upload-only detached process that outlives the hook and uploads to Honcho out-of-band. It never writes `claude-context.md` or `/dev/tty`, removes its payload on every exit path, and prunes stale payloads.
- **Hardening:** payload files are written `0600` in a `0700` queue dir (they hold transcript-derived text); transcript reads are tail-capped (4 MB) so a huge transcript can't re-block the exit; queue pruning is bounded; dispatch failures clean up any unpublished payload.

## Tests

`src/session-end-nonblocking.e2e.test.ts` spawns the real hook against a black-hole mock API (records the request, then holds the response open forever) under a throwaway `HOME`, and asserts the hook returns in under 3s and exits 0 while the upload still reaches the API from the detached worker *after* the hook returned. Plus payload-permission and transcript tail-cap unit tests. `bun test` is green and `tsc --noEmit` is clean.

## Relation to #45

This removes the 12s hard-timeout force-exit that #45 reports as silently dropping the session-end upload: the upload no longer races the hook's exit, so a slow or unreachable API can no longer force-exit the hook mid-flush. It does **not** implement #45's queue-progress proposals (chunked per-batch marking, catch-up flush, surfacing) — those remain open.

## Note

The ~1s "memory saved" cooldown animation on exit is intentionally dropped — it was the blocking step.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Session end process no longer blocks application exit
  * Memory uploads to Honcho now happen asynchronously in the background

* **Tests**
  * Added end-to-end tests validating non-blocking session completion behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->