### PR TITLE
fix: upload messages live instead of queuing to session-end

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to claude-honcho will be documented in this file.
 
 ## [Unreleased]
 
+## [0.2.7] - 2026-07-22
+
+### Added
+
+- `saveToolUse` config flag (`HONCHO_SAVE_TOOL_USE` env var) to opt into uploading tool-use messages.
+
+### Changed
+
+- Messages upload live (user prompts on submit, assistant messages from the stop hook) instead of being queued and flushed at session end.
+
+### Fixed
+
+- Stop hook no longer uploads assistant messages when the turn has no preceding user prompt.
+
 ## [0.2.6] - 2026-07-21
 
 ### Fixed

--- a/plugins/honcho/.claude-plugin/plugin.json
+++ b/plugins/honcho/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "honcho",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "description": "Persistent memory for Claude Code sessions using Honcho by Plastic Labs",
   "author": {
     "name": "Plastic Labs",

--- a/plugins/honcho/package.json
+++ b/plugins/honcho/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-honcho",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "description": "Persistent memory for Claude Code sessions using Honcho by Plastic Labs",
   "type": "module",
   "keywords": [

--- a/plugins/honcho/src/cache.ts
+++ b/plugins/honcho/src/cache.ts
@@ -1,12 +1,11 @@
 import { homedir } from "os";
 import { join } from "path";
-import { existsSync, readFileSync, writeFileSync, appendFileSync, mkdirSync } from "fs";
+import { existsSync, readFileSync, writeFileSync, mkdirSync } from "fs";
 import { getContextRefreshConfig, getLocalContextConfig } from "./config.js";
 
 const CACHE_DIR = join(homedir(), ".honcho");
 const ID_CACHE_FILE = join(CACHE_DIR, "cache.json");
 const CONTEXT_CACHE_FILE = join(CACHE_DIR, "context-cache.json");
-const MESSAGE_QUEUE_FILE = join(CACHE_DIR, "message-queue.jsonl");
 const CLAUDE_CONTEXT_FILE = join(CACHE_DIR, "claude-context.md");
 
 // Ensure cache directory exists
@@ -246,82 +245,6 @@ export function resetMessageCount(): void {
 }
 
 // ============================================
-// Message Queue - local file for reliability
-// ============================================
-
-interface QueuedMessage {
-  content: string;
-  peerId: string;
-  cwd: string;
-  timestamp: string;
-  uploaded?: boolean;
-  instanceId?: string; // Claude Code instance for parallel session support
-}
-
-export function queueMessage(content: string, peerId: string, cwd: string, instanceId?: string): void {
-  ensureCacheDir();
-  const message: QueuedMessage = {
-    content,
-    peerId,
-    cwd,
-    timestamp: new Date().toISOString(),
-    uploaded: false,
-    instanceId: instanceId || getClaudeInstanceId() || undefined,
-  };
-  appendFileSync(MESSAGE_QUEUE_FILE, JSON.stringify(message) + "\n");
-}
-
-export function getQueuedMessages(forCwd?: string): QueuedMessage[] {
-  ensureCacheDir();
-  if (!existsSync(MESSAGE_QUEUE_FILE)) {
-    return [];
-  }
-  try {
-    const content = readFileSync(MESSAGE_QUEUE_FILE, "utf-8");
-    const lines = content.split("\n").filter((line) => line.trim());
-    const messages = lines.map((line) => JSON.parse(line)).filter((msg) => !msg.uploaded);
-    // Filter by cwd if specified
-    if (forCwd) {
-      return messages.filter((msg) => msg.cwd === forCwd);
-    }
-    return messages;
-  } catch {
-    return [];
-  }
-}
-
-export function clearMessageQueue(): void {
-  ensureCacheDir();
-  writeFileSync(MESSAGE_QUEUE_FILE, "");
-}
-
-export function markMessagesUploaded(forCwd?: string): void {
-  if (!forCwd) {
-    // Clear all
-    clearMessageQueue();
-    return;
-  }
-  // Only remove messages for the specified cwd, keep others
-  ensureCacheDir();
-  if (!existsSync(MESSAGE_QUEUE_FILE)) return;
-  try {
-    const content = readFileSync(MESSAGE_QUEUE_FILE, "utf-8");
-    const lines = content.split("\n").filter((line) => line.trim());
-    const remaining = lines.filter((line) => {
-      try {
-        const msg = JSON.parse(line);
-        return msg.cwd !== forCwd;
-      } catch {
-        return false;
-      }
-    });
-    writeFileSync(MESSAGE_QUEUE_FILE, remaining.join("\n") + (remaining.length ? "\n" : ""));
-  } catch {
-    // ignore
-  }
-}
-
-// ============================================
 // CLAUDE Context File - self-summary
 // ============================================
 
@@ -525,6 +448,7 @@ export function detectGitChanges(previous: GitState | null, current: GitState): 
 // Message Chunking - split large messages for API limits
 // ============================================
 
+// Under Honcho's 25k-char per-message cap, with headroom for the [Part i/N] prefix.
 const MAX_MESSAGE_SIZE = 24000;
 
 export function chunkContent(content: string, maxSize: number = MAX_MESSAGE_SIZE): string[] {
@@ -563,6 +487,17 @@ export function chunkContent(content: string, maxSize: number = MAX_MESSAGE_SIZE
   return chunks;
 }
 
+export const HONCHO_MAX_BATCH = 100;
+
+type SessionLike = { addMessages: (messages: any[]) => Promise<unknown> };
+
+/** Upload messages, split across calls of ≤100 to stay under Honcho's batch cap. */
+export async function addMessagesBatched(session: SessionLike, messages: any[]): Promise<void> {
+  for (let i = 0; i < messages.length; i += HONCHO_MAX_BATCH) {
+    await session.addMessages(messages.slice(i, i + HONCHO_MAX_BATCH));
+  }
+}
+
 // ============================================
 // Utility: Clear all caches (for debugging)
 // ============================================
@@ -571,7 +506,6 @@ export function clearAllCaches(): void {
   ensureCacheDir();
   if (existsSync(ID_CACHE_FILE)) writeFileSync(ID_CACHE_FILE, "{}");
   if (existsSync(CONTEXT_CACHE_FILE)) writeFileSync(CONTEXT_CACHE_FILE, "{}");
-  if (existsSync(MESSAGE_QUEUE_FILE)) writeFileSync(MESSAGE_QUEUE_FILE, "");
   if (existsSync(GIT_STATE_FILE)) writeFileSync(GIT_STATE_FILE, "{}");
   // Don't clear claude-context.md - that's valuable history
 }

--- a/plugins/honcho/src/config.ts
+++ b/plugins/honcho/src/config.ts
@@ -76,6 +76,7 @@ export interface HostConfig {
   enabled?: boolean;
   logging?: boolean;
   saveMessages?: boolean;
+  saveToolUse?: boolean;
   sessionStrategy?: SessionStrategy;
   sessionPeerPrefix?: boolean;
   /** Default reasoning level for Honcho dialectic calls (default: "medium") */
@@ -171,6 +172,8 @@ interface HonchoFileConfig {
   aiPeer?: string;
   sessions?: Record<string, string>;
   saveMessages?: boolean;
+  /** Save [Tool] action summaries to Honcho (default: false) */
+  saveToolUse?: boolean;
   messageUpload?: MessageUploadConfig;
   contextRefresh?: ContextRefreshConfig;
   endpoint?: HonchoEndpointConfig;
@@ -217,6 +220,8 @@ export interface HonchoCLAUDEConfig {
   sessions?: Record<string, string>;
   /** Save messages to Honcho (default: true) */
   saveMessages?: boolean;
+  /** Save [Tool] action summaries to Honcho (default: false — low signal, redundant with assistant reasoning) */
+  saveToolUse?: boolean;
   /** Default reasoning level for Honcho dialectic calls (default: "medium") */
   reasoningLevel?: ReasoningLevel;
   /**
@@ -339,6 +344,7 @@ function resolveConfig(raw: HonchoFileConfig, host: HonchoHost): HonchoCLAUDECon
     sessionPeerPrefix: hostBlock?.sessionPeerPrefix ?? raw.sessionPeerPrefix,
     sessions: raw.sessions,
     saveMessages: hostBlock?.saveMessages ?? raw.saveMessages,
+    saveToolUse: hostBlock?.saveToolUse ?? raw.saveToolUse,
     reasoningLevel: hostBlock?.reasoningLevel ?? raw.reasoningLevel,
     observationMode: hostBlock?.observationMode ?? raw.observationMode,
     messageUpload: hostBlock?.messageUpload ?? raw.messageUpload,
@@ -379,6 +385,7 @@ export function loadConfigFromEnv(host?: HonchoHost): HonchoCLAUDEConfig | null 
     workspace,
     aiPeer,
     saveMessages: process.env.HONCHO_SAVE_MESSAGES !== "false",
+    saveToolUse: process.env.HONCHO_SAVE_TOOL_USE === "true",
     enabled: process.env.HONCHO_ENABLED !== "false",
     logging: process.env.HONCHO_LOGGING !== "false",
   };
@@ -414,6 +421,9 @@ function mergeWithEnvVars(config: HonchoCLAUDEConfig): HonchoCLAUDEConfig {
   }
   if (process.env.HONCHO_LOGGING === "false") {
     config.logging = false;
+  }
+  if (process.env.HONCHO_SAVE_TOOL_USE !== undefined) {
+    config.saveToolUse = process.env.HONCHO_SAVE_TOOL_USE === "true";
   }
   return config;
 }

--- a/plugins/honcho/src/hooks/post-tool-use.ts
+++ b/plugins/honcho/src/hooks/post-tool-use.ts
@@ -232,8 +232,8 @@ export async function handlePostToolUse(): Promise<void> {
 }
 
 async function logToHonchoAsync(config: any, cwd: string, summary: string): Promise<void> {
-  // Skip if message saving is disabled
-  if (config.saveMessages === false) {
+  // Skip if message saving is disabled, or if [Tool] logging isn't opted in.
+  if (config.saveMessages === false || config.saveToolUse !== true) {
     return;
   }
 

--- a/plugins/honcho/src/hooks/session-end.ts
+++ b/plugins/honcho/src/hooks/session-end.ts
@@ -120,7 +120,8 @@ function parseTranscript(transcriptPath: string): Array<{ role: string; content:
           }
 
           if (assistantContent && assistantContent.trim()) {
-            // only used to build ~/.honcho/claude-context.md; not uploaded here
+            // Feeds the local work summary only — assistant messages upload live
+            // from the stop hook, not here.
             messages.push({
               role: "assistant",
               content: assistantContent,

--- a/plugins/honcho/src/hooks/session-end.ts
+++ b/plugins/honcho/src/hooks/session-end.ts
@@ -2,13 +2,11 @@ import { Honcho } from "@honcho-ai/sdk";
 import { loadConfig, getSessionName, getHonchoClientOptions, isPluginEnabled, getCachedStdin } from "../config.js";
 import { existsSync, readFileSync } from "fs";
 import {
-  getQueuedMessages,
-  markMessagesUploaded,
   generateClaudeSummary,
   saveClaudeLocalContext,
   loadClaudeLocalContext,
   getInstanceIdForCwd,
-  chunkContent,
+  addMessagesBatched,
 } from "../cache.js";
 import { playCooldown } from "../spinner.js";
 import { clearSessionFiles } from "../state.js";
@@ -122,12 +120,11 @@ function parseTranscript(transcriptPath: string): Array<{ role: string; content:
           }
 
           if (assistantContent && assistantContent.trim()) {
-            const isMeaningful = isMeaningfulAssistantContent(assistantContent);
-            const maxLen = isMeaningful ? 3000 : 1500;
+            // only used to build ~/.honcho/claude-context.md; not uploaded here
             messages.push({
               role: "assistant",
-              content: assistantContent.slice(0, maxLen),
-              isMeaningful,
+              content: assistantContent,
+              isMeaningful: isMeaningfulAssistantContent(assistantContent),
               timestamp: entry.timestamp,
             });
           }
@@ -242,46 +239,12 @@ export async function handleSessionEnd(): Promise<void> {
   try {
     const honcho = new Honcho(getHonchoClientOptions(config));
 
-    const [session, userPeer, aiPeer] = await Promise.all([
+    const [session, aiPeer] = await Promise.all([
       honcho.session(sessionName),
-      honcho.peer(config.peerName),
       honcho.peer(config.aiPeer),
     ]);
 
-    // Build all upload batches before sending
-    const queuedMessages = getQueuedMessages(cwd);
-    logHook("session-end", `Processing ${queuedMessages.length} queued + ${assistantMessages.length} assistant msgs`);
-
-    const userMessages = queuedMessages.flatMap((msg) => {
-      const chunks = chunkContent(msg.content);
-      return chunks.map(chunk =>
-        userPeer.message(chunk, {
-          createdAt: msg.timestamp,
-          metadata: {
-            instance_id: msg.instanceId || undefined,
-            session_affinity: sessionName,
-          },
-        })
-      );
-    });
-
-    const aiMessages = (config.saveMessages !== false && assistantMessages.length > 0)
-      ? assistantMessages.flatMap((msg) => {
-          const chunks = chunkContent(msg.content);
-          return chunks.map(chunk =>
-            aiPeer.message(chunk, {
-              createdAt: msg.timestamp,
-              metadata: {
-                instance_id: instanceId || undefined,
-                type: msg.isMeaningful ? 'assistant_prose' : 'assistant_brief',
-                meaningful: msg.isMeaningful || false,
-                session_affinity: sessionName,
-              },
-            })
-          );
-        })
-      : [];
-
+    // just the end marker; messages upload live elsewhere
     const endMarker = aiPeer.message(
       `[Session ended] Reason: ${reason}, Messages: ${transcriptMessages.length}, Time: ${new Date().toISOString()}`,
       {
@@ -293,21 +256,13 @@ export async function handleSessionEnd(): Promise<void> {
       }
     );
 
-    // Single addMessages call with everything — one round trip instead of three.
-    const allMessages = [...userMessages, ...aiMessages, endMarker];
-
-    if (allMessages.length > 0) {
-      const meaningfulCount = assistantMessages.filter(m => m.isMeaningful).length;
-      logApiCall("session.addMessages", "POST",
-        `${userMessages.length} user + ${aiMessages.length} assistant (${meaningfulCount} meaningful) + 1 marker`);
+    {
+      logApiCall("session.addMessages", "POST", `end marker`);
 
       // Start API upload immediately; run animation concurrently.
-      const uploadPromise = session.addMessages(allMessages);
+      const uploadPromise = addMessagesBatched(session, [endMarker]);
 
-      // Trap SIGTERM/SIGINT to prevent default termination while upload
-      // is in flight. The handler is a no-op — its only purpose is to
-      // keep the process alive. Cooldown's own exit handler cleans up
-      // the cursor if the process exits unexpectedly.
+      // No-op signal handlers keep the process alive while the upload is in flight.
       const sigHandler = () => {};
       process.on("SIGINT", sigHandler);
       if (process.platform === "win32") {
@@ -325,8 +280,7 @@ export async function handleSessionEnd(): Promise<void> {
         }
       };
 
-      // Hard safety net: if the upload hangs beyond SDK timeout + margin,
-      // force exit. Local summary was already saved in phase 1.
+      // Force exit if the upload hangs (local summary already saved above).
       const hardTimeout = setTimeout(() => {
         logHook("session-end", "Hard timeout reached — forcing exit");
         removeSigHandlers();
@@ -334,24 +288,16 @@ export async function handleSessionEnd(): Promise<void> {
       }, 12_000);
       hardTimeout.unref();
 
-      let uploadSucceeded = false;
       await Promise.all([
-        uploadPromise.then(() => { uploadSucceeded = true; }).finally(() => {
+        uploadPromise.finally(() => {
           clearTimeout(hardTimeout);
           removeSigHandlers();
         }),
         playCooldown("saving memory"),
       ]);
-
-      if (uploadSucceeded && queuedMessages.length > 0) {
-        markMessagesUploaded(cwd);
-      }
-    } else {
-      await playCooldown("saving memory");
     }
 
-    const meaningfulCount = assistantMessages.filter(m => m.isMeaningful).length;
-    logHook("session-end", `Session saved: ${assistantMessages.length} assistant msgs (${meaningfulCount} meaningful), ${queuedMessages.length} queued msgs`);
+    logHook("session-end", `Session ended — end marker saved (${assistantMessages.length} assistant msgs handled live)`);
     clearSessionFiles(hookInput.session_id);
     process.exit(0);
   } catch (error) {

--- a/plugins/honcho/src/hooks/stop.ts
+++ b/plugins/honcho/src/hooks/stop.ts
@@ -72,6 +72,8 @@ function getCurrentTurnAssistantMessages(transcriptPath: string): Array<{ text: 
       continue;
     }
   }
+  // return nothing if there's no last prompt
+  if (lastPromptIdx === -1) return [];
 
   const blocks: Array<{ text: string; timestamp?: string }> = [];
   for (let i = lastPromptIdx + 1; i < lines.length; i++) {

--- a/plugins/honcho/src/hooks/stop.ts
+++ b/plugins/honcho/src/hooks/stop.ts
@@ -1,7 +1,7 @@
-import { Honcho } from "@honcho-ai/sdk";
+import { Honcho, Session, Peer } from "@honcho-ai/sdk";
 import { loadConfig, getSessionForPath, getSessionName, getHonchoClientOptions, isPluginEnabled, getCachedStdin } from "../config.js";
 import { existsSync, readFileSync } from "fs";
-import { getInstanceIdForCwd } from "../cache.js";
+import { getInstanceIdForCwd, chunkContent, addMessagesBatched } from "../cache.js";
 import { logHook, logApiCall, setLogContext } from "../log.js";
 import { visStopMessage } from "../visual.js";
 
@@ -16,6 +16,8 @@ interface HookInput {
 interface TranscriptEntry {
   type?: string;
   role?: string;
+  timestamp?: string;
+  isMeta?: boolean;
   message?: {
     role?: string;
     content: string | Array<{ type: string; text?: string; name?: string; input?: any }>;
@@ -23,73 +25,66 @@ interface TranscriptEntry {
   content?: string | Array<{ type: string; text?: string }>;
 }
 
-/**
- * Check if content is meaningful (not just tool announcements)
- */
-function isMeaningfulContent(content: string): boolean {
-  if (content.length < 20) return false;
-
-  // Skip pure tool invocation one-liners
-  const toolAnnouncements = [
-    /^(I'll|Let me|I'm going to|I will|Now I'll|First,? I'll)\s+(run|use|execute|check|read|look at|search|edit|write|create)/i,
-  ];
-  for (const pattern of toolAnnouncements) {
-    if (pattern.test(content.trim()) && content.length < 150) {
-      return false;
-    }
-  }
-
-  return true;
+/** True for a real user-typed prompt. Excludes tool_results, isMeta entries, and `<...>` command caveats. */
+function isRealUserPrompt(entry: TranscriptEntry): boolean {
+  if (entry.isMeta) return false;
+  const mc = entry.message?.content ?? entry.content;
+  const text =
+    typeof mc === "string"
+      ? mc
+      : Array.isArray(mc)
+        ? mc.filter((b) => b.type === "text" && b.text).map((b) => b.text!).join("")
+        : "";
+  const trimmed = text.trim();
+  return trimmed.length > 0 && !trimmed.startsWith("<");
 }
 
-/**
- * Extract the last assistant message from the transcript
- */
-function getLastAssistantMessage(transcriptPath: string): string | null {
-  if (!transcriptPath || !existsSync(transcriptPath)) {
-    return null;
+function assistantText(entry: TranscriptEntry): string {
+  const mc = entry.message?.content ?? entry.content;
+  if (typeof mc === "string") return mc;
+  if (Array.isArray(mc)) {
+    return mc.filter((p) => p.type === "text" && p.text).map((p) => p.text!).join("\n\n");
   }
+  return "";
+}
 
+/** Assistant text blocks since the last real user prompt (the just-completed turn). */
+function getCurrentTurnAssistantMessages(transcriptPath: string): Array<{ text: string; timestamp?: string }> {
+  if (!transcriptPath || !existsSync(transcriptPath)) return [];
+
+  let lines: string[];
   try {
-    const content = readFileSync(transcriptPath, "utf-8");
-    const lines = content.trim().split("\n").filter((line) => line.trim());
-
-    // Read from the end to find the last assistant message
-    for (let i = lines.length - 1; i >= 0; i--) {
-      try {
-        const entry: TranscriptEntry = JSON.parse(lines[i]);
-
-        const entryType = entry.type || entry.role;
-        const messageContent = entry.message?.content || entry.content;
-
-        if (entryType === "assistant" && messageContent) {
-          let assistantContent = "";
-
-          if (typeof messageContent === "string") {
-            assistantContent = messageContent;
-          } else if (Array.isArray(messageContent)) {
-            // Extract text blocks only (skip tool_use blocks)
-            const textBlocks = messageContent
-              .filter((p) => p.type === "text" && p.text)
-              .map((p) => p.text!)
-              .join("\n\n");
-
-            assistantContent = textBlocks;
-          }
-
-          if (assistantContent && assistantContent.trim()) {
-            return assistantContent;
-          }
-        }
-      } catch {
-        continue;
-      }
-    }
+    lines = readFileSync(transcriptPath, "utf-8").trim().split("\n").filter((l) => l.trim());
   } catch {
-    // Failed to read transcript
+    return [];
   }
 
-  return null;
+  // Walk back to the last real user prompt — the start of the current turn.
+  let lastPromptIdx = -1;
+  for (let i = lines.length - 1; i >= 0; i--) {
+    try {
+      const entry: TranscriptEntry = JSON.parse(lines[i]);
+      if ((entry.type || entry.role) === "user" && isRealUserPrompt(entry)) {
+        lastPromptIdx = i;
+        break;
+      }
+    } catch {
+      continue;
+    }
+  }
+
+  const blocks: Array<{ text: string; timestamp?: string }> = [];
+  for (let i = lastPromptIdx + 1; i < lines.length; i++) {
+    try {
+      const entry: TranscriptEntry = JSON.parse(lines[i]);
+      if ((entry.type || entry.role) !== "assistant") continue;
+      const text = assistantText(entry);
+      if (text && text.trim()) blocks.push({ text, timestamp: entry.timestamp });
+    } catch {
+      continue;
+    }
+  }
+  return blocks;
 }
 
 export async function handleStop(): Promise<void> {
@@ -132,40 +127,50 @@ export async function handleStop(): Promise<void> {
   // Set log context
   setLogContext(cwd, sessionName);
 
-  // Get the last assistant message from the transcript
-  const lastMessage = getLastAssistantMessage(transcriptPath || "");
+  const turnMessages = getCurrentTurnAssistantMessages(transcriptPath || "");
 
-  if (!lastMessage || !isMeaningfulContent(lastMessage)) {
-    logHook("stop", `Skipping (no meaningful content)`);
-    // Don't show systemMessage for skips — too noisy since this fires every turn
+  if (turnMessages.length === 0) {
+    logHook("stop", `Skipping (no assistant content this turn)`);
     process.exit(0);
   }
 
-  logHook("stop", `Capturing assistant response (${lastMessage.length} chars)`);
+  logHook("stop", `Capturing ${turnMessages.length} assistant message(s) this turn`);
 
   try {
     const honcho = new Honcho(getHonchoClientOptions(config));
 
-    // Get session and peer using new fluent API
-    const session = await honcho.session(sessionName);
-    const aiPeer = await honcho.peer(config.aiPeer);
+    // Local peer handle, no get-or-create hop (see postUserMessage in user-prompt.ts).
+    const noEnsure = () => Promise.resolve();
+    const aiPeer = new Peer(config.aiPeer, honcho.workspaceId, honcho.http, undefined, undefined, noEnsure);
 
-    // Upload the assistant response
-    logApiCall("session.addMessages", "POST", `assistant response (${lastMessage.length} chars)`);
+    // Last block is the turn's response; earlier ones are intermediate reasoning.
+    const fallbackTs = new Date().toISOString();
+    const lastIdx = turnMessages.length - 1;
+    const messages = turnMessages.flatMap((block, i) =>
+      chunkContent(block.text).map((chunk) =>
+        aiPeer.message(chunk, {
+          createdAt: block.timestamp || fallbackTs,
+          metadata: {
+            instance_id: instanceId || undefined,
+            type: i === lastIdx ? "assistant_response" : "assistant_intermediate",
+            session_affinity: sessionName,
+          },
+        })
+      )
+    );
+    logApiCall("session.addMessages", "POST", `${turnMessages.length} assistant msg(s), ${messages.length} chunk(s), direct`);
 
-    await session.addMessages([
-      aiPeer.message(lastMessage.slice(0, 3000), {
-        createdAt: new Date().toISOString(),
-        metadata: {
-          instance_id: instanceId || undefined,
-          type: "assistant_response",
-          session_affinity: sessionName,
-        },
-      }),
-    ]);
+    try {
+      const session = new Session(sessionName, honcho.workspaceId, honcho.http, undefined, undefined, noEnsure);
+      await addMessagesBatched(session, messages);
+    } catch (e) {
+      logHook("stop", `Direct upload failed, retrying via get-or-create: ${e}`);
+      const session = await honcho.session(sessionName);
+      await addMessagesBatched(session, messages);
+    }
 
-    logHook("stop", `Assistant response saved`);
-    visStopMessage("out", `saved response (${lastMessage.length} chars)`);
+    logHook("stop", `Saved ${turnMessages.length} assistant message(s)`);
+    visStopMessage("out", `saved ${turnMessages.length} assistant msg(s)`);
   } catch (error) {
     logHook("stop", `Upload failed: ${error}`, { error: String(error) });
   }

--- a/plugins/honcho/src/hooks/user-prompt.ts
+++ b/plugins/honcho/src/hooks/user-prompt.ts
@@ -147,21 +147,27 @@ export async function handleUserPrompt(): Promise<void> {
   const messageCountBefore = getMessageCount();
   incrementMessageCount();
 
-  // On the first prompt only, nudge active use of the honcho MCP tools
-  // (search/chat/get_context) instead of relying on this passive injection.
+  // First prompt of the session: nudge the harness to actively call the honcho
+  // MCP tools (search/chat/get_context) rather than rely only on this passive
+  // injection. Injected once to respect a lean per-turn context budget.
   if (messageCountBefore === 0) {
     sessionToolHint =
       `Honcho memory tools are available — call honcho.search(query) or honcho.get_context to recall ` +
       `facts about ${config.peerName} across sessions, and honcho.chat(question) for dialectic/` +
       `psychological questions. Prefer querying over guessing when the user's history is relevant.`;
   }
-  // Show each one-time banner once: nag on prompt 1, link right after (prompt 1,
-  // or 2 if the nag took prompt 1).
+  // Stagger the one-off banners so the first prompt isn't crowded. The
+  // version-update nag (if stale) takes the first message and bumps the GUI
+  // session link to the second; with no nag, the link shows on the first.
+  // The nag flag is written at SessionStart and stable for the session, so
+  // its presence on message 2 tells us the link hasn't been shown yet.
   const nag = readVersionNag();
-  const link = formatSessionLink(honchoSessionUrl(config.workspace, sessionName));
-  let sessionLink: string | undefined;
-  if (messageCountBefore === 0) sessionLink = nag ?? link;
-  else if (messageCountBefore === 1 && nag) sessionLink = link;
+  const sessionLink =
+    messageCountBefore === 0
+      ? nag ?? formatSessionLink(honchoSessionUrl(config.workspace, sessionName))
+      : messageCountBefore === 1 && nag
+        ? formatSessionLink(honchoSessionUrl(config.workspace, sessionName))
+        : undefined;
 
   // Skip trivial prompts — no context needed for "y", "ok", etc.
   if (shouldSkipContextRetrieval(prompt)) {
@@ -220,11 +226,9 @@ export async function handleUserPrompt(): Promise<void> {
   process.exit(0);
 }
 
-/**
- * Upload a user prompt. SessionStart already created the session/peers, so we
- * build handles locally and skip the get-or-create round trips (1 hop, not 3).
- * Falls back to the fluent path if the direct write fails.
- */
+
+// Upload a user prompt. SessionStart already created the session/peers
+
 async function postUserMessage(
   config: any,
   prompt: string,

--- a/plugins/honcho/src/hooks/user-prompt.ts
+++ b/plugins/honcho/src/hooks/user-prompt.ts
@@ -1,4 +1,4 @@
-import { Honcho } from "@honcho-ai/sdk";
+import { Honcho, Session, Peer } from "@honcho-ai/sdk";
 import { readFileSync, existsSync } from "node:fs";
 import { join } from "node:path";
 import { loadConfig, getSessionName, getHonchoClientOptions, isPluginEnabled, getCachedStdin, getObservationMode } from "../config.js";
@@ -12,7 +12,8 @@ import {
   shouldRefreshKnowledgeGraph,
   markKnowledgeGraphRefreshed,
   getInstanceIdForCwd,
-  queueMessage,
+  chunkContent,
+  addMessagesBatched,
 } from "../cache.js";
 import { logHook, logApiCall, logCache, setLogContext } from "../log.js";
 import { visContextLine, visSkipMessage, addSystemMessage, verboseApiResult, verboseList } from "../visual.js";
@@ -132,41 +133,41 @@ export async function handleUserPrompt(): Promise<void> {
   logHook("user-prompt", `Prompt received (${prompt.length} chars)`);
   setSessionLink(honchoSessionUrl(config.workspace, sessionName), sessionName, hookInput.session_id);
 
-  // Queue user prompt for upload at session-end (instant, no network)
+  // Upload the prompt immediately, concurrent with context retrieval and
+  // awaited before each exit. Log-and-drop on failure, like stop.ts.
+  let uploadPromise: Promise<void> = Promise.resolve();
   if (config.saveMessages !== false) {
-    queueMessage(prompt, config.peerName, cwd, instanceId || undefined);
+    uploadPromise = postUserMessage(config, prompt, instanceId || undefined, sessionName)
+      .catch((e) => {
+        logHook("user-prompt", `Immediate upload failed: ${e}`);
+      });
   }
 
   // Track message count for threshold-based refresh
   const messageCountBefore = getMessageCount();
   incrementMessageCount();
 
-  // First prompt of the session: nudge the harness to actively call the honcho
-  // MCP tools (search/chat/get_context) rather than rely only on this passive
-  // injection. Injected once to respect a lean per-turn context budget.
+  // On the first prompt only, nudge active use of the honcho MCP tools
+  // (search/chat/get_context) instead of relying on this passive injection.
   if (messageCountBefore === 0) {
     sessionToolHint =
       `Honcho memory tools are available — call honcho.search(query) or honcho.get_context to recall ` +
       `facts about ${config.peerName} across sessions, and honcho.chat(question) for dialectic/` +
       `psychological questions. Prefer querying over guessing when the user's history is relevant.`;
   }
-  // Stagger the one-off banners so the first prompt isn't crowded. The
-  // version-update nag (if stale) takes the first message and bumps the GUI
-  // session link to the second; with no nag, the link shows on the first.
-  // The nag flag is written at SessionStart and stable for the session, so
-  // its presence on message 2 tells us the link hasn't been shown yet.
+  // Show each one-time banner once: nag on prompt 1, link right after (prompt 1,
+  // or 2 if the nag took prompt 1).
   const nag = readVersionNag();
-  const sessionLink =
-    messageCountBefore === 0
-      ? nag ?? formatSessionLink(honchoSessionUrl(config.workspace, sessionName))
-      : messageCountBefore === 1 && nag
-        ? formatSessionLink(honchoSessionUrl(config.workspace, sessionName))
-        : undefined;
+  const link = formatSessionLink(honchoSessionUrl(config.workspace, sessionName));
+  let sessionLink: string | undefined;
+  if (messageCountBefore === 0) sessionLink = nag ?? link;
+  else if (messageCountBefore === 1 && nag) sessionLink = link;
 
   // Skip trivial prompts — no context needed for "y", "ok", etc.
   if (shouldSkipContextRetrieval(prompt)) {
     logHook("user-prompt", "Skipping context (trivial prompt)");
     visSkipMessage("user-prompt", sessionLink ? `${sessionLink} · trivial prompt` : "trivial prompt");
+    await uploadPromise;
     process.exit(0);
   }
 
@@ -182,6 +183,7 @@ export async function handleUserPrompt(): Promise<void> {
     verboseList("peer.context() -> peerCard (cached)", cachedContext?.peerCard);
 
     serveContext(config.peerName, cachedContext, true, sessionLink);
+    await uploadPromise;
     process.exit(0);
   }
 
@@ -201,6 +203,7 @@ export async function handleUserPrompt(): Promise<void> {
     }
     if (context) {
       serveContext(config.peerName, context, false, sessionLink);
+      await uploadPromise;
       process.exit(0);
     }
   }
@@ -213,7 +216,45 @@ export async function handleUserPrompt(): Promise<void> {
   }
   // No cache at all — exit silently, context will arrive after session-start completes
 
+  await uploadPromise;
   process.exit(0);
+}
+
+/**
+ * Upload a user prompt. SessionStart already created the session/peers, so we
+ * build handles locally and skip the get-or-create round trips (1 hop, not 3).
+ * Falls back to the fluent path if the direct write fails.
+ */
+async function postUserMessage(
+  config: any,
+  prompt: string,
+  instanceId: string | undefined,
+  sessionName: string,
+): Promise<void> {
+  const honcho = new Honcho(getHonchoClientOptions(config));
+  const noEnsure = () => Promise.resolve();
+
+  const userPeer = new Peer(config.peerName, honcho.workspaceId, honcho.http, undefined, undefined, noEnsure);
+  const createdAt = new Date().toISOString();
+  const messages = chunkContent(prompt).map((chunk) =>
+    userPeer.message(chunk, {
+      createdAt,
+      metadata: {
+        instance_id: instanceId || undefined,
+        session_affinity: sessionName,
+      },
+    })
+  );
+
+  logApiCall("session.addMessages", "POST", `user prompt (${prompt.length} chars, ${messages.length} msg, direct)`);
+  try {
+    const session = new Session(sessionName, honcho.workspaceId, honcho.http, undefined, undefined, noEnsure);
+    await addMessagesBatched(session, messages);
+  } catch (e) {
+    logHook("user-prompt", `Direct upload failed, retrying via get-or-create: ${e}`);
+    const session = await honcho.session(sessionName);
+    await addMessagesBatched(session, messages);
+  }
 }
 
 /**
@@ -309,8 +350,7 @@ function formatCachedContext(context: any, peerName: string): { parts: string[];
   return { parts, conclusionCount };
 }
 
-// Set once per session (first prompt) to nudge active use of the honcho MCP
-// tools without taxing every turn's context budget.
+// Set once per session to nudge active use of the honcho MCP tools.
 let sessionToolHint = "";
 
 function outputContext(peerName: string, contextParts: string[], systemMsg?: string): void {


### PR DESCRIPTION
- post user prompts and assistant turns directly in the user-prompt/stop hooks; drop the local message-queue and session-end batch upload
- add addMessagesBatched helper to respect Honcho's 100-message batch cap
- capture all assistant messages in a turn, not just the last
- add opt-in saveToolUse flag (default off) for [Tool] summaries (didn't totally remove it becuase its possible it could be helpful) 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added `saveToolUse` to control whether tool-use activity is saved.
  - User prompts are now uploaded immediately (best-effort) instead of being queued for later.
  - Assistant messages from the current turn are saved live, capturing all relevant assistant text blocks with improved labeling.
- **Bug Fixes**
  - Improved large-message upload reliability using batching (max 100) and a retry path.
  - Session-end now sends only a single completion marker to avoid duplicate transcript uploads.
  - Stop-hook upload is skipped correctly when there is no preceding real user prompt.
- **Configuration**
  - `saveToolUse` can be set via config and `HONCHO_SAVE_TOOL_USE` environment variable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->