### PR TITLE
fix: build a search query for prompts not written in Latin script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to claude-honcho will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- Context retrieval for prompts not written in Latin script. `extractTopics` produced no search terms for a Persian, Japanese, Russian, etc. prompt, so `peer.context()` was called without a `searchQuery` and the user got the same generic most-frequent conclusions on every turn instead of recall relevant to what they just asked. Mixed-script prompts were worse than empty — a query built from the one or two Latin loanwords that happened to survive. These prompts now fall back to the prompt itself, which the embedding-based search handles directly.
+
 ## [0.2.5] - 2026-06-02
 
 ### Added

--- a/plugins/honcho/package.json
+++ b/plugins/honcho/package.json
@@ -14,6 +14,9 @@
   ],
   "author": "Plastic Labs",
   "license": "MIT",
+  "scripts": {
+    "test": "bun test"
+  },
   "dependencies": {
     "@honcho-ai/sdk": "^2.1.0",
     "@modelcontextprotocol/sdk": "^1.26.0"

--- a/plugins/honcho/src/hooks/user-prompt.test.ts
+++ b/plugins/honcho/src/hooks/user-prompt.test.ts
@@ -1,0 +1,52 @@
+import { expect, test } from "bun:test";
+import { extractTopics } from "./user-prompt.js";
+
+const query = (prompt: string) => extractTopics(prompt).join(" ");
+
+test("a prompt in a non-Latin script yields a query instead of nothing", () => {
+  // Persian: "check whether Honcho is writing memory properly"
+  expect(query("بررسی کن ببین هونچو داره حافظه رو درست مینویسه یا نه")).toBe(
+    "بررسی کن ببین هونچو داره حافظه رو درست مینویسه یا نه",
+  );
+  // Japanese, Russian — same path.
+  expect(query("認証フローのバグを修正して")).not.toBe("");
+  expect(query("почини баг в авторизации")).not.toBe("");
+});
+
+test("a mixed-script prompt keeps the whole question, not just the Latin crumbs", () => {
+  // Persian for "review branch X and push it if it's complete". The old word
+  // fallback returned ["production"], which searches for the wrong thing.
+  const prompt = "برنچ production رو ریویو کن و اگه کامل بود پوش کن";
+  expect(query(prompt)).toBe(prompt);
+});
+
+test("high-signal extractors still win over the whole-prompt fallback", () => {
+  // Persian for "open the file src/config.ts".
+  expect(extractTopics("فایل src/config.ts رو باز کن")).toEqual(["src/config.ts"]);
+});
+
+test("Latin-script prompts are unaffected", () => {
+  expect(extractTopics("why does the docker build fail for the api?")).toEqual([
+    "docker",
+    "api",
+  ]);
+  expect(extractTopics("rename the widget helper to something clearer")).toEqual([
+    "rename",
+    "widget",
+    "helper",
+    "something",
+    "clearer",
+  ]);
+  // Punctuation and emoji are not letters, so they don't trip the script check.
+  expect(extractTopics("ship it 🚀 — the caching layer is done")).toEqual([
+    "ship",
+    "caching",
+    "layer",
+    "done",
+  ]);
+});
+
+test("a long pasted prompt is capped rather than embedded whole", () => {
+  const prompt = "خطا: " + "x".repeat(2000);
+  expect(query(prompt).length).toBe(500);
+});

--- a/plugins/honcho/src/hooks/user-prompt.ts
+++ b/plugins/honcho/src/hooks/user-prompt.ts
@@ -34,11 +34,20 @@ const SKIP_CONTEXT_PATTERNS = [
 
 const FETCH_TIMEOUT_MS = 4000;
 
+// A letter from a writing system other than Latin: Persian, Arabic, Hebrew,
+// Cyrillic, Greek, CJK, and so on. Digits and punctuation are not letters,
+// so an ASCII prompt with an emoji or a curly quote does not match.
+const NON_LATIN_SCRIPT = /(?![\p{Script=Latin}])\p{L}/u;
+
+// Cap for a whole-prompt search query — long enough to carry the question,
+// short enough that a pasted stack trace doesn't become the embedding.
+const MAX_QUERY_CHARS = 500;
+
 /**
  * Extract meaningful topics from a prompt for semantic search.
  * Returns terms that are high-signal for conclusion matching.
  */
-function extractTopics(prompt: string): string[] {
+export function extractTopics(prompt: string): string[] {
   const topics: string[] = [];
 
   // File paths (high signal)
@@ -59,6 +68,15 @@ function extractTopics(prompt: string): string[] {
 
   if (topics.length > 0) {
     return [...new Set(topics)];
+  }
+
+  // The word fallback below only sees [a-z], so for a prompt written in another
+  // script it returns either nothing — dropping the caller into static context,
+  // where the user gets the same generic conclusions every turn — or a couple of
+  // stray loanwords that misrepresent the question. The search is embedding-based,
+  // so hand it the prompt itself instead.
+  if (NON_LATIN_SCRIPT.test(prompt)) {
+    return [prompt.trim().slice(0, MAX_QUERY_CHARS)];
   }
 
   // Fallback: meaningful words >3 chars minus stopwords


### PR DESCRIPTION
## Problem

`extractTopics` in `src/hooks/user-prompt.ts` recognizes only Latin text — file extensions, quoted strings, a hardcoded English tech-term list, and finally an `[a-z]{4,}` word fallback. A prompt written in Persian, Japanese, Russian, Greek, Chinese, etc. matches none of them, so the function returns `[]`, `handleUserPrompt` omits `searchQuery` from the `peer.context()` call, and the hook falls through to static context.

The practical effect for a non-English user is that memory stops being responsive: every turn injects the same generic most-frequent conclusions, no matter what was asked.

```ts
extractTopics("認証フローのバグを修正して")                      // []
extractTopics("почини баг в авторизации")                     // []
extractTopics("بررسی کن ببین هونچو داره حافظه رو مینویسه")      // []
```

Mixed-script prompts fail more quietly, which is worse — the query looks valid but describes the wrong thing:

```ts
// Persian for "review branch production and push it if it's complete"
extractTopics("برنچ production رو ریویو کن و اگه کامل بود پوش کن")  // ["production"]
```

I hit this on a self-hosted instance where the whole conversation is in Persian. Across two days, the plugin's `activity.log` recorded zero `search:` context calls — every one was `static context`.

## Change

If the prompt contains a letter from a non-Latin script, fall back to the prompt itself (capped at 500 chars) instead of the `[a-z]` word list. The search is embedding-based, so the raw prompt is a serviceable query — arguably a better one than a keyword bag.

```ts
const NON_LATIN_SCRIPT = /(?![\p{Script=Latin}])\p{L}/u;
```

Scoped deliberately:

- The high-signal extractors still run first, so `"فایل src/config.ts رو باز کن"` returns `["src/config.ts"]`, not the sentence.
- The check is on letters, so an ASCII prompt with an emoji or a curly quote is unaffected.
- Latin-script prompts take exactly the path they did before — no behavior change.

`extractTopics` is now exported so it can be tested.

## Tests

Added `src/hooks/user-prompt.test.ts` (bun's built-in runner, no new dependency) and a `test` script to `plugins/honcho/package.json`:

```bash
cd plugins/honcho && bun test
```

Five tests: non-Latin prompts produce a query, mixed-script prompts keep the whole question, the high-signal extractors still win, Latin prompts are byte-for-byte unchanged, and long prompts are capped. All pass; `tsc --noEmit` is clean.

## Verified live

Ran the patched hook against a self-hosted Honcho with a Persian prompt. The log line went from `GET userPeer.context → static context` to:

```
GET userPeer.context → search: وضعیت دیپلوی رنسانس و برنچ production چطوره؟
```

and the injected conclusions changed from the generic most-frequent set to ones matching the question.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved context retrieval for prompts written in non-Latin and mixed writing systems.
  * Preserved relevant full-prompt search context when topic extraction cannot identify specific terms.
  * Continued prioritizing high-signal details, such as file paths, when available.

* **Tests**
  * Added coverage for multilingual, mixed-script, Latin-script, and long prompts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->