### PR TITLE
fix(mcp): set dialectic chat timeout to 120s

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,14 +6,14 @@
   },
   "metadata": {
     "description": "Honcho plugins for Claude Code - memory, development tools, and more",
-    "version": "0.2.5"
+    "version": "0.2.6"
   },
   "plugins": [
     {
       "name": "honcho",
       "source": "./plugins/honcho",
       "description": "Persistent memory for Claude Code sessions using Honcho",
-      "version": "0.2.5",
+      "version": "0.2.6",
       "keywords": ["memory", "context", "persistence"],
       "strict": false
     },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ All notable changes to claude-honcho will be documented in this file.
 
 ### Fixed
 
-- MCP `chat` tool no longer times out on long dialectic queries (~80s at max reasoning). Dialectic calls run on a dedicated 120s-timeout Honcho client instead of the shared 8s one, and the plugin's MCP server config sets a 150s per-tool timeout so the harness-side wall clock always outlasts the SDK's.
+- MCP `chat` tool no longer times out on long dialectic queries (~80s at max reasoning). Dialectic calls run on a dedicated no-retry Honcho client under a single 120s deadline covering the whole flow, and the plugin's MCP server config sets a 150s per-tool timeout, so the server's clean timeout error always surfaces before the harness aborts the call.
 
 ## [0.2.5] - 2026-06-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to claude-honcho will be documented in this file.
 
 ## [Unreleased]
 
+## [0.2.6] - 2026-07-21
+
 ### Fixed
 
 - MCP `chat` tool no longer times out on long dialectic queries (~80s at max reasoning). Dialectic calls run on a dedicated 120s-timeout Honcho client instead of the shared 8s one, and the plugin's MCP server config sets a 150s per-tool timeout so the harness-side wall clock always outlasts the SDK's.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to claude-honcho will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- MCP `chat` tool no longer times out on long dialectic queries (~80s at max reasoning). Dialectic calls run on a dedicated 120s-timeout Honcho client instead of the shared 8s one, and the plugin's MCP server config sets a 150s per-tool timeout so the harness-side wall clock always outlasts the SDK's.
+
 ## [0.2.5] - 2026-06-02
 
 ### Added

--- a/plugins/honcho/.claude-plugin/plugin.json
+++ b/plugins/honcho/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "honcho",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "description": "Persistent memory for Claude Code sessions using Honcho by Plastic Labs",
   "author": {
     "name": "Plastic Labs",

--- a/plugins/honcho/mcp-servers.json
+++ b/plugins/honcho/mcp-servers.json
@@ -1,6 +1,7 @@
 {
   "honcho": {
     "command": "bun",
-    "args": ["run", "${CLAUDE_PLUGIN_ROOT}/mcp-server.ts"]
+    "args": ["run", "${CLAUDE_PLUGIN_ROOT}/mcp-server.ts"],
+    "timeout": 150000
   }
 }

--- a/plugins/honcho/package.json
+++ b/plugins/honcho/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-honcho",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "description": "Persistent memory for Claude Code sessions using Honcho by Plastic Labs",
   "type": "module",
   "keywords": [

--- a/plugins/honcho/src/mcp/server.ts
+++ b/plugins/honcho/src/mcp/server.ts
@@ -559,7 +559,7 @@ export async function runMcpServer(): Promise<void> {
   const server = new Server(
     {
       name: "honcho",
-      version: "0.2.4",
+      version: "0.2.6",
     },
     {
       capabilities: {
@@ -572,10 +572,12 @@ export async function runMcpServer(): Promise<void> {
   const honcho = new Honcho(getHonchoClientOptions(config));
 
   // Dedicated client for dialectic queries, which run far past the shared
-  // 8s timeout (≈80s at max reasoning)
+  // 8s timeout (≈80s at max reasoning). No retries: the chat case enforces
+  // one DIALECTIC_TIMEOUT_MS deadline across the whole flow.
   const honchoDialectic = new Honcho({
     ...getHonchoClientOptions(config),
     timeout: DIALECTIC_TIMEOUT_MS,
+    maxRetries: 0,
   });
 
   // List available tools
@@ -855,22 +857,39 @@ export async function runMcpServer(): Promise<void> {
           const query = args?.query as string;
           const reasoningLevel = (args?.reasoning_level as string) ?? config.reasoningLevel ?? "medium";
 
-          const dialecticPeer = await honchoDialectic.peer(activePeer.id);
-
-          const response = await dialecticPeer.chat(query, {
-            ...(chatTarget ? { target: chatTarget } : {}),
-            session,
-            reasoningLevel,
+          // Single deadline for the whole flow (peer resolve + chat), so
+          // sequential requests can't stack past the harness's 150s budget
+          let deadlineTimer: ReturnType<typeof setTimeout> | undefined;
+          const deadline = new Promise<never>((_, reject) => {
+            deadlineTimer = setTimeout(
+              () => reject(new Error(`Dialectic call exceeded ${DIALECTIC_TIMEOUT_MS}ms`)),
+              DIALECTIC_TIMEOUT_MS
+            );
           });
 
-          return {
-            content: [
-              {
-                type: "text",
-                text: response ?? "No response from Honcho",
-              },
-            ],
-          };
+          const chatFlow = (async () => {
+            const dialecticPeer = await honchoDialectic.peer(activePeer.id);
+            return dialecticPeer.chat(query, {
+              ...(chatTarget ? { target: chatTarget } : {}),
+              session,
+              reasoningLevel,
+            });
+          })();
+
+          try {
+            const response = await Promise.race([chatFlow, deadline]);
+            return {
+              content: [
+                {
+                  type: "text",
+                  text: response ?? "No response from Honcho",
+                },
+              ],
+            };
+          } finally {
+            clearTimeout(deadlineTimer);
+            chatFlow.catch(() => {});
+          }
         }
 
         case "create_conclusion": {

--- a/plugins/honcho/src/mcp/server.ts
+++ b/plugins/honcho/src/mcp/server.ts
@@ -545,6 +545,9 @@ function handleSetConfig(args: Record<string, unknown>) {
   };
 }
 
+/** Client-side ceiling for dialectic chat calls. */
+const DIALECTIC_TIMEOUT_MS = 120_000;
+
 export async function runMcpServer(): Promise<void> {
   setDetectedHost("claude_code");
   const config = loadConfig();
@@ -567,6 +570,13 @@ export async function runMcpServer(): Promise<void> {
 
   // Initialize Honcho client
   const honcho = new Honcho(getHonchoClientOptions(config));
+
+  // Dedicated client for dialectic queries, which run far past the shared
+  // 8s timeout (≈80s at max reasoning)
+  const honchoDialectic = new Honcho({
+    ...getHonchoClientOptions(config),
+    timeout: DIALECTIC_TIMEOUT_MS,
+  });
 
   // List available tools
   server.setRequestHandler(ListToolsRequestSchema, async () => {
@@ -845,7 +855,9 @@ export async function runMcpServer(): Promise<void> {
           const query = args?.query as string;
           const reasoningLevel = (args?.reasoning_level as string) ?? config.reasoningLevel ?? "medium";
 
-          const response = await activePeer.chat(query, {
+          const dialecticPeer = await honchoDialectic.peer(activePeer.id);
+
+          const response = await dialecticPeer.chat(query, {
             ...(chatTarget ? { target: chatTarget } : {}),
             session,
             reasoningLevel,


### PR DESCRIPTION
## Problem

MCP calls timeout at 8s, which comes up a lot for higher reasoning dialectic calls.


## Fixes

1. **SDK-side**: `peer.chat()` has no per-request timeout, so `chat` now routes through a dedicated `Honcho` client with a 120s timeout. 
2. **Harness-side**: Claude Code's per-tool wall clock is normally the user-level `MCP_TOOL_TIMEOUT`, but the [per-server `timeout` field](https://code.claude.com/docs/en/mcp#push-messages-with-channels) in the server config overrides it, which we set to 150s.
