### PR TITLE
fix: let a declared session path own its subdirectories

### DIFF
--- a/plugins/honcho/package.json
+++ b/plugins/honcho/package.json
@@ -14,6 +14,9 @@
   ],
   "author": "Plastic Labs",
   "license": "MIT",
+  "scripts": {
+    "test": "bun test"
+  },
   "dependencies": {
     "@honcho-ai/sdk": "^2.1.0",
     "@modelcontextprotocol/sdk": "^1.26.0"

--- a/plugins/honcho/src/config.test.ts
+++ b/plugins/honcho/src/config.test.ts
@@ -1,0 +1,36 @@
+import { expect, test } from "bun:test";
+import { resolveSessionPath } from "./config.js";
+
+const sessions = {
+  "/Users/me": "home",
+  "/Users/me/work": "work",
+  "/Users/me/work/api": "api",
+};
+
+test("an exact declared path still wins", () => {
+  expect(resolveSessionPath(sessions, "/Users/me/work")).toBe("work");
+  expect(resolveSessionPath(sessions, "/Users/me/work/api")).toBe("api");
+});
+
+test("a subdirectory resolves to its declared root", () => {
+  expect(resolveSessionPath(sessions, "/Users/me/work/src/modules")).toBe("work");
+  expect(resolveSessionPath(sessions, "/Users/me/work/api/src")).toBe("api");
+});
+
+test("the nearest declared root wins, not the first or the shortest", () => {
+  expect(resolveSessionPath(sessions, "/Users/me/work/api/tests/unit")).toBe("api");
+});
+
+test("a sibling that merely shares a name prefix is not a parent", () => {
+  // "/Users/me/work" must not claim "/Users/me/workspace".
+  expect(resolveSessionPath(sessions, "/Users/me/workspace")).toBe("home");
+});
+
+test("a path outside every declared root is unmapped", () => {
+  expect(resolveSessionPath({ "/Users/me/work": "work" }, "/tmp/scratch")).toBeNull();
+  expect(resolveSessionPath({}, "/Users/me/work/src")).toBeNull();
+});
+
+test("a declared root with a trailing slash behaves the same", () => {
+  expect(resolveSessionPath({ "/Users/me/work/": "work" }, "/Users/me/work/src")).toBe("work");
+});

--- a/plugins/honcho/src/config.ts
+++ b/plugins/honcho/src/config.ts
@@ -628,10 +628,31 @@ export function getClaudeSettingsDir(): string {
   return join(homedir(), ".claude");
 }
 
+/** Longest declared path that is `cwd` or an ancestor of it. */
+export function resolveSessionPath(
+  sessions: Record<string, string>,
+  cwd: string,
+): string | null {
+  if (sessions[cwd]) return sessions[cwd];
+
+  // A declared root owns its subtree: work done in <project>/src belongs to
+  // <project>, not to a session named "src". Exact-match alone forks a session
+  // per subdirectory the user happens to launch from, and the memory for one
+  // project ends up scattered over "src", "scripts", "modules", ...
+  let best: string | null = null;
+  for (const root of Object.keys(sessions)) {
+    const prefix = root.endsWith("/") ? root : `${root}/`;
+    if (cwd.startsWith(prefix) && (best === null || root.length > best.length)) {
+      best = root;
+    }
+  }
+  return best ? sessions[best] : null;
+}
+
 export function getSessionForPath(cwd: string): string | null {
   const config = loadConfig();
   if (!config?.sessions) return null;
-  return config.sessions[cwd] || null;
+  return resolveSessionPath(config.sessions, cwd);
 }
 
 export function deriveSessionName(


### PR DESCRIPTION
## Problem

`getSessionForPath` looks up `config.sessions` by exact `cwd`:

```ts
return config.sessions[cwd] || null;
```

So a mapping only applies when Claude Code is launched from that precise directory. Start it one level down and the `per-directory` strategy falls through to `basename(cwd)` and silently mints a new session.

In practice this scatters one project's memory across sessions that are not projects at all. On my instance, after two days:

```
agora        340 messages   <- the mapped root
backoffice    86
honcho        65   <- .workspace/services/honcho
swagger-v2    14   <- apps/chatbot/.../swagger-v2
src           10   <- apps/chatbot/src
backups       10   <- .workspace/backups
scripts        4
core           2
chatbot        1
customerservice, entities, modules, root, selectfield  (0 after their content was moved)
```

Every one of those fragments belonged to a directory *under* a path already declared in `sessions`. It compounds: each new subdirectory you happen to `cd` into mints another session, and neither `search` scoped to a session nor the session summary sees the rest of the work.

## Change

Fall back to the longest declared path that is an ancestor of `cwd`.

```ts
export function resolveSessionPath(sessions: Record<string, string>, cwd: string): string | null
```

- Exact matches behave exactly as before — that branch is checked first.
- When declared roots nest (`~/work` and `~/work/api`), the **nearest** one wins.
- The prefix test is boundary-aware, so `/a/work` does not claim `/a/workspace`.
- A `cwd` outside every declared root still returns `null` and falls through to the existing strategy logic, so nothing changes for users who declare no `sessions`.

Split into a pure `resolveSessionPath(sessions, cwd)` so it's testable without touching config on disk; `getSessionForPath` is now a thin wrapper.

## Tests

`src/config.test.ts` (bun's built-in runner, no new dependency), plus a `test` script in `plugins/honcho/package.json`:

```bash
cd plugins/honcho && bun test
```

Six tests: exact match still wins, subdirectories resolve to their root, nearest root wins when roots nest, a name-prefix sibling is not treated as a parent, unmapped paths stay `null`, and a declared root with a trailing slash behaves the same.  `tsc --noEmit` is clean.

---

The `package.json` `test` script also appears in #74 and #75; whichever lands first, the others are a one-line rebase.
