### PR TITLE
fix(user-prompt): inject prompt-matched conclusions instead of stalest representation lines

### DIFF
--- a/plugins/honcho/src/hooks/user-prompt.test.ts
+++ b/plugins/honcho/src/hooks/user-prompt.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, test } from "bun:test";
+import { extractTopics, formatCachedContext, stripConclusionLine } from "./user-prompt";
+
+function conclusions(parts: string[]): string[] {
+  const block = parts.find((p) => p.startsWith("Relevant conclusions: "));
+  if (!block) return [];
+  return block.replace("Relevant conclusions: ", "").split("; ");
+}
+
+describe("stripConclusionLine", () => {
+  test("strips leading [timestamp] prefix", () => {
+    expect(stripConclusionLine("[2026-06-10 16:38:50] user likes coffee")).toBe("user likes coffee");
+  });
+
+  test("strips leading bullet", () => {
+    expect(stripConclusionLine("- user likes coffee")).toBe("user likes coffee");
+  });
+
+  test("trims whitespace and leaves plain lines untouched", () => {
+    expect(stripConclusionLine("  user likes coffee  ")).toBe("user likes coffee");
+  });
+});
+
+describe("extractTopics", () => {
+  test("extracts technical terms", () => {
+    expect(extractTopics("how do I configure kubernetes and redis?")).toEqual(["kubernetes", "redis"]);
+  });
+
+  test("extracts file paths", () => {
+    expect(extractTopics("look at src/hooks/user-prompt.ts please")).toContain("src/hooks/user-prompt.ts");
+  });
+
+  test("extracts quoted strings", () => {
+    expect(extractTopics('what about the "billing service"?')).toContain("billing service");
+  });
+
+  test("returns empty for prompts with no high-signal topics (callers fall back to the raw prompt)", () => {
+    // Regression: the old stopword fallback was English-only and turned
+    // non-English prompts into low-signal word salad.
+    expect(extractTopics("come siamo messi ora con il lavoro?")).toEqual([]);
+    expect(extractTopics("what should we do next?")).toEqual([]);
+  });
+});
+
+describe("formatCachedContext", () => {
+  const rep = [
+    "# Header is filtered",
+    "[2026-01-01 10:00:00] oldest fact",
+    "[2026-03-01 10:00:00] middle fact",
+    "[2026-06-01 10:00:00] newest fact",
+  ].join("\n");
+
+  test("puts search-matched conclusions first", () => {
+    const ctx = { representation: rep, searchMatched: ["matched one", "matched two"] };
+    const { parts } = formatCachedContext(ctx, "peer");
+    expect(conclusions(parts).slice(0, 2)).toEqual(["matched one", "matched two"]);
+  });
+
+  test("fills remaining slots with newest representation lines, not oldest", () => {
+    // Regression for the core bug: the representation is ordered
+    // oldest-first and the hook used to inject its head.
+    const ctx = { representation: rep };
+    const { parts } = formatCachedContext(ctx, "peer");
+    expect(conclusions(parts)).toEqual(["newest fact", "middle fact", "oldest fact"]);
+  });
+
+  test("dedupes search matches against representation lines (normalized)", () => {
+    const ctx = { representation: rep, searchMatched: ["Newest FACT"] };
+    const { parts, conclusionCount } = formatCachedContext(ctx, "peer");
+    expect(conclusions(parts)).toEqual(["Newest FACT", "middle fact", "oldest fact"]);
+    expect(conclusionCount).toBe(3);
+  });
+
+  test("caps the selection at 5", () => {
+    const many = Array.from({ length: 8 }, (_, i) => `[2026-01-0${i + 1} 10:00:00] fact ${i + 1}`).join("\n");
+    const ctx = { representation: many, searchMatched: ["m1", "m2"] };
+    const { parts, conclusionCount } = formatCachedContext(ctx, "peer");
+    expect(conclusionCount).toBe(5);
+    expect(conclusions(parts)).toEqual(["m1", "m2", "fact 8", "fact 7", "fact 6"]);
+  });
+
+  test("preserves original order for lines without timestamps", () => {
+    const ctx = { representation: "first line\nsecond line\nthird line" };
+    const { parts } = formatCachedContext(ctx, "peer");
+    expect(conclusions(parts)).toEqual(["first line", "second line", "third line"]);
+  });
+
+  test("works with search matches only (no representation)", () => {
+    const ctx = { searchMatched: ["only match"] };
+    const { parts } = formatCachedContext(ctx, "peer");
+    expect(conclusions(parts)).toEqual(["only match"]);
+  });
+
+  test("returns no conclusion part when there is nothing to inject", () => {
+    const { parts, conclusionCount } = formatCachedContext({ representation: "" }, "peer");
+    expect(parts.filter((p) => p.startsWith("Relevant conclusions"))).toHaveLength(0);
+    expect(conclusionCount).toBe(0);
+  });
+
+  test("appends peer card as Profile", () => {
+    const ctx = { representation: rep, peerCard: ["name: avigano", "role: advisor"] };
+    const { parts } = formatCachedContext(ctx, "peer");
+    expect(parts.at(-1)).toBe("Profile: name: avigano; role: advisor");
+  });
+
+  test("survives a JSON cache round-trip (searchMatched is a plain property)", () => {
+    const ctx = JSON.parse(JSON.stringify({ representation: rep, searchMatched: ["matched one"] }));
+    const { parts } = formatCachedContext(ctx, "peer");
+    expect(conclusions(parts)[0]).toBe("matched one");
+  });
+});

--- a/plugins/honcho/src/hooks/user-prompt.ts
+++ b/plugins/honcho/src/hooks/user-prompt.ts
@@ -38,7 +38,7 @@ const FETCH_TIMEOUT_MS = 4000;
  * Extract meaningful topics from a prompt for semantic search.
  * Returns terms that are high-signal for conclusion matching.
  */
-function extractTopics(prompt: string): string[] {
+export function extractTopics(prompt: string): string[] {
   const topics: string[] = [];
 
   // File paths (high signal)
@@ -299,11 +299,11 @@ async function fetchFreshContext(config: any, prompt: string): Promise<{ context
   return { context: contextResult };
 }
 
-function stripConclusionLine(line: string): string {
+export function stripConclusionLine(line: string): string {
   return line.replace(/^\[.*?\]\s*/, "").replace(/^- /, "").trim();
 }
 
-function formatCachedContext(context: any, peerName: string): { parts: string[]; conclusionCount: number } {
+export function formatCachedContext(context: any, peerName: string): { parts: string[]; conclusionCount: number } {
   const parts: string[] = [];
   let conclusionCount = 0;
   const rep = context?.representation;

--- a/plugins/honcho/src/hooks/user-prompt.ts
+++ b/plugins/honcho/src/hooks/user-prompt.ts
@@ -57,14 +57,10 @@ function extractTopics(prompt: string): string[] {
   const errors = prompt.match(/error[:\s]+[\w\s]+|failed[:\s]+[\w\s]+|exception[:\s]+[\w\s]+/gi) || [];
   topics.push(...errors.slice(0, 2));
 
-  if (topics.length > 0) {
-    return [...new Set(topics)];
-  }
-
-  // Fallback: meaningful words >3 chars minus stopwords
-  const stopwords = new Set(['the', 'and', 'for', 'that', 'this', 'with', 'from', 'have', 'are', 'was', 'were', 'been', 'being', 'has', 'had', 'does', 'did', 'will', 'would', 'could', 'should', 'can', 'may', 'might', 'must', 'shall', 'need', 'want', 'like', 'just', 'also', 'more', 'some', 'what', 'when', 'where', 'which', 'who', 'how', 'why', 'all', 'each', 'every', 'both', 'few', 'most', 'other', 'into', 'over', 'such', 'only', 'same', 'than', 'very', 'your', 'make', 'take', 'come', 'give', 'look', 'think', 'know']);
-  const words = prompt.toLowerCase().match(/\b[a-z]{4,}\b/g) || [];
-  return [...new Set(words.filter(w => !stopwords.has(w)))].slice(0, 10);
+  // No keyword fallback: extracted word lists are English-only and produce
+  // low-signal queries for other languages. Callers fall back to the raw
+  // prompt, which embeds better for semantic search anyway.
+  return [...new Set(topics)];
 }
 
 function shouldSkipContextRetrieval(prompt: string): boolean {
@@ -246,22 +242,37 @@ async function fetchFreshContext(config: any, prompt: string): Promise<{ context
 
   const startTime = Date.now();
 
-  // Try search-based context first — returns conclusions relevant to the prompt
+  // Try search-based context first — returns conclusions relevant to the prompt.
+  // Fall back to the raw prompt (truncated) when no high-signal topics match:
+  // natural text embeds well, and it keeps non-English prompts working.
   const topics = extractTopics(prompt);
-  const searchQuery = topics.length > 0 ? topics.join(" ") : undefined;
+  const searchQuery = topics.length > 0 ? topics.join(" ") : prompt.trim().slice(0, 300);
 
   let contextResult: any = null;
 
   if (searchQuery) {
     try {
-      contextResult = await contextPeer.context({
-        ...(contextTarget ? { target: contextTarget } : {}),
-        searchQuery,
-        searchTopK: 5,
-        searchMaxDistance: 0.7,
-        maxConclusions: 15,
-        includeMostFrequent: true,
-      });
+      // The representation merges search hits with frequent/recent conclusions
+      // into one timestamp-ordered string, so prompt-relevant lines get lost.
+      // Query matched conclusions separately and let the formatter put them first.
+      const conclusionScope = contextTarget
+        ? contextPeer.conclusionsOf(contextTarget)
+        : contextPeer.conclusions;
+      const [ctx, matched] = await Promise.all([
+        contextPeer.context({
+          ...(contextTarget ? { target: contextTarget } : {}),
+          searchQuery,
+          searchTopK: 5,
+          searchMaxDistance: 0.7,
+          maxConclusions: 15,
+          includeMostFrequent: true,
+        }),
+        conclusionScope.query(searchQuery, 5).catch((): any[] => []),
+      ]);
+      contextResult = ctx;
+      if (contextResult && matched?.length) {
+        contextResult.searchMatched = matched.map((c: any) => c.content).filter(Boolean);
+      }
       logApiCall(contextLabel, "GET", `search: ${searchQuery.slice(0, 60)}`, Date.now() - startTime, true);
     } catch (e) {
       // Search failed — fall through to static context
@@ -288,17 +299,42 @@ async function fetchFreshContext(config: any, prompt: string): Promise<{ context
   return { context: contextResult };
 }
 
+function stripConclusionLine(line: string): string {
+  return line.replace(/^\[.*?\]\s*/, "").replace(/^- /, "").trim();
+}
+
 function formatCachedContext(context: any, peerName: string): { parts: string[]; conclusionCount: number } {
   const parts: string[] = [];
   let conclusionCount = 0;
   const rep = context?.representation;
 
+  // Prompt-matched conclusions first (semantic search), then the most recent
+  // representation lines to fill up to 5 slots. The representation is ordered
+  // oldest-first, so taking its head would inject the stalest facts.
+  const seen = new Set<string>();
+  const selected: string[] = [];
+  const push = (text: string) => {
+    const clean = stripConclusionLine(text);
+    const key = clean.toLowerCase();
+    if (clean && !seen.has(key) && selected.length < 5) {
+      seen.add(key);
+      selected.push(clean);
+    }
+  };
+
+  for (const c of context?.searchMatched ?? []) push(String(c));
+
   if (typeof rep === "string" && rep.trim()) {
     const lines = rep.split("\n").filter((l: string) => l.trim() && !l.startsWith("#"));
-    const selected = lines.slice(0, 5);
+    // Sort newest-first when lines carry a leading [timestamp]; otherwise keep order.
+    const stamped = lines.map((l: string, i: number) => ({ l, t: l.match(/^\[([^\]]+)\]/)?.[1] ?? "", i }));
+    stamped.sort((a, b) => (b.t.localeCompare(a.t)) || (a.i - b.i));
+    for (const { l } of stamped) push(l);
+  }
+
+  if (selected.length > 0) {
     conclusionCount = selected.length;
-    const summary = selected.map((l: string) => l.replace(/^\[.*?\]\s*/, "").replace(/^- /, "")).join("; ");
-    if (summary) parts.push(`Relevant conclusions: ${summary}`);
+    parts.push(`Relevant conclusions: ${selected.join("; ")}`);
   }
 
   const peerCard = context?.peerCard;


### PR DESCRIPTION
## Problem

The `UserPromptSubmit` hook runs a semantic search over the user's prompt (`peer.context({ searchQuery, ... })`), but then `formatCachedContext()` injects **the first 5 lines of the representation string**. The representation merges search hits with frequent/recent conclusions into a single timestamp-**ascending** list, so the injected lines are always the *oldest* conclusions in the window — the search results never surface.

Measured on a live workspace (358 conclusions): with and without `searchQuery`, **4 of 5 injected lines were identical** and unrelated to the prompt. In practice every turn re-injects the same stale facts regardless of what the user asks — closely related to the repetition reported in #39 (`includeMostFrequent` pinning is only half the story; head-of-representation selection is the other half).

A second, compounding issue: `extractTopics()` falls back to an English-stopword word filter, so non-English prompts produce low-signal queries ("come siamo messi" → word salad).

## Fix

- Query matched conclusions explicitly (`conclusionScope.query(searchQuery, 5)`) in parallel with `peer.context()` and put them **first** in the injected block (cached alongside the context, so cache-served turns keep them too)
- Fill the remaining slots with the **newest** representation lines (timestamp-desc when lines carry a `[timestamp]` prefix) instead of the oldest, deduped by normalized text
- Drop the English-only stopword fallback; fall back to the raw prompt (truncated to 300 chars), which embeds better for semantic search and keeps non-English prompts working

No new API surface: `conclusionScope.query` already exists in the SDK; failures degrade gracefully to the previous behavior (`.catch(() => [])`).

## Before / after (live workspace, same prompts)

Prompt (Italian): *"come va il deriver di honcho su kubernetes? flux ha applicato la modifica ai worker?"*

Before — 5 conclusions about an unrelated design discussion from a previous day, identical to what every other prompt received.

After — all 5 conclusions about the user's Kubernetes/k3s work from the same day.

Prompt (English): *"help me create the new jira tickets for the REORG board"* → after: all 5 conclusions about the user's recent Jira board work.

## Test plan

- [x] `tsc --noEmit` clean
- [x] Deterministic unit tests: `bun test` — 16 cases covering search-matched-first ordering, newest-not-oldest fill (regression for the head-of-representation bug), normalized dedup, the 5-slot cap, and the empty-topics return that drives the raw-prompt fallback (`src/hooks/user-prompt.test.ts`)
- [x] Fresh-fetch path: hook invoked with stdin payload, context cache cleared — injected conclusions match prompt topic (English and Italian prompts)
- [x] Search-failure path: `conclusionScope.query` rejection falls back to representation-only selection
- [x] Cache-served path: `searchMatched` survives the context cache round-trip (plain JSON property)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Enhanced search query generation for more consistent results
  * Optimized context retrieval through concurrent processing for improved performance
  * Refined prioritization of search-matched conclusions in context display
  * Improved chronological ordering of context information for better relevance

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
