### PR TITLE
fix: adding support for host level apiKey in claude_code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to claude-honcho will be documented in this file.
 
+## [Unreleased]
+
+### Added
+
+- Per-host `apiKey` field in `hosts.<name>` — takes precedence over root `apiKey`, still overridden by `HONCHO_API_KEY` env var. Lets different integrations authenticate against different Honcho orgs from one config file.
+
 ## [0.2.4] - 2026-04-01
 
 ### Added

--- a/plugins/honcho/src/config.ts
+++ b/plugins/honcho/src/config.ts
@@ -62,6 +62,13 @@ export interface HostConfig {
   workspace?: string;
   /** AI peer name for this host (e.g. "claude", "cursor") */
   aiPeer?: string;
+  /**
+   * Honcho API key scoped to this host. Takes precedence over the root
+   * `apiKey` field, but is still overridden by the HONCHO_API_KEY env var.
+   * Useful when different hosts (claude_code, cursor, opencode) authenticate
+   * against different Honcho orgs or workspaces.
+   */
+  apiKey?: string;
 
   /** Per-host overrides for settings that may differ across tools */
   enabled?: boolean;
@@ -279,7 +286,12 @@ export function loadConfig(host?: HonchoHost): HonchoCLAUDEConfig | null {
 }
 
 function resolveConfig(raw: HonchoFileConfig, host: HonchoHost): HonchoCLAUDEConfig | null {
-  const apiKey = process.env.HONCHO_API_KEY || raw.apiKey;
+  const hostBlock = raw.hosts?.[host]
+    ?? raw.hosts?.[host.replace(/_/g, "-")]
+    ?? raw.hosts?.[host.replace(/-/g, "_")];
+
+  // Resolution order: env var > host-scoped apiKey > root apiKey.
+  const apiKey = process.env.HONCHO_API_KEY || hostBlock?.apiKey || raw.apiKey;
   if (!apiKey) return null;
 
   const peerName = raw.peerName || process.env.HONCHO_PEER_NAME || process.env.USER || process.env.USERNAME || "user";
@@ -287,10 +299,6 @@ function resolveConfig(raw: HonchoFileConfig, host: HonchoHost): HonchoCLAUDECon
   // Resolve host-specific fields
   let workspace: string;
   let aiPeer: string;
-
-  const hostBlock = raw.hosts?.[host]
-    ?? raw.hosts?.[host.replace(/_/g, "-")]
-    ?? raw.hosts?.[host.replace(/-/g, "_")];
 
   if (raw.globalOverride === true) {
     // Global override: flat fields apply to ALL hosts

--- a/plugins/honcho/src/config.ts
+++ b/plugins/honcho/src/config.ts
@@ -495,6 +495,13 @@ export function saveConfig(config: HonchoCLAUDEConfig): void {
   setHostIfExplicit("localContext", config.localContext, existing.localContext);
   setHostIfExplicit("endpoint", config.endpoint, existing.endpoint);
 
+  // Preserve a host-scoped apiKey already on disk. This integration never writes
+  // apiKey (config.apiKey is the *resolved* key — env/root — and must not be
+  // materialized here), but must not drop hosts.<host>.apiKey on rewrite.
+  if (existingHost.apiKey !== undefined) {
+    hostEntry.apiKey = existingHost.apiKey;
+  }
+
   existing.hosts[host] = hostEntry;
 
   writeFileSync(CONFIG_FILE, JSON.stringify(existing, null, 2));

--- a/plugins/honcho/src/mcp/server.ts
+++ b/plugins/honcho/src/mcp/server.ts
@@ -166,6 +166,26 @@ function handleGetConfig(cwd: string) {
     }
   }
 
+  // HONCHO_API_KEY is omitted from ENV_SHADOW_MAP and handled specially: an API
+  // key selects the Honcho *environment*, so when the env var overrides the
+  // configured key (resolveConfig: env wins, matching standard env>config
+  // precedence) every read and write silently routes to a different environment
+  // than config.json names. That's far more surprising than a normal override,
+  // so surface it whenever the env var is set — loudly on a mismatch.
+  const envApiKey = process.env.HONCHO_API_KEY;
+  if (envApiKey && rawFile.apiKey) {
+    const mask = (k: string) => `${k.slice(0, 10)}…${k.slice(-4)}`;
+    if (envApiKey !== rawFile.apiKey) {
+      warnings.push(
+        `HONCHO_API_KEY env var (${mask(envApiKey)}) overrides config.json apiKey (${mask(rawFile.apiKey)}) and is the key actually in use. ` +
+        `An API key selects the Honcho environment, so reads/writes go to the env var's environment, NOT the one config.json names. ` +
+        `Unset HONCHO_API_KEY in your shell to use config.json's key.`
+      );
+    } else {
+      warnings.push(`apiKey is also set via HONCHO_API_KEY env var (identical value). The env var takes precedence at runtime.`);
+    }
+  }
+
   // Check for legacy fields without hosts block
   if (cfgExists && !rawFile.hosts) {
     warnings.push("Config uses legacy flat fields. Consider running /honcho:config to migrate to hosts block.");


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-host API key support so each host can have distinct authentication credentials.

* **Bug Fixes**
  * Preserve existing host-specific API keys when saving configuration to avoid accidental removal.
  * Add warnings when the HONCHO_API_KEY environment variable conflicts with or matches a host config.

* **Documentation**
  * Changelog documents API key resolution precedence: HONCHO_API_KEY → host-specific → root.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->