### PR TITLE
fix: skip reasoning for non-meaningful session-end uploads

### DIFF
--- a/plugins/honcho/src/hooks/session-end.ts
+++ b/plugins/honcho/src/hooks/session-end.ts
@@ -277,6 +277,9 @@ export async function handleSessionEnd(): Promise<void> {
                 meaningful: msg.isMeaningful || false,
                 session_affinity: sessionName,
               },
+              ...(msg.isMeaningful
+                ? {}
+                : { configuration: { reasoning: { enabled: false } } }),
             })
           );
         })
@@ -286,6 +289,7 @@ export async function handleSessionEnd(): Promise<void> {
       `[Session ended] Reason: ${reason}, Messages: ${transcriptMessages.length}, Time: ${new Date().toISOString()}`,
       {
         createdAt: new Date().toISOString(),
+        configuration: { reasoning: { enabled: false } },
         metadata: {
           instance_id: instanceId || undefined,
           session_affinity: sessionName,


### PR DESCRIPTION
## Summary
- Disable per-message `reasoning` for assistant uploads tagged `meaningful: false` (tool stubs / brief acknowledgments).
- Same for the `[Session ended]` marker, which was producing junk conclusions (e.g. "session contained N messages").
- Messages are still stored for history/summaries; only representation enqueue is skipped.

## Test plan
- [ ] End a Claude Code session that used tools; confirm brief `[Used tools: …]` messages still appear in Honcho, but no new representation queue items / conclusions from them.
- [ ] End a session with real prose; confirm meaningful assistant messages still derive normally.
- [ ] Confirm session-end marker is stored without deriving conclusions about message count.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session-end messages by disabling reasoning for non-meaningful assistant responses and the final session-ended marker.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->