### PR TITLE
Revert "Simplifying Adding Messages to Honcho (#42)"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,18 +8,6 @@ All notable changes to claude-honcho will be documented in this file.
 
 - Version-update nag: warns on first prompt when the installed plugin is behind the published version (checks for updates at most once a day; silent on failure).
 
-### Changed
-
-- User prompts are now written to Honcho in real time on `UserPromptSubmit` instead of being queued for `SessionEnd` flush. Mirrors the existing fire-and-forget pattern used by `PostToolUse` and `Stop`.
-
-### Fixed
-
-- Eliminated a duplication bug where repeated `SessionEnd` failures (12s timeout, double-fire) caused queued prompts to be re-uploaded indefinitely.
-
-### Removed
-
-- The local `~/.honcho/message-queue.jsonl` queue file is no longer used and can be deleted from user machines to reclaim disk. The plugin will not auto-delete it.
-
 ## [0.2.4] - 2026-04-01
 
 ### Added

--- a/plugins/honcho/src/cache.ts
+++ b/plugins/honcho/src/cache.ts
@@ -1,11 +1,12 @@
 import { homedir } from "os";
 import { join } from "path";
-import { existsSync, readFileSync, writeFileSync, mkdirSync } from "fs";
+import { existsSync, readFileSync, writeFileSync, appendFileSync, mkdirSync } from "fs";
 import { getContextRefreshConfig, getLocalContextConfig } from "./config.js";
 
 const CACHE_DIR = join(homedir(), ".honcho");
 const ID_CACHE_FILE = join(CACHE_DIR, "cache.json");
 const CONTEXT_CACHE_FILE = join(CACHE_DIR, "context-cache.json");
+const MESSAGE_QUEUE_FILE = join(CACHE_DIR, "message-queue.jsonl");
 const CLAUDE_CONTEXT_FILE = join(CACHE_DIR, "claude-context.md");
 
 // Ensure cache directory exists
@@ -242,6 +243,82 @@ export function resetMessageCount(): void {
   cache.messageCount = 0;
   cache.lastRefreshMessageCount = 0;
   saveContextCache(cache);
+}
+
+// ============================================
+// Message Queue - local file for reliability
+// ============================================
+
+interface QueuedMessage {
+  content: string;
+  peerId: string;
+  cwd: string;
+  timestamp: string;
+  uploaded?: boolean;
+  instanceId?: string; // Claude Code instance for parallel session support
+}
+
+export function queueMessage(content: string, peerId: string, cwd: string, instanceId?: string): void {
+  ensureCacheDir();
+  const message: QueuedMessage = {
+    content,
+    peerId,
+    cwd,
+    timestamp: new Date().toISOString(),
+    uploaded: false,
+    instanceId: instanceId || getClaudeInstanceId() || undefined,
+  };
+  appendFileSync(MESSAGE_QUEUE_FILE, JSON.stringify(message) + "\n");
+}
+
+export function getQueuedMessages(forCwd?: string): QueuedMessage[] {
+  ensureCacheDir();
+  if (!existsSync(MESSAGE_QUEUE_FILE)) {
+    return [];
+  }
+  try {
+    const content = readFileSync(MESSAGE_QUEUE_FILE, "utf-8");
+    const lines = content.split("\n").filter((line) => line.trim());
+    const messages = lines.map((line) => JSON.parse(line)).filter((msg) => !msg.uploaded);
+    // Filter by cwd if specified
+    if (forCwd) {
+      return messages.filter((msg) => msg.cwd === forCwd);
+    }
+    return messages;
+  } catch {
+    return [];
+  }
+}
+
+export function clearMessageQueue(): void {
+  ensureCacheDir();
+  writeFileSync(MESSAGE_QUEUE_FILE, "");
+}
+
+export function markMessagesUploaded(forCwd?: string): void {
+  if (!forCwd) {
+    // Clear all
+    clearMessageQueue();
+    return;
+  }
+  // Only remove messages for the specified cwd, keep others
+  ensureCacheDir();
+  if (!existsSync(MESSAGE_QUEUE_FILE)) return;
+  try {
+    const content = readFileSync(MESSAGE_QUEUE_FILE, "utf-8");
+    const lines = content.split("\n").filter((line) => line.trim());
+    const remaining = lines.filter((line) => {
+      try {
+        const msg = JSON.parse(line);
+        return msg.cwd !== forCwd;
+      } catch {
+        return false;
+      }
+    });
+    writeFileSync(MESSAGE_QUEUE_FILE, remaining.join("\n") + (remaining.length ? "\n" : ""));
+  } catch {
+    // ignore
+  }
 }
 
 // ============================================
@@ -494,6 +571,7 @@ export function clearAllCaches(): void {
   ensureCacheDir();
   if (existsSync(ID_CACHE_FILE)) writeFileSync(ID_CACHE_FILE, "{}");
   if (existsSync(CONTEXT_CACHE_FILE)) writeFileSync(CONTEXT_CACHE_FILE, "{}");
+  if (existsSync(MESSAGE_QUEUE_FILE)) writeFileSync(MESSAGE_QUEUE_FILE, "");
   if (existsSync(GIT_STATE_FILE)) writeFileSync(GIT_STATE_FILE, "{}");
   // Don't clear claude-context.md - that's valuable history
 }

--- a/plugins/honcho/src/config.ts
+++ b/plugins/honcho/src/config.ts
@@ -698,7 +698,7 @@ export function getHonchoClientOptions(config: HonchoCLAUDEConfig): HonchoClient
     baseURL: getHonchoBaseUrl(config),
     workspaceId: config.workspace,
     timeout: 8000,
-    maxRetries: 0,
+    maxRetries: 1,
   };
 }
 

--- a/plugins/honcho/src/hooks/session-end.ts
+++ b/plugins/honcho/src/hooks/session-end.ts
@@ -2,6 +2,8 @@ import { Honcho } from "@honcho-ai/sdk";
 import { loadConfig, getSessionName, getHonchoClientOptions, isPluginEnabled, getCachedStdin } from "../config.js";
 import { existsSync, readFileSync } from "fs";
 import {
+  getQueuedMessages,
+  markMessagesUploaded,
   generateClaudeSummary,
   saveClaudeLocalContext,
   loadClaudeLocalContext,
@@ -239,12 +241,28 @@ export async function handleSessionEnd(): Promise<void> {
   try {
     const honcho = new Honcho(getHonchoClientOptions(config));
 
-    const [session, aiPeer] = await Promise.all([
+    const [session, userPeer, aiPeer] = await Promise.all([
       honcho.session(sessionName),
+      honcho.peer(config.peerName),
       honcho.peer(config.aiPeer),
     ]);
 
-    logHook("session-end", `Processing ${assistantMessages.length} assistant msgs`);
+    // Build all upload batches before sending
+    const queuedMessages = getQueuedMessages(cwd);
+    logHook("session-end", `Processing ${queuedMessages.length} queued + ${assistantMessages.length} assistant msgs`);
+
+    const userMessages = queuedMessages.flatMap((msg) => {
+      const chunks = chunkContent(msg.content);
+      return chunks.map(chunk =>
+        userPeer.message(chunk, {
+          createdAt: msg.timestamp,
+          metadata: {
+            instance_id: msg.instanceId || undefined,
+            session_affinity: sessionName,
+          },
+        })
+      );
+    });
 
     const aiMessages = (config.saveMessages !== false && assistantMessages.length > 0)
       ? assistantMessages.flatMap((msg) => {
@@ -275,12 +293,12 @@ export async function handleSessionEnd(): Promise<void> {
     );
 
     // Single addMessages call with everything — one round trip instead of three.
-    const allMessages = [...aiMessages, endMarker];
+    const allMessages = [...userMessages, ...aiMessages, endMarker];
 
     if (allMessages.length > 0) {
       const meaningfulCount = assistantMessages.filter(m => m.isMeaningful).length;
       logApiCall("session.addMessages", "POST",
-        `${aiMessages.length} assistant (${meaningfulCount} meaningful) + 1 marker`);
+        `${userMessages.length} user + ${aiMessages.length} assistant (${meaningfulCount} meaningful) + 1 marker`);
 
       // Start API upload immediately; run animation concurrently.
       const uploadPromise = session.addMessages(allMessages);
@@ -315,19 +333,24 @@ export async function handleSessionEnd(): Promise<void> {
       }, 12_000);
       hardTimeout.unref();
 
+      let uploadSucceeded = false;
       await Promise.all([
-        uploadPromise.finally(() => {
+        uploadPromise.then(() => { uploadSucceeded = true; }).finally(() => {
           clearTimeout(hardTimeout);
           removeSigHandlers();
         }),
         playCooldown("saving memory"),
       ]);
+
+      if (uploadSucceeded && queuedMessages.length > 0) {
+        markMessagesUploaded(cwd);
+      }
     } else {
       await playCooldown("saving memory");
     }
 
     const meaningfulCount = assistantMessages.filter(m => m.isMeaningful).length;
-    logHook("session-end", `Session saved: ${assistantMessages.length} assistant msgs (${meaningfulCount} meaningful)`);
+    logHook("session-end", `Session saved: ${assistantMessages.length} assistant msgs (${meaningfulCount} meaningful), ${queuedMessages.length} queued msgs`);
     process.exit(0);
   } catch (error) {
     logHook("session-end", `Error: ${error}`, { error: String(error) });

--- a/plugins/honcho/src/hooks/user-prompt.ts
+++ b/plugins/honcho/src/hooks/user-prompt.ts
@@ -12,7 +12,7 @@ import {
   shouldRefreshKnowledgeGraph,
   markKnowledgeGraphRefreshed,
   getInstanceIdForCwd,
-  chunkContent,
+  queueMessage,
 } from "../cache.js";
 import { logHook, logApiCall, logCache, setLogContext } from "../log.js";
 import { visContextLine, visSkipMessage, addSystemMessage, verboseApiResult, verboseList } from "../visual.js";
@@ -130,30 +130,9 @@ export async function handleUserPrompt(): Promise<void> {
 
   logHook("user-prompt", `Prompt received (${prompt.length} chars)`);
 
-  const honcho = new Honcho(getHonchoClientOptions(config));
-
-  // Best-effort upload. Wrap the entire SDK interaction so a transient
-  // rejection during session/peer setup can't abort context retrieval below.
+  // Queue user prompt for upload at session-end (instant, no network)
   if (config.saveMessages !== false) {
-    try {
-      const [session, userPeer] = await Promise.all([
-        honcho.session(sessionName),
-        honcho.peer(config.peerName),
-      ]);
-      const chunks = chunkContent(prompt);
-      const messages = chunks.map((chunk) =>
-        userPeer.message(chunk, {
-          metadata: {
-            instance_id: instanceId || undefined,
-            session_affinity: sessionName,
-          },
-        })
-      );
-      logApiCall("session.addMessages", "POST", `user prompt (${prompt.length} chars)`);
-      await session.addMessages(messages);
-    } catch (e) {
-      logHook("user-prompt", `Upload failed: ${e}`);
-    }
+    queueMessage(prompt, config.peerName, cwd, instanceId || undefined);
   }
 
   // Track message count for threshold-based refresh
@@ -198,7 +177,7 @@ export async function handleUserPrompt(): Promise<void> {
   logCache("miss", "userContext", forceRefresh ? "threshold refresh" : "stale cache");
 
   const fetchResult = await Promise.race([
-    fetchFreshContext(config, prompt, honcho).then(r => ({ ok: true as const, ...r })),
+    fetchFreshContext(config, prompt).then(r => ({ ok: true as const, ...r })),
     new Promise<{ ok: false }>(resolve => setTimeout(() => resolve({ ok: false }), FETCH_TIMEOUT_MS)),
   ]).catch((): { ok: false } => ({ ok: false }));
 
@@ -240,7 +219,8 @@ function serveContext(
   outputContext(peerName, contextParts, sessionLink ? `${sessionLink}\n${visMsg}` : visMsg);
 }
 
-async function fetchFreshContext(config: any, prompt: string, honcho: Honcho): Promise<{ context: any }> {
+async function fetchFreshContext(config: any, prompt: string): Promise<{ context: any }> {
+  const honcho = new Honcho(getHonchoClientOptions(config));
   const observationMode = getObservationMode(config);
 
   // unified: user self-observations — query via userPeer (no target).


### PR DESCRIPTION
Reverts #42.

The real-time write path from #42 isn't actually viable yet — it's still blocked on something on the Honcho side before message uploads can be made async/real-time. Until that's unblocked, this restores the previous queue-and-flush behavior

## What this restores
- `cache.ts` — `queueMessage()` / `~/.honcho/message-queue.jsonl` queue logic
- `user-prompt.ts` — user prompts are queued for the `SessionEnd` flush again instead of written in real time on `UserPromptSubmit`
- `session-end.ts`, `config.ts` — queue-flush behavior

## Preserved (not reverted)
- The version-update nag from #48 (`4689ad7`) is untouched — `user-prompt.ts` auto-merged cleanly and the `CHANGELOG.md` "Added" entry for it is kept.

`bunx tsc --noEmit` passes clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added local message queuing to persist user prompts for reliable delivery at session end.

* **Bug Fixes**
  * Improved API request retry behavior for better reliability.

* **Changed**
  * User prompts are now queued locally and uploaded with session data instead of immediate upload, reducing network overhead.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->