### PR TITLE
fix: match trivial Bash commands by token, and see through wrappers

### DIFF
--- a/plugins/honcho/package.json
+++ b/plugins/honcho/package.json
@@ -14,6 +14,9 @@
   ],
   "author": "Plastic Labs",
   "license": "MIT",
+  "scripts": {
+    "test": "bun test"
+  },
   "dependencies": {
     "@honcho-ai/sdk": "^2.1.0",
     "@modelcontextprotocol/sdk": "^1.26.0"

--- a/plugins/honcho/src/hooks/post-tool-use.test.ts
+++ b/plugins/honcho/src/hooks/post-tool-use.test.ts
@@ -1,0 +1,32 @@
+import { expect, test } from "bun:test";
+import { isTrivialCommand } from "./post-tool-use.js";
+
+test("plain trivial commands are still filtered", () => {
+  for (const cmd of ["ls -a", "pwd", "cd /tmp", "git status --short", "git log --oneline -3"]) {
+    expect(isTrivialCommand(cmd)).toBe(true);
+  }
+});
+
+test("a wrapper in front does not smuggle a trivial command through", () => {
+  for (const cmd of ["rtk ls -a", "rtk git status --short", "sudo cat /etc/hosts", "time ls"]) {
+    expect(isTrivialCommand(cmd)).toBe(true);
+  }
+});
+
+test("real work is still logged", () => {
+  for (const cmd of ["npm run build", "rtk git commit -m x", "docker compose up -d", "pytest -q"]) {
+    expect(isTrivialCommand(cmd)).toBe(false);
+  }
+});
+
+test("a command that merely starts with a trivial one is not filtered", () => {
+  // The old startsWith check swallowed all of these as cd / cat / type / ls.
+  for (const cmd of ["cdk deploy", "catalog-build --all", "typescript-bundle", "lsof -i :3000"]) {
+    expect(isTrivialCommand(cmd)).toBe(false);
+  }
+});
+
+test("a bare wrapper is not mistaken for its argument", () => {
+  expect(isTrivialCommand("rtk")).toBe(false);
+  expect(isTrivialCommand("")).toBe(false);
+});

--- a/plugins/honcho/src/hooks/post-tool-use.ts
+++ b/plugins/honcho/src/hooks/post-tool-use.ts
@@ -13,6 +13,27 @@ interface HookInput {
   workspace_roots?: string[];
 }
 
+// Read-only / navigation commands that carry no memory signal.
+const TRIVIAL_COMMANDS = new Set([
+  "cd", "ls", "pwd", "echo", "cat", "head", "tail", "which", "type",
+  "git status", "git log", "git diff",
+]);
+
+// Wrappers that run the real command as their arguments, so `rtk git status`
+// is still `git status`. A user who routes every command through one of these
+// would otherwise defeat the list entirely and log all of it as real work.
+const COMMAND_WRAPPERS = new Set(["rtk", "sudo", "doas", "env", "time", "command", "nice"]);
+
+export function isTrivialCommand(command: string): boolean {
+  const tokens = command.trim().split(/\s+/);
+  while (tokens.length > 1 && COMMAND_WRAPPERS.has(tokens[0])) {
+    tokens.shift();
+  }
+  // Whole tokens, not a string prefix: `startsWith("cd")` also swallowed
+  // `cdk deploy`, and `startsWith("cat")` swallowed `catalog-build`.
+  return TRIVIAL_COMMANDS.has(tokens[0]) || TRIVIAL_COMMANDS.has(tokens.slice(0, 2).join(" "));
+}
+
 function shouldLogTool(toolName: string, toolInput: Record<string, any>): boolean {
   const significantTools = new Set(["Write", "Edit", "Bash", "Task", "NotebookEdit"]);
 
@@ -20,13 +41,8 @@ function shouldLogTool(toolName: string, toolInput: Record<string, any>): boolea
     return false;
   }
 
-  if (toolName === "Bash") {
-    const command = toolInput.command || "";
-    // Skip read-only / navigation commands that carry no memory signal.
-    const trivialCommands = ["cd", "ls", "pwd", "echo", "cat", "head", "tail", "which", "type", "git status", "git log", "git diff"];
-    if (trivialCommands.some((cmd) => command.trim().startsWith(cmd))) {
-      return false;
-    }
+  if (toolName === "Bash" && isTrivialCommand(toolInput.command || "")) {
+    return false;
   }
 
   return true;


### PR DESCRIPTION
## Problem

`shouldLogTool` in `src/hooks/post-tool-use.ts` filters out read-only Bash commands so they don't fill memory with noise. It tests the raw command string with `startsWith`, which fails in both directions.

**Wrappers defeat it completely.** Anything that runs the real command as its arguments — `rtk`, `sudo`, `doas`, `env`, `time` — shifts the command one token to the right, and then no entry in the list can match:

```ts
shouldLogTool("Bash", { command: "rtk git status --short" })  // true — stored as real work
shouldLogTool("Bash", { command: "sudo cat /etc/hosts" })     // true
shouldLogTool("Bash", { command: "time ls" })                 // true
```

I found this on an instance where every command goes through a token-optimizing proxy. **45% of all stored messages were tool logs**, and the bulk of them were `ls`, `read`, and `git status` — precisely what the list exists to drop. They are stored, embedded, and (with `observeMe` on) fed to the deriver.

**Prefix matching also drops real work.** A command whose name merely begins with a trivial one is silently discarded:

```ts
shouldLogTool("Bash", { command: "cdk deploy" })          // false — matched "cd"
shouldLogTool("Bash", { command: "catalog-build --all" }) // false — matched "cat"
shouldLogTool("Bash", { command: "lsof -i :3000" })       // false — matched "ls"
shouldLogTool("Bash", { command: "typescript-bundle" })   // false — matched "type"
```

A deploy via `cdk` never reaches memory.

## Change

Tokenize, strip a leading wrapper token, then compare **whole tokens** against the list (first token, or first two for the `git status` entries).

```ts
const COMMAND_WRAPPERS = new Set(["rtk", "sudo", "doas", "env", "time", "command", "nice"]);
```

The trivial-command list itself is unchanged. `isTrivialCommand` is exported so it can be tested directly.

## Tests

`src/hooks/post-tool-use.test.ts` (bun's built-in runner, no new dependency), plus a `test` script in `plugins/honcho/package.json`:

```bash
cd plugins/honcho && bun test
```

Five tests: plain trivial commands still filtered, wrappers no longer smuggle them through, real work still logged, near-miss names (`cdk`/`catalog-build`/`lsof`/`typescript-bundle`) no longer swallowed, and a bare wrapper isn't mistaken for its argument. `tsc --noEmit` is clean.

---

The `package.json` `test` script also appears in #74; whichever lands first, the other is a one-line rebase.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved filtering of trivial Bash commands so wrapped commands are handled consistently.
  * Prevented commands that merely share a prefix with a trivial command from being incorrectly filtered.
  * Ensured empty commands and standalone wrappers are handled correctly.

* **Tests**
  * Added automated coverage for trivial, wrapped, and non-trivial command classification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->