### PR TITLE
Reapply: real-time message writes to Honcho (re-land #42)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ All notable changes to claude-honcho will be documented in this file.
 
 - Version-update nag: warns on first prompt when the installed plugin is behind the published version (checks for updates at most once a day; silent on failure).
 
+### Changed
+
+- User prompts are now written to Honcho in real time on `UserPromptSubmit` instead of being queued for `SessionEnd` flush. Mirrors the existing fire-and-forget pattern used by `PostToolUse` and `Stop`.
+
+### Fixed
+
+- Eliminated a duplication bug where repeated `SessionEnd` failures (12s timeout, double-fire) caused queued prompts to be re-uploaded indefinitely.
+
+### Removed
+
+- The local `~/.honcho/message-queue.jsonl` queue file is no longer used and can be deleted from user machines to reclaim disk. The plugin will not auto-delete it.
+
 ## [0.2.4] - 2026-04-01
 
 ### Added

--- a/plugins/honcho/src/cache.ts
+++ b/plugins/honcho/src/cache.ts
@@ -1,12 +1,11 @@
 import { homedir } from "os";
 import { join } from "path";
-import { existsSync, readFileSync, writeFileSync, appendFileSync, mkdirSync } from "fs";
+import { existsSync, readFileSync, writeFileSync, mkdirSync } from "fs";
 import { getContextRefreshConfig, getLocalContextConfig } from "./config.js";
 
 const CACHE_DIR = join(homedir(), ".honcho");
 const ID_CACHE_FILE = join(CACHE_DIR, "cache.json");
 const CONTEXT_CACHE_FILE = join(CACHE_DIR, "context-cache.json");
-const MESSAGE_QUEUE_FILE = join(CACHE_DIR, "message-queue.jsonl");
 const CLAUDE_CONTEXT_FILE = join(CACHE_DIR, "claude-context.md");
 
 // Ensure cache directory exists
@@ -243,82 +242,6 @@ export function resetMessageCount(): void {
   cache.messageCount = 0;
   cache.lastRefreshMessageCount = 0;
   saveContextCache(cache);
-}
-
-// ============================================
-// Message Queue - local file for reliability
-// ============================================
-
-interface QueuedMessage {
-  content: string;
-  peerId: string;
-  cwd: string;
-  timestamp: string;
-  uploaded?: boolean;
-  instanceId?: string; // Claude Code instance for parallel session support
-}
-
-export function queueMessage(content: string, peerId: string, cwd: string, instanceId?: string): void {
-  ensureCacheDir();
-  const message: QueuedMessage = {
-    content,
-    peerId,
-    cwd,
-    timestamp: new Date().toISOString(),
-    uploaded: false,
-    instanceId: instanceId || getClaudeInstanceId() || undefined,
-  };
-  appendFileSync(MESSAGE_QUEUE_FILE, JSON.stringify(message) + "\n");
-}
-
-export function getQueuedMessages(forCwd?: string): QueuedMessage[] {
-  ensureCacheDir();
-  if (!existsSync(MESSAGE_QUEUE_FILE)) {
-    return [];
-  }
-  try {
-    const content = readFileSync(MESSAGE_QUEUE_FILE, "utf-8");
-    const lines = content.split("\n").filter((line) => line.trim());
-    const messages = lines.map((line) => JSON.parse(line)).filter((msg) => !msg.uploaded);
-    // Filter by cwd if specified
-    if (forCwd) {
-      return messages.filter((msg) => msg.cwd === forCwd);
-    }
-    return messages;
-  } catch {
-    return [];
-  }
-}
-
-export function clearMessageQueue(): void {
-  ensureCacheDir();
-  writeFileSync(MESSAGE_QUEUE_FILE, "");
-}
-
-export function markMessagesUploaded(forCwd?: string): void {
-  if (!forCwd) {
-    // Clear all
-    clearMessageQueue();
-    return;
-  }
-  // Only remove messages for the specified cwd, keep others
-  ensureCacheDir();
-  if (!existsSync(MESSAGE_QUEUE_FILE)) return;
-  try {
-    const content = readFileSync(MESSAGE_QUEUE_FILE, "utf-8");
-    const lines = content.split("\n").filter((line) => line.trim());
-    const remaining = lines.filter((line) => {
-      try {
-        const msg = JSON.parse(line);
-        return msg.cwd !== forCwd;
-      } catch {
-        return false;
-      }
-    });
-    writeFileSync(MESSAGE_QUEUE_FILE, remaining.join("\n") + (remaining.length ? "\n" : ""));
-  } catch {
-    // ignore
-  }
 }
 
 // ============================================
@@ -571,7 +494,6 @@ export function clearAllCaches(): void {
   ensureCacheDir();
   if (existsSync(ID_CACHE_FILE)) writeFileSync(ID_CACHE_FILE, "{}");
   if (existsSync(CONTEXT_CACHE_FILE)) writeFileSync(CONTEXT_CACHE_FILE, "{}");
-  if (existsSync(MESSAGE_QUEUE_FILE)) writeFileSync(MESSAGE_QUEUE_FILE, "");
   if (existsSync(GIT_STATE_FILE)) writeFileSync(GIT_STATE_FILE, "{}");
   // Don't clear claude-context.md - that's valuable history
 }

--- a/plugins/honcho/src/config.ts
+++ b/plugins/honcho/src/config.ts
@@ -698,7 +698,7 @@ export function getHonchoClientOptions(config: HonchoCLAUDEConfig): HonchoClient
     baseURL: getHonchoBaseUrl(config),
     workspaceId: config.workspace,
     timeout: 8000,
-    maxRetries: 1,
+    maxRetries: 0,
   };
 }
 

--- a/plugins/honcho/src/hooks/session-end.ts
+++ b/plugins/honcho/src/hooks/session-end.ts
@@ -2,8 +2,6 @@ import { Honcho } from "@honcho-ai/sdk";
 import { loadConfig, getSessionName, getHonchoClientOptions, isPluginEnabled, getCachedStdin } from "../config.js";
 import { existsSync, readFileSync } from "fs";
 import {
-  getQueuedMessages,
-  markMessagesUploaded,
   generateClaudeSummary,
   saveClaudeLocalContext,
   loadClaudeLocalContext,
@@ -241,28 +239,12 @@ export async function handleSessionEnd(): Promise<void> {
   try {
     const honcho = new Honcho(getHonchoClientOptions(config));
 
-    const [session, userPeer, aiPeer] = await Promise.all([
+    const [session, aiPeer] = await Promise.all([
       honcho.session(sessionName),
-      honcho.peer(config.peerName),
       honcho.peer(config.aiPeer),
     ]);
 
-    // Build all upload batches before sending
-    const queuedMessages = getQueuedMessages(cwd);
-    logHook("session-end", `Processing ${queuedMessages.length} queued + ${assistantMessages.length} assistant msgs`);
-
-    const userMessages = queuedMessages.flatMap((msg) => {
-      const chunks = chunkContent(msg.content);
-      return chunks.map(chunk =>
-        userPeer.message(chunk, {
-          createdAt: msg.timestamp,
-          metadata: {
-            instance_id: msg.instanceId || undefined,
-            session_affinity: sessionName,
-          },
-        })
-      );
-    });
+    logHook("session-end", `Processing ${assistantMessages.length} assistant msgs`);
 
     const aiMessages = (config.saveMessages !== false && assistantMessages.length > 0)
       ? assistantMessages.flatMap((msg) => {
@@ -293,12 +275,12 @@ export async function handleSessionEnd(): Promise<void> {
     );
 
     // Single addMessages call with everything — one round trip instead of three.
-    const allMessages = [...userMessages, ...aiMessages, endMarker];
+    const allMessages = [...aiMessages, endMarker];
 
     if (allMessages.length > 0) {
       const meaningfulCount = assistantMessages.filter(m => m.isMeaningful).length;
       logApiCall("session.addMessages", "POST",
-        `${userMessages.length} user + ${aiMessages.length} assistant (${meaningfulCount} meaningful) + 1 marker`);
+        `${aiMessages.length} assistant (${meaningfulCount} meaningful) + 1 marker`);
 
       // Start API upload immediately; run animation concurrently.
       const uploadPromise = session.addMessages(allMessages);
@@ -333,24 +315,19 @@ export async function handleSessionEnd(): Promise<void> {
       }, 12_000);
       hardTimeout.unref();
 
-      let uploadSucceeded = false;
       await Promise.all([
-        uploadPromise.then(() => { uploadSucceeded = true; }).finally(() => {
+        uploadPromise.finally(() => {
           clearTimeout(hardTimeout);
           removeSigHandlers();
         }),
         playCooldown("saving memory"),
       ]);
-
-      if (uploadSucceeded && queuedMessages.length > 0) {
-        markMessagesUploaded(cwd);
-      }
     } else {
       await playCooldown("saving memory");
     }
 
     const meaningfulCount = assistantMessages.filter(m => m.isMeaningful).length;
-    logHook("session-end", `Session saved: ${assistantMessages.length} assistant msgs (${meaningfulCount} meaningful), ${queuedMessages.length} queued msgs`);
+    logHook("session-end", `Session saved: ${assistantMessages.length} assistant msgs (${meaningfulCount} meaningful)`);
     process.exit(0);
   } catch (error) {
     logHook("session-end", `Error: ${error}`, { error: String(error) });

--- a/plugins/honcho/src/hooks/user-prompt.ts
+++ b/plugins/honcho/src/hooks/user-prompt.ts
@@ -12,7 +12,7 @@ import {
   shouldRefreshKnowledgeGraph,
   markKnowledgeGraphRefreshed,
   getInstanceIdForCwd,
-  queueMessage,
+  chunkContent,
 } from "../cache.js";
 import { logHook, logApiCall, logCache, setLogContext } from "../log.js";
 import { visContextLine, visSkipMessage, addSystemMessage, verboseApiResult, verboseList } from "../visual.js";
@@ -130,9 +130,30 @@ export async function handleUserPrompt(): Promise<void> {
 
   logHook("user-prompt", `Prompt received (${prompt.length} chars)`);
 
-  // Queue user prompt for upload at session-end (instant, no network)
+  const honcho = new Honcho(getHonchoClientOptions(config));
+
+  // Best-effort upload. Wrap the entire SDK interaction so a transient
+  // rejection during session/peer setup can't abort context retrieval below.
   if (config.saveMessages !== false) {
-    queueMessage(prompt, config.peerName, cwd, instanceId || undefined);
+    try {
+      const [session, userPeer] = await Promise.all([
+        honcho.session(sessionName),
+        honcho.peer(config.peerName),
+      ]);
+      const chunks = chunkContent(prompt);
+      const messages = chunks.map((chunk) =>
+        userPeer.message(chunk, {
+          metadata: {
+            instance_id: instanceId || undefined,
+            session_affinity: sessionName,
+          },
+        })
+      );
+      logApiCall("session.addMessages", "POST", `user prompt (${prompt.length} chars)`);
+      await session.addMessages(messages);
+    } catch (e) {
+      logHook("user-prompt", `Upload failed: ${e}`);
+    }
   }
 
   // Track message count for threshold-based refresh
@@ -177,7 +198,7 @@ export async function handleUserPrompt(): Promise<void> {
   logCache("miss", "userContext", forceRefresh ? "threshold refresh" : "stale cache");
 
   const fetchResult = await Promise.race([
-    fetchFreshContext(config, prompt).then(r => ({ ok: true as const, ...r })),
+    fetchFreshContext(config, prompt, honcho).then(r => ({ ok: true as const, ...r })),
     new Promise<{ ok: false }>(resolve => setTimeout(() => resolve({ ok: false }), FETCH_TIMEOUT_MS)),
   ]).catch((): { ok: false } => ({ ok: false }));
 
@@ -219,8 +240,7 @@ function serveContext(
   outputContext(peerName, contextParts, sessionLink ? `${sessionLink}\n${visMsg}` : visMsg);
 }
 
-async function fetchFreshContext(config: any, prompt: string): Promise<{ context: any }> {
-  const honcho = new Honcho(getHonchoClientOptions(config));
+async function fetchFreshContext(config: any, prompt: string, honcho: Honcho): Promise<{ context: any }> {
   const observationMode = getObservationMode(config);
 
   // unified: user self-observations — query via userPeer (no target).


### PR DESCRIPTION
Re-applies the changes from #42, which were reverted in #53.

#42 made user prompts write to Honcho in real time on `UserPromptSubmit` (instead of queuing for the `SessionEnd` flush), and removed the local `~/.honcho/message-queue.jsonl` queue. That was reverted in #53 because the real-time path is still blocked on something on the Honcho side.

This PR holds those changes so we can re-land them the moment that's unblocked — **do not merge until the Honcho-side blocker is resolved.**

## Merge order
1. Merge #53 first (the revert).
2. Then merge this. Its base is the `revert-42-realtime-writes` branch; once #53 merges and that branch is deleted, GitHub will auto-retarget this PR's base to `main`.

## Contents
- `cache.ts` — removes the `queueMessage()` / queue-file logic
- `user-prompt.ts` — writes prompts to Honcho in real time (version-nag from #48 preserved)
- `session-end.ts`, `config.ts` — drop the queue-flush path
- Wraps the full SDK interaction in try/catch in the user-prompt hook (per CodeRabbit review on #42)

`bunx tsc --noEmit` passes clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)