### PR TITLE
feat(capture): opt-in skipToolEvents / skipGitObservations to cut memory noise

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,7 +221,9 @@ All configuration lives in a single global file at `~/.honcho/config.json`. You 
   "messageUpload": {
     "maxUserTokens": null,            // Truncate user messages (null = no limit)
     "maxAssistantTokens": null,       // Truncate assistant messages (null = no limit)
-    "summarizeAssistant": false       // Summarize instead of sending full assistant text
+    "summarizeAssistant": false,      // Summarize instead of sending full assistant text
+    "skipToolEvents": false,          // Don't upload "[Tool] Edited …" events (cuts noise for heavy tool users)
+    "skipGitObservations": false      // Don't upload "[Git External]" commit observations at session start
   },
 
   // Context retrieval

--- a/plugins/honcho/src/config.ts
+++ b/plugins/honcho/src/config.ts
@@ -15,6 +15,18 @@ export interface MessageUploadConfig {
   maxAssistantTokens?: number;
   /** Summarize assistant messages instead of sending full text (default: false) */
   summarizeAssistant?: boolean;
+  /**
+   * Skip uploading per-tool-use events (`[Tool] Edited …`) to Honcho (default: false).
+   * Heavy tool users generate thousands of low-value edit/diff fragments that
+   * dominate the derived memory and pollute semantic search. Local claude-context.md
+   * is unaffected — only the Honcho upload is skipped.
+   */
+  skipToolEvents?: boolean;
+  /**
+   * Skip uploading `[Git External]` commit observations at session start (default: false).
+   * Turns every commit into a memory ("made a commit <hash>") — usually noise.
+   */
+  skipGitObservations?: boolean;
 }
 
 export interface ContextRefreshConfig {
@@ -623,6 +635,8 @@ export function getMessageUploadConfig(): MessageUploadConfig {
     maxUserTokens: config?.messageUpload?.maxUserTokens ?? undefined,
     maxAssistantTokens: config?.messageUpload?.maxAssistantTokens ?? undefined,
     summarizeAssistant: config?.messageUpload?.summarizeAssistant ?? false,
+    skipToolEvents: config?.messageUpload?.skipToolEvents ?? false,
+    skipGitObservations: config?.messageUpload?.skipGitObservations ?? false,
   };
 }
 

--- a/plugins/honcho/src/hooks/post-tool-use.ts
+++ b/plugins/honcho/src/hooks/post-tool-use.ts
@@ -237,6 +237,12 @@ async function logToHonchoAsync(config: any, cwd: string, summary: string): Prom
     return;
   }
 
+  // Skip uploading tool-use events when configured — they dominate derived memory
+  // and pollute semantic search. Local claude-context.md already captured this above.
+  if (config.messageUpload?.skipToolEvents) {
+    return;
+  }
+
   const honcho = new Honcho(getHonchoClientOptions(config));
   const sessionName = getSessionName(cwd);
 

--- a/plugins/honcho/src/hooks/session-start.ts
+++ b/plugins/honcho/src/hooks/session-start.ts
@@ -128,7 +128,7 @@ export async function handleSessionStart(): Promise<void> {
 
     // Upload git changes as observations (fire-and-forget)
     // These capture external activity that happened OUTSIDE of Claude sessions
-    if (gitChanges.length > 0) {
+    if (gitChanges.length > 0 && !config.messageUpload?.skipGitObservations) {
       const gitObservations = gitChanges
         .filter((c) => c.type !== "initial") // Don't log initial state as observation
         .map((change) =>

--- a/plugins/honcho/src/mcp/server.ts
+++ b/plugins/honcho/src/mcp/server.ts
@@ -403,6 +403,18 @@ function handleSetConfig(args: Record<string, unknown>) {
       cfg.messageUpload.summarizeAssistant = Boolean(value);
       break;
 
+    case "messageUpload.skipToolEvents":
+      previousValue = cfg.messageUpload?.skipToolEvents;
+      if (!cfg.messageUpload) cfg.messageUpload = {};
+      cfg.messageUpload.skipToolEvents = Boolean(value);
+      break;
+
+    case "messageUpload.skipGitObservations":
+      previousValue = cfg.messageUpload?.skipGitObservations;
+      if (!cfg.messageUpload) cfg.messageUpload = {};
+      cfg.messageUpload.skipGitObservations = Boolean(value);
+      break;
+
     case "contextRefresh.messageThreshold":
       previousValue = cfg.contextRefresh?.messageThreshold;
       if (!cfg.contextRefresh) cfg.contextRefresh = {};
@@ -717,6 +729,8 @@ export async function runMcpServer(): Promise<void> {
                   "messageUpload.maxUserTokens",
                   "messageUpload.maxAssistantTokens",
                   "messageUpload.summarizeAssistant",
+                  "messageUpload.skipToolEvents",
+                  "messageUpload.skipGitObservations",
                   "contextRefresh.messageThreshold",
                   "contextRefresh.ttlSeconds",
                   "contextRefresh.skipDialectic",


### PR DESCRIPTION
## Problem

Heavy tool users — Claude Code coding sessions especially — flood Honcho with low-value inputs that dominate the derived memory and pollute semantic search:

- `post-tool-use` uploads a `[Tool] Edited <file>: <diff-fragment>` message for **every** significant tool call.
- `session-start` uploads a `[Git External]` message per commit, so every commit becomes a conclusion (*"dave made a Git commit <hash>"*).

On a busy workspace this is thousands of near-worthless messages. In one real instance, a workspace-scoped semantic search for substantive content returned **9 of 10** results as `[Tool] Edited energy.ts: removed: meter, meter, gridAmps`-style fragments, and the derived conclusions were majority commit-hash / tool-noise. Today the only mitigation is the all-or-nothing `saveMessages: false`, which also drops the substantive conversation.

## Change

Two **opt-in** `MessageUploadConfig` toggles, both default `false` (no behavior change for existing users):

- **`messageUpload.skipToolEvents`** — skip the Honcho upload of `[Tool] …` events. `claude-context.md` (local project memory) is still written, so project context isn't lost — only the Honcho firehose is suppressed.
- **`messageUpload.skipGitObservations`** — skip the `[Git External]` commit observations at session start.

Settable three ways, consistent with existing config:
- `config.json` → `messageUpload.skipToolEvents` / `skipGitObservations`
- `set_config` MCP tool (both added to the field enum + handlers)
- documented in the README config block

## Testing

- `tsc --noEmit` passes.
- Verified the guards: `post-tool-use` returns before the Honcho `addMessages` when `skipToolEvents` is set (local context append still runs); `session-start` skips the git-observation upload when `skipGitObservations` is set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Km4oh3yBKgksgH4e5HExMw

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added two new message upload settings: `skipToolEvents` and `skipGitObservations`.
  * These options can now be set through the configuration tool and default to `false`.

* **Bug Fixes**
  * Message uploads now respect the new settings, letting you prevent tool-use events and git change observations from being sent.
  * Existing upload behavior remains unchanged when the options are not enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->