### PR TITLE
feat(config): make dashboard URL configurable for self-hosted deployments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to claude-honcho will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- Configurable dashboard URL for session links. Self-hosted deployments can now point the clickable "view your session" links at their own GUI instead of the hardcoded `app.honcho.dev`. Set it via the `endpoint.dashboardUrl` config field, the `set_config` MCP tool, or the `HONCHO_DASHBOARD_URL` env var (which takes precedence). Defaults to `https://app.honcho.dev`, so hosted users are unaffected. Useful when the GUI runs on a different host than the API (e.g. API at `honcho.example.com`, dashboard at `dashboard.example.com`).
+
 ## [0.2.5] - 2026-06-02
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -236,8 +236,10 @@ All configuration lives in a single global file at `~/.honcho/config.json`. You 
 
   // Endpoint
   "endpoint": {
-    "environment": "production"       // "production" | "local"
+    "environment": "production",      // "production" | "local"
     // or: "baseUrl": "http://your-server:8000/v3"
+    // Self-hosted GUI on a different host than the API? Point session links at it:
+    "dashboardUrl": "https://dashboard.your-server.com"
   },
 
   // Miscellaneous
@@ -421,6 +423,7 @@ Environment variables work for initial bootstrap (before a config file exists). 
 | `HONCHO_AI_PEER`       | No       | `claude`      | AI peer name                                                      |
 | `HONCHO_HOST`          | No       | auto-detected | Force host detection: `claude_code`, `cursor`, or `obsidian`      |
 | `HONCHO_ENDPOINT`      | No       | `production`  | `production`, `local`, or a full URL                              |
+| `HONCHO_DASHBOARD_URL` | No       | `https://app.honcho.dev` | GUI base URL for session links (for self-hosted dashboards) |
 | `HONCHO_ENABLED`       | No       | `true`        | Set to `false` to disable                                         |
 | `HONCHO_SAVE_MESSAGES` | No       | `true`        | Set to `false` to stop saving messages                            |
 | `HONCHO_LOGGING`       | No       | `true`        | Set to `false` to disable file logging to `~/.honcho/`            |
@@ -496,6 +499,16 @@ Or via env var:
 export HONCHO_ENDPOINT="local"  # Uses localhost:8000
 # or
 export HONCHO_ENDPOINT="http://your-server:8000/v3"
+```
+
+Session links printed by the plugin point at `https://app.honcho.dev` by default.
+If you self-host the dashboard (often on a different host than the API), point the
+links at your own GUI:
+```json
+{ "endpoint": { "baseUrl": "https://honcho.your-server.com/v3", "dashboardUrl": "https://dashboard.your-server.com" } }
+```
+```bash
+export HONCHO_DASHBOARD_URL="https://dashboard.your-server.com"
 ```
 
 ### Temporarily disabling memory

--- a/plugins/honcho/src/config.ts
+++ b/plugins/honcho/src/config.ts
@@ -44,12 +44,22 @@ export interface HonchoEndpointConfig {
   environment?: HonchoEnvironment;
   /** Custom URL override (takes precedence over environment) */
   baseUrl?: string;
+  /**
+   * Dashboard (GUI) base URL used to build clickable session links.
+   * Self-hosted deployments often serve the GUI on a different host than the
+   * API (e.g. API at honcho.example.com, GUI at dashboard.example.com), so this
+   * is configured independently of `baseUrl`. Defaults to the hosted platform.
+   */
+  dashboardUrl?: string;
 }
 
 const HONCHO_BASE_URLS = {
   production: "https://api.honcho.dev/v3",
   local: "http://localhost:8000/v3",
 } as const;
+
+/** Dashboard (GUI) base URL for the hosted platform. */
+const DEFAULT_DASHBOARD_URL = "https://app.honcho.dev";
 
 // ============================================
 // Host Detection
@@ -372,6 +382,7 @@ export function loadConfigFromEnv(host?: HonchoHost): HonchoCLAUDEConfig | null 
     : process.env.HONCHO_CLAUDE_PEER;
   const aiPeer = process.env.HONCHO_AI_PEER || hostPeerEnv || DEFAULT_AI_PEER[resolvedHost];
   const endpoint = process.env.HONCHO_ENDPOINT;
+  const dashboardUrl = process.env.HONCHO_DASHBOARD_URL;
 
   const config: HonchoCLAUDEConfig = {
     apiKey,
@@ -389,6 +400,10 @@ export function loadConfigFromEnv(host?: HonchoHost): HonchoCLAUDEConfig | null 
     } else if (endpoint.startsWith("http")) {
       config.endpoint = { baseUrl: endpoint };
     }
+  }
+
+  if (dashboardUrl) {
+    config.endpoint = { ...config.endpoint, dashboardUrl };
   }
 
   return config;
@@ -713,6 +728,21 @@ export function getHonchoBaseUrl(config: HonchoCLAUDEConfig): string {
   return getHonchoBaseUrlForEndpoint(config.endpoint);
 }
 
+/**
+ * Get the dashboard (GUI) base URL used for session links.
+ * Priority: HONCHO_DASHBOARD_URL env > endpoint.dashboardUrl > hosted default.
+ * Trailing slashes are stripped so callers can safely append a path.
+ */
+export function getDashboardUrlForEndpoint(endpoint?: HonchoEndpointConfig): string {
+  const raw = process.env.HONCHO_DASHBOARD_URL || endpoint?.dashboardUrl || DEFAULT_DASHBOARD_URL;
+  return raw.replace(/\/+$/, "");
+}
+
+/** Get the dashboard (GUI) base URL for a resolved runtime config. */
+export function getDashboardUrl(config: HonchoCLAUDEConfig): string {
+  return getDashboardUrlForEndpoint(config.endpoint);
+}
+
 export function getHonchoClientOptions(config: HonchoCLAUDEConfig): HonchoClientOptions {
   return {
     apiKey: config.apiKey,
@@ -740,10 +770,20 @@ export function getObservationMode(config: HonchoCLAUDEConfig): ObservationMode 
   return config.observationMode ?? "unified";
 }
 
-export function setEndpoint(environment?: HonchoEnvironment, baseUrl?: string): void {
+export function setEndpoint(
+  environment?: HonchoEnvironment,
+  baseUrl?: string,
+  dashboardUrl?: string,
+): void {
   const config = loadConfig();
   if (!config) return;
   if (environment && !VALID_ENVIRONMENTS.has(environment)) return;
-  config.endpoint = { environment, baseUrl };
+  // Preserve an existing custom dashboard URL when the caller doesn't set one —
+  // switching API environment shouldn't silently reset the GUI link target.
+  config.endpoint = {
+    environment,
+    baseUrl,
+    dashboardUrl: dashboardUrl ?? config.endpoint?.dashboardUrl,
+  };
   saveConfig(config);
 }

--- a/plugins/honcho/src/hooks/session-start.ts
+++ b/plugins/honcho/src/hooks/session-start.ts
@@ -1,5 +1,5 @@
 import { Honcho } from "@honcho-ai/sdk";
-import { loadConfig, getSessionForPath, setSessionForPath, getSessionName, getHonchoClientOptions, isPluginEnabled, getCachedStdin, getObservationMode } from "../config.js";
+import { loadConfig, getSessionForPath, setSessionForPath, getSessionName, getHonchoClientOptions, isPluginEnabled, getCachedStdin, getObservationMode, getDashboardUrl } from "../config.js";
 import {
   setCachedUserContext,
   setCachedSessionId,
@@ -84,7 +84,7 @@ export async function handleSessionStart(): Promise<void> {
   const spinner = new Spinner({ style: "neural" });
   spinner.start(`${sessionName} · loading memory`);
   setMemoryState("loading", sessionName, claudeInstanceId);
-  setSessionLink(honchoSessionUrl(config.workspace, sessionName), sessionName, claudeInstanceId);
+  setSessionLink(honchoSessionUrl(config.workspace, sessionName, getDashboardUrl(config)), sessionName, claudeInstanceId);
 
   try {
     logHook("session-start", `Starting session in ${cwd}`, { branch: currentGitState?.branch });

--- a/plugins/honcho/src/hooks/user-prompt.ts
+++ b/plugins/honcho/src/hooks/user-prompt.ts
@@ -1,7 +1,7 @@
 import { Honcho } from "@honcho-ai/sdk";
 import { readFileSync, existsSync } from "node:fs";
 import { join } from "node:path";
-import { loadConfig, getSessionName, getHonchoClientOptions, isPluginEnabled, getCachedStdin, getObservationMode } from "../config.js";
+import { loadConfig, getSessionName, getHonchoClientOptions, isPluginEnabled, getCachedStdin, getObservationMode, getDashboardUrl } from "../config.js";
 import {
   getCachedUserContext,
   getStaleCachedUserContext,
@@ -130,7 +130,7 @@ export async function handleUserPrompt(): Promise<void> {
   }
 
   logHook("user-prompt", `Prompt received (${prompt.length} chars)`);
-  setSessionLink(honchoSessionUrl(config.workspace, sessionName), sessionName, hookInput.session_id);
+  setSessionLink(honchoSessionUrl(config.workspace, sessionName, getDashboardUrl(config)), sessionName, hookInput.session_id);
 
   // Queue user prompt for upload at session-end (instant, no network)
   if (config.saveMessages !== false) {
@@ -158,9 +158,9 @@ export async function handleUserPrompt(): Promise<void> {
   const nag = readVersionNag();
   const sessionLink =
     messageCountBefore === 0
-      ? nag ?? formatSessionLink(honchoSessionUrl(config.workspace, sessionName))
+      ? nag ?? formatSessionLink(honchoSessionUrl(config.workspace, sessionName, getDashboardUrl(config)))
       : messageCountBefore === 1 && nag
-        ? formatSessionLink(honchoSessionUrl(config.workspace, sessionName))
+        ? formatSessionLink(honchoSessionUrl(config.workspace, sessionName, getDashboardUrl(config)))
         : undefined;
 
   // Skip trivial prompts — no context needed for "y", "ok", etc.

--- a/plugins/honcho/src/mcp/server.ts
+++ b/plugins/honcho/src/mcp/server.ts
@@ -16,6 +16,7 @@ import {
   configExists,
   getDetectedHost,
   getEndpointInfo,
+  getDashboardUrl,
   getKnownHosts,
   setDetectedHost,
   type HonchoCLAUDEConfig,
@@ -48,6 +49,7 @@ const ENV_SHADOW_MAP: Record<string, string> = {
   saveMessages: "HONCHO_SAVE_MESSAGES",
   "endpoint.baseUrl": "HONCHO_ENDPOINT",
   "endpoint.environment": "HONCHO_ENDPOINT",
+  "endpoint.dashboardUrl": "HONCHO_DASHBOARD_URL",
 };
 
 // Fields that require confirm=true to change
@@ -123,7 +125,7 @@ function handleGetConfig(cwd: string) {
     ? endpointInfo.type === "production" ? "platform" : endpointInfo.type
     : null;
 
-  const sessionUrl = cfg && sessionName ? honchoSessionUrl(cfg.workspace, sessionName) : null;
+  const sessionUrl = cfg && sessionName ? honchoSessionUrl(cfg.workspace, sessionName, getDashboardUrl(cfg)) : null;
 
   const current = cfg ? {
     workspace: cfg.workspace,
@@ -348,6 +350,18 @@ function handleSetConfig(args: Record<string, unknown>) {
       cacheInvalidation = { cleared: ["all IDs", "all context"], reason: "Endpoint URL changed" };
       break;
 
+    case "endpoint.dashboardUrl": {
+      previousValue = cfg.endpoint?.dashboardUrl;
+      if (!cfg.endpoint) cfg.endpoint = {};
+      // Empty string clears the override, reverting to the hosted default.
+      const dash = String(value).trim();
+      cfg.endpoint.dashboardUrl = dash === "" ? undefined : dash;
+      // endpoint is a global field — write to root (user-directed action).
+      // Display-only (session links); no ID/context cache to invalidate.
+      saveRootField("endpoint", cfg.endpoint);
+      break;
+    }
+
     case "sessionStrategy":
       previousValue = cfg.sessionStrategy ?? "per-directory";
       cfg.sessionStrategy = String(value) as SessionStrategy;
@@ -525,7 +539,7 @@ function handleSetConfig(args: Record<string, unknown>) {
   // Include session URL when session-affecting fields change
   const cwd = getLastActiveCwd() || process.cwd();
   const newSessionName = SESSION_AFFECTING_FIELDS.has(field) ? getSessionName(cwd) : undefined;
-  const sessionUrl = newSessionName ? honchoSessionUrl(cfg.workspace, newSessionName) : undefined;
+  const sessionUrl = newSessionName ? honchoSessionUrl(cfg.workspace, newSessionName, getDashboardUrl(cfg)) : undefined;
 
   return {
     content: [{
@@ -709,6 +723,7 @@ export async function runMcpServer(): Promise<void> {
                   "globalOverride",
                   "endpoint.environment",
                   "endpoint.baseUrl",
+                  "endpoint.dashboardUrl",
                   "sessionStrategy",
                   "sessionPeerPrefix",
                   "enabled",

--- a/plugins/honcho/src/styles.ts
+++ b/plugins/honcho/src/styles.ts
@@ -146,11 +146,21 @@ export function highlight(text: string): string {
   return `${colors.peach}${text}${colors.reset}`;
 }
 
+/** Default dashboard (GUI) base URL — the hosted platform. */
+const DEFAULT_DASHBOARD_URL = "https://app.honcho.dev";
+
 /**
- * Build a Honcho app URL for a session
+ * Build a Honcho dashboard URL for a session.
+ * `dashboardBaseUrl` lets self-hosted deployments point links at their own GUI
+ * (resolve it via getDashboardUrl(config)); it defaults to the hosted platform.
  */
-export function honchoSessionUrl(workspace: string, sessionName: string): string {
-  return `https://app.honcho.dev/explore?workspace=${encodeURIComponent(workspace)}&view=sessions&session=${encodeURIComponent(sessionName)}`;
+export function honchoSessionUrl(
+  workspace: string,
+  sessionName: string,
+  dashboardBaseUrl: string = DEFAULT_DASHBOARD_URL,
+): string {
+  const base = dashboardBaseUrl.replace(/\/+$/, "");
+  return `${base}/explore?workspace=${encodeURIComponent(workspace)}&view=sessions&session=${encodeURIComponent(sessionName)}`;
 }
 
 /**
@@ -163,7 +173,11 @@ export function hyperlink(url: string, text: string): string {
 /**
  * Styled session line with clickable hyperlink to Honcho app
  */
-export function sessionLine(workspace: string, sessionName: string): string {
-  const url = honchoSessionUrl(workspace, sessionName);
+export function sessionLine(
+  workspace: string,
+  sessionName: string,
+  dashboardBaseUrl?: string,
+): string {
+  const url = honchoSessionUrl(workspace, sessionName, dashboardBaseUrl);
   return `${colors.dim}Honcho session:${colors.reset} ${hyperlink(url, `${colors.skyBlue}${sessionName}${colors.reset}`)}`;
 }


### PR DESCRIPTION
## Problem

The plugin's clickable **"view your session in honcho GUI"** links are hardcoded to `https://app.honcho.dev`:

```ts
// src/styles.ts
export function honchoSessionUrl(workspace, sessionName) {
  return `https://app.honcho.dev/explore?workspace=...&view=sessions&session=...`;
}
```

For anyone running a **self-hosted Honcho**, this link is wrong — their sessions live on their own instance, but the link sends them to the SaaS dashboard (which doesn't have their data). The link target is completely decoupled from the configured `endpoint.baseUrl`, so even a fully self-hosted setup still points at `app.honcho.dev`.

It can't simply be derived from `endpoint.baseUrl` either: the GUI is commonly served on a **different host** than the API (e.g. API at `honcho.example.com`, dashboard at `dashboard.example.com`).

## Change

Add an independently configurable dashboard base URL:

- **`endpoint.dashboardUrl`** config field
- **`HONCHO_DASHBOARD_URL`** env var (takes precedence, matching the existing env-override pattern)
- **`set_config`** MCP field `endpoint.dashboardUrl` (empty string clears the override)

Resolution order: `HONCHO_DASHBOARD_URL` > `endpoint.dashboardUrl` > `https://app.honcho.dev`. Trailing slashes are normalized.

`honchoSessionUrl()` / `sessionLine()` keep the hosted default, so **hosted users see no change**. All call sites (`session-start`, `user-prompt`, `mcp/server`) thread the resolved value. `setEndpoint()` preserves a custom dashboard URL across API-environment switches.

## Example

```json
{
  "endpoint": {
    "baseUrl": "https://honcho.example.com/v3",
    "dashboardUrl": "https://dashboard.example.com"
  }
}
```
→ `https://dashboard.example.com/explore?workspace=...&view=sessions&session=...`

## Testing

- `tsc --noEmit` passes.
- Runtime-verified the URL builder + resolver: default unchanged, self-host honored, trailing slash normalized, env var wins over config field.

README (config block, env-var table, self-hosting section) and CHANGELOG updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Km4oh3yBKgksgH4e5HExMw

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Session “view” links can now point to a configurable dashboard URL, making them work with self-hosted setups.
  * Added support for setting the dashboard link destination through configuration or an environment variable, with a hosted default.

* **Documentation**
  * Updated the changelog and README with the new configuration option, environment variable, and self-hosting examples.

* **Bug Fixes**
  * Session links now keep their dashboard destination when switching API settings, instead of resetting unexpectedly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->