### PR TITLE
feat honcho:import

### DIFF
--- a/plugins/honcho/skills/import/SKILL.md
+++ b/plugins/honcho/skills/import/SKILL.md
@@ -1,0 +1,73 @@
+---
+description: Import past local Claude Code sessions into Honcho memory (backfill history)
+user-invocable: true
+---
+
+# Honcho Import
+
+Backfill the user's existing local Claude Code session transcripts into Honcho so
+past work becomes apart of Honcho's memory. It uploads real conversation content, so it
+always previews first and requires explicit confirmation.
+
+Transcripts live at `~/.claude/projects/<cwd-as-dashes>/<session-uuid>.jsonl`. The
+importer reconstructs each conversation, names sessions using the user's configured
+`sessionStrategy`, and uploads with the original message timestamps into the user's
+configured workspace.
+
+## Prerequisite
+
+Honcho must already be configured (`HONCHO_API_KEY` set or `~/.honcho/config.json`
+present). If not, tell the user to run `/honcho:setup` first and stop here.
+
+## Optional arguments
+
+The user may specify scope in natural language; translate it to flags:
+- window → `--days N` (default 30)
+- a specific workspace → `--workspace NAME` (default: their configured workspace)
+
+## Steps
+
+### 1. Preview (safe — no upload)
+
+Run the importer in dry-run mode and show the user the plan:
+
+```bash
+bun run "${CLAUDE_PLUGIN_ROOT}/src/skills/backfill-runner.ts" --dry-run
+```
+
+If `CLAUDE_PLUGIN_ROOT` isn't set, the plugin lives here (find the version
+directory inside and run the importer from there):
+
+```bash
+echo "$HOME/.claude/plugins/cache/honcho/honcho"
+```
+
+Report the workspace, session count, and message count. Note that any sessions
+already imported are skipped automatically (the importer is idempotent).
+
+### 2. Confirm
+
+Ask the user to confirm before uploading. **Do not upload without an explicit yes**
+— this sends real conversation content to Honcho.
+
+### 3. Import
+
+On confirmation, run the real import (add `--days`/`--workspace` if the user asked):
+
+```bash
+bun run "${CLAUDE_PLUGIN_ROOT}/src/skills/backfill-runner.ts" --yes
+```
+
+### 4. Report
+
+Tell the user, honestly and without first-run/restart framing:
+
+> Imported <N> message(s) across <M> session(s) into `<workspace>`. Honcho will
+> start reasoning over them (no restart needed).
+
+Notes to relay if relevant:
+- Idempotent: already-imported transcripts are recorded in
+  `~/.honcho/backfill-state.json` and skipped on re-run, so it's safe to run again
+  (e.g. with a wider `--days` window) to pull in more history later.
+- Sessions are named by the configured `sessionStrategy`, so imported history lines
+  up with future live sessions.

--- a/plugins/honcho/skills/setup/SKILL.md
+++ b/plugins/honcho/skills/setup/SKILL.md
@@ -9,77 +9,52 @@ Walk the user through first-time Honcho configuration so persistent memory works
 
 ## Steps
 
-### 1. Check current state
+### 1. Validate the connection
 
-Check if `HONCHO_API_KEY` is set as an environment variable OR if `~/.honcho/config.json` already has an apiKey:
-
-```bash
-bun -e "
-const fs = require('fs');
-const path = require('path');
-const configPath = path.join(require('os').homedir(), '.honcho', 'config.json');
-const envKey = process.env.HONCHO_API_KEY;
-let configKey = '';
-try { configKey = JSON.parse(fs.readFileSync(configPath, 'utf-8')).apiKey || ''; } catch {}
-console.log(envKey || configKey ? 'set' : 'not set');
-"
-```
-
-If the output is `set`, skip to step 3 (validation). Otherwise continue.
-
-### 2. Direct user to set their API key
-
-Tell the user to get a free API key at https://app.honcho.dev, then set it as an environment variable.
-
-Detect the platform and give the appropriate command:
-
-**If Windows** (check with `bun -e "console.log(process.platform)"` if unsure):
-
-> Set your API key in PowerShell:
-> ```powershell
-> setx HONCHO_API_KEY "your-key-here"
-> ```
-> Then restart Claude Code and run `/honcho:setup` again.
-
-**If macOS / Linux:**
-
-> Add to your shell config (`~/.zshrc` or `~/.bashrc`):
-> ```
-> export HONCHO_API_KEY="your-key-here"
-> ```
-> Then restart Claude Code and run `/honcho:setup` again.
-
-IMPORTANT: Do NOT ask the user to paste their API key into the chat. Keys must be set via environment variable outside of Claude Code.
-
-Stop here and wait for the user to come back after restarting. Do not proceed to validation until the user runs `/honcho:setup` again.
-
-### 3. Validate the API key
-
-Run the setup runner to validate the connection:
+Run the setup runner. It's a committed script (`src/skills/setup-runner.ts`) that
+checks for an API key (env var, then `~/.honcho/config.json`), validates the
+connection, writes the config, and installs the memory statusLine:
 
 ```bash
 bun run "${CLAUDE_PLUGIN_ROOT}/src/skills/setup-runner.ts"
 ```
 
-If `CLAUDE_PLUGIN_ROOT` is not set, resolve the path:
+If `CLAUDE_PLUGIN_ROOT` isn't set, the plugin lives here (find the version
+directory inside and run the runner from there):
 
 ```bash
-bun -e "const h=require('os').homedir();const p=require('path');console.log(p.join(h,'.claude','plugins','cache','honcho','honcho'))"
+echo "$HOME/.claude/plugins/cache/honcho/honcho"
 ```
 
-Then find the version directory inside that path and run the setup runner from there.
+**If the runner reports "No API key found"**, it prints how to set one and exits.
+Relay that to the user:
 
-If it succeeds, the key is valid and the full config file has been created. The
-runner also installs the memory statusLine: it copies the renderer to
-`~/.honcho/honcho-statusline.sh` and registers it in `~/.claude/settings.json`
-(only when no `statusLine` is already configured — an existing one is left
-untouched and the path is printed for manual use). Toggle visibility later with
-the `statusline` key in `~/.honcho/config.json`: `on` (default) or `off`.
+- Get a free key at https://app.honcho.dev
+- **macOS / Linux:** add to `~/.zshrc` (or `~/.bashrc`): `export HONCHO_API_KEY="your-key-here"`
+- **Windows (PowerShell):** `setx HONCHO_API_KEY "your-key-here"`
+- Then restart Claude Code and run `/honcho:setup` again.
 
-If it fails, help the user troubleshoot:
-- Authentication error: key may be invalid, get a new one from https://app.honcho.dev
-- Network error: check internet connection
+Do NOT ask the user to paste their key into the chat — it must be set as an
+environment variable outside Claude Code. Stop here and wait for them to come back.
 
-### 4. Confirm setup
+**If the runner succeeds**, the key is valid and the config file has been created.
+The statusLine renderer is copied to `~/.honcho/honcho-statusline.sh` and registered
+in `~/.claude/settings.json` (only when no `statusLine` is already configured — an
+existing one is left untouched and the path is printed for manual use). Toggle
+visibility later with the `statusline` key in `~/.honcho/config.json`: `on`
+(default) or `off`.
+
+If it fails for another reason:
+- Authentication error: key may be invalid — get a new one at https://app.honcho.dev
+- Network error: check the internet connection
+
+### 2. Confirm setup
 
 Tell the user that Honcho is configured and memory will be active on their next session. Suggest they restart Claude Code to see the memory context load.
+
+If the setup runner (step 1) reported that past local sessions are available to
+import, mention it as an optional next step — do **not** import here. Point them to
+the dedicated command:
+
+> You also have past Claude Code sessions that can be imported into Honcho.
+> Run `/honcho:import` whenever you'd like to backfill them.

--- a/plugins/honcho/src/config.ts
+++ b/plugins/honcho/src/config.ts
@@ -559,6 +559,36 @@ export function getSessionForPath(cwd: string): string | null {
   return config.sessions[cwd] || null;
 }
 
+export function deriveSessionName(
+  strategy: SessionStrategy,
+  cwd: string,
+  opts: { peerName?: string; sessionPeerPrefix?: boolean; branch?: string; instanceId?: string } = {}
+): string {
+  const usePrefix = opts.sessionPeerPrefix !== false; // default true
+  const peerPart = opts.peerName ? sanitizeForSessionName(opts.peerName) : "user";
+  const repoPart = sanitizeForSessionName(basename(cwd));
+  const base = usePrefix ? `${peerPart}-${repoPart}` : repoPart;
+
+  switch (strategy) {
+    case "git-branch": {
+      if (opts.branch) {
+        const branchPart = sanitizeForSessionName(opts.branch);
+        return `${base}-${branchPart}`;
+      }
+      return base;
+    }
+    case "chat-instance": {
+      if (opts.instanceId) {
+        return usePrefix ? `${peerPart}-chat-${opts.instanceId}` : `chat-${opts.instanceId}`;
+      }
+      return base;
+    }
+    case "per-directory":
+    default:
+      return base;
+  }
+}
+
 /** Session name derived from strategy. Manual overrides only apply to per-directory.
  *  @param instanceId - Explicit instance ID for chat-instance strategy. Falls back to
  *                      per-cwd cache, then global cache. Callers should pass hookInput.session_id
@@ -577,32 +607,23 @@ export function getSessionName(cwd: string, instanceId?: string): string {
     }
   }
 
-  const usePrefix = config?.sessionPeerPrefix !== false; // default true
-  const peerPart = config?.peerName ? sanitizeForSessionName(config.peerName) : "user";
-  const repoPart = sanitizeForSessionName(basename(cwd));
-  const base = usePrefix ? `${peerPart}-${repoPart}` : repoPart;
-
-  switch (strategy) {
-    case "git-branch": {
-      const gitState = captureGitState(cwd);
-      if (gitState) {
-        const branchPart = sanitizeForSessionName(gitState.branch);
-        return `${base}-${branchPart}`;
-      }
-      return base;
-    }
-    case "chat-instance": {
-      // Prefer explicit instanceId > per-cwd cache > global cache (legacy)
-      const resolved = instanceId || getInstanceIdForCwd(cwd) || getClaudeInstanceId();
-      if (resolved) {
-        return usePrefix ? `${peerPart}-chat-${resolved}` : `chat-${resolved}`;
-      }
-      return base;
-    }
-    case "per-directory":
-    default:
-      return base;
+  // Resolve live env state, then delegate to the pure deriver.
+  let branch: string | undefined;
+  if (strategy === "git-branch") {
+    branch = captureGitState(cwd)?.branch;
   }
+  let resolvedInstanceId: string | undefined;
+  if (strategy === "chat-instance") {
+    // Prefer explicit instanceId > per-cwd cache > global cache (legacy)
+    resolvedInstanceId = instanceId || getInstanceIdForCwd(cwd) || getClaudeInstanceId() || undefined;
+  }
+
+  return deriveSessionName(strategy, cwd, {
+    peerName: config?.peerName,
+    sessionPeerPrefix: config?.sessionPeerPrefix,
+    branch,
+    instanceId: resolvedInstanceId,
+  });
 }
 
 export function setSessionForPath(cwd: string, sessionName: string): void {

--- a/plugins/honcho/src/skills/backfill-runner.ts
+++ b/plugins/honcho/src/skills/backfill-runner.ts
@@ -1,0 +1,305 @@
+#!/usr/bin/env bun
+/**
+ * Backfill runner — imports local Claude Code session transcripts into Honcho.
+ *
+ * Scans ~/.claude/projects/<dir>/<uuid>.jsonl within a recency window, rebuilds
+ * each conversation, names sessions with the same rules as the live hooks, and
+ * uploads with the original message timestamps.
+ *
+ * Usage:
+ *   bun run backfill-runner.ts [--days N] [--workspace NAME] [--dry-run] [--yes]
+ *   --days N          transcripts modified in the last N days (default 30)
+ *   --workspace NAME  target workspace (default: configured workspace)
+ *   --dry-run         print the plan without uploading
+ *   --yes             reserved; non-interactive, uploads unless --dry-run
+ */
+import { Honcho } from "@honcho-ai/sdk";
+import {
+  loadConfig,
+  getHonchoClientOptions,
+  getObservationMode,
+  deriveSessionName,
+  getConfigDir,
+  setDetectedHost,
+  type SessionStrategy,
+} from "../config.js";
+import { addMessagesBatched, chunkContent } from "../cache.js";
+import { parseTranscriptForBackfill, type ParsedMessage } from "./transcript-parse.js";
+import * as s from "../styles.js";
+import { homedir } from "os";
+import { join, basename } from "path";
+import { existsSync, readFileSync, writeFileSync, mkdirSync, readdirSync, statSync } from "fs";
+
+interface Args {
+  days: number;
+  workspace?: string;
+  dryRun: boolean;
+}
+
+function parseArgs(argv: string[]): Args {
+  const args: Args = { days: 30, dryRun: false };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === "--dry-run") args.dryRun = true;
+    else if (a === "--yes") { /* reserved, non-interactive */ }
+    else if (a === "--days") args.days = parseInt(argv[++i] ?? "30", 10) || 30;
+    else if (a.startsWith("--days=")) args.days = parseInt(a.slice("--days=".length), 10) || 30;
+    else if (a === "--workspace") args.workspace = argv[++i];
+    else if (a.startsWith("--workspace=")) args.workspace = a.slice("--workspace=".length);
+  }
+  return args;
+}
+
+const PROJECTS_DIR = join(homedir(), ".claude", "projects");
+const STATE_FILE = join(getConfigDir(), "backfill-state.json");
+
+/** Idempotency ledger: which (workspace, transcript@mtime) pairs already imported. */
+interface BackfillState {
+  imported: Record<string, number>; // key `${workspace}::${transcriptPath}` -> mtimeMs
+}
+
+function loadState(): BackfillState {
+  try {
+    return JSON.parse(readFileSync(STATE_FILE, "utf-8"));
+  } catch {
+    return { imported: {} };
+  }
+}
+
+function saveState(state: BackfillState): void {
+  if (!existsSync(getConfigDir())) mkdirSync(getConfigDir(), { recursive: true });
+  writeFileSync(STATE_FILE, JSON.stringify(state, null, 2));
+}
+
+/** All transcript files under ~/.claude/projects modified within `days`. */
+export function findTranscripts(days: number): Array<{ path: string; mtimeMs: number }> {
+  if (!existsSync(PROJECTS_DIR)) return [];
+  const cutoff = Date.now() - days * 24 * 60 * 60 * 1000;
+  const out: Array<{ path: string; mtimeMs: number }> = [];
+  for (const dir of readdirSync(PROJECTS_DIR)) {
+    const dirPath = join(PROJECTS_DIR, dir);
+    let entries: string[];
+    try {
+      if (!statSync(dirPath).isDirectory()) continue;
+      entries = readdirSync(dirPath);
+    } catch {
+      continue;
+    }
+    for (const file of entries) {
+      if (!file.endsWith(".jsonl")) continue;
+      const path = join(dirPath, file);
+      try {
+        const st = statSync(path);
+        if (st.mtimeMs >= cutoff) out.push({ path, mtimeMs: st.mtimeMs });
+      } catch {
+        continue;
+      }
+    }
+  }
+  return out;
+}
+
+interface SessionGroup {
+  name: string;
+  messages: Array<ParsedMessage & { sourceTranscript: string }>;
+}
+
+/** Group all messages into Honcho sessions, naming each via the configured strategy
+ *  and per-message cwd/branch (+ the transcript uuid for chat-instance). */
+export function groupIntoSessions(
+  transcripts: Array<{ path: string; mtimeMs: number }>,
+  strategy: SessionStrategy,
+  peerName: string | undefined,
+  sessionPeerPrefix: boolean | undefined,
+  sessionOverrides: Record<string, string> = {}
+): { groups: Map<string, SessionGroup>; parsed: number; empty: number } {
+  const groups = new Map<string, SessionGroup>();
+  let parsed = 0;
+  let empty = 0;
+
+  for (const { path } of transcripts) {
+    const { messages, cwd: tCwd, gitBranch: tBranch, sessionId } = parseTranscriptForBackfill(path);
+    if (messages.length === 0) {
+      empty++;
+      continue;
+    }
+    parsed++;
+    const source = basename(path);
+    for (const msg of messages) {
+      const cwd = msg.cwd || tCwd;
+      if (!cwd) continue; // can't name a session without a directory
+      // Honor manual per-directory overrides exactly as getSessionName() does,
+      // so backfilled sessions share names with future live sessions.
+      const name =
+        strategy === "per-directory" && sessionOverrides[cwd]
+          ? sessionOverrides[cwd]
+          : deriveSessionName(strategy, cwd, {
+              peerName,
+              sessionPeerPrefix,
+              branch: msg.gitBranch || tBranch,
+              instanceId: sessionId,
+            });
+      let group = groups.get(name);
+      if (!group) {
+        group = { name, messages: [] };
+        groups.set(name, group);
+      }
+      group.messages.push({ ...msg, sourceTranscript: source });
+    }
+  }
+  return { groups, parsed, empty };
+}
+
+async function run(): Promise<void> {
+  setDetectedHost("claude_code");
+  const args = parseArgs(process.argv.slice(2));
+
+  console.log("");
+  console.log(s.header("honcho backfill"));
+  console.log("");
+
+  const config = loadConfig();
+  if (!config) {
+    console.log(s.warn("No Honcho config found — run /honcho:setup first."));
+    process.exit(1);
+  }
+
+  const targetWorkspace = args.workspace || config.workspace;
+  const strategy: SessionStrategy = config.sessionStrategy ?? "per-directory";
+
+  console.log(`  ${s.label("Workspace")}:   ${targetWorkspace}${args.workspace ? s.dim("  (override)") : ""}`);
+  console.log(`  ${s.label("Strategy")}:    ${strategy}`);
+  console.log(`  ${s.label("Window")}:      last ${args.days} days`);
+  console.log(`  ${s.label("User peer")}:   ${config.peerName}`);
+  console.log(`  ${s.label("AI peer")}:     ${config.aiPeer}`);
+  console.log("");
+
+  // Discover + filter transcripts
+  const allTranscripts = findTranscripts(args.days);
+  const state = loadState();
+  const already = allTranscripts.filter((t) => state.imported[`${targetWorkspace}::${t.path}`] === t.mtimeMs);
+  const todo = allTranscripts.filter((t) => state.imported[`${targetWorkspace}::${t.path}`] !== t.mtimeMs);
+
+  console.log(s.section("Scanning transcripts"));
+  console.log(s.listItem(`${allTranscripts.length} transcript(s) in window`));
+  if (already.length > 0) {
+    console.log(s.listItem(s.dim(`${already.length} already imported into ${targetWorkspace} — skipping`)));
+  }
+  if (todo.length === 0) {
+    console.log("");
+    console.log(s.success("Nothing new to import."));
+    process.exit(0);
+  }
+
+  // Group into sessions
+  const { groups, parsed, empty } = groupIntoSessions(
+    todo,
+    strategy,
+    config.peerName,
+    config.sessionPeerPrefix,
+    config.sessions ?? {}
+  );
+  const totalMessages = [...groups.values()].reduce((n, g) => n + g.messages.length, 0);
+
+  console.log(s.listItem(`${parsed} transcript(s) with content${empty ? s.dim(` (${empty} empty, skipped)`) : ""}`));
+  console.log(s.listItem(`${groups.size} session(s), ${totalMessages} message(s) to upload`));
+  console.log("");
+
+  // Show a preview of session names + counts (cap the printed list)
+  console.log(s.section("Sessions"));
+  const sorted = [...groups.values()].sort((a, b) => b.messages.length - a.messages.length);
+  for (const g of sorted.slice(0, 15)) {
+    console.log(s.listItem(`${g.name} ${s.dim(`(${g.messages.length} msg)`)}`));
+  }
+  if (sorted.length > 15) console.log(s.listItem(s.dim(`… and ${sorted.length - 15} more`)));
+  console.log("");
+
+  if (args.dryRun) {
+    console.log(s.success("Dry run — no messages uploaded."));
+    process.exit(0);
+  }
+
+  // Upload
+  const opts = getHonchoClientOptions(config);
+  opts.workspaceId = targetWorkspace;
+  // Backfilling large histories: give the network more headroom than the hooks.
+  opts.timeout = 60_000;
+  opts.maxRetries = 3;
+  const honcho = new Honcho(opts);
+  const observationMode = getObservationMode(config);
+
+  console.log(s.section(`Uploading to ${targetWorkspace}`));
+
+  let uploadedSessions = 0;
+  let uploadedMessages = 0;
+  const errors: string[] = [];
+
+  for (const g of sorted) {
+    try {
+      const [session, userPeer, aiPeer] = await Promise.all([
+        honcho.session(g.name),
+        honcho.peer(config.peerName),
+        honcho.peer(config.aiPeer),
+      ]);
+
+      const peers: Parameters<typeof session.addPeers>[0] =
+        observationMode === "directional" ? [userPeer, [aiPeer, { observeOthers: true }]] : [userPeer, aiPeer];
+      await session.addPeers(peers);
+
+      const fallbackTs = new Date().toISOString();
+      const messages = g.messages.flatMap((m) => {
+        const peer = m.role === "user" ? userPeer : aiPeer;
+        return chunkContent(m.content).map((chunk) =>
+          peer.message(chunk, {
+            createdAt: m.timestamp || fallbackTs,
+            metadata: {
+              backfill: true,
+              source_transcript: m.sourceTranscript,
+              session_affinity: g.name,
+              type: m.role === "assistant"
+                ? (m.isResponse ? "assistant_response" : "assistant_intermediate")
+                : undefined,
+            },
+          })
+        );
+      });
+
+      await addMessagesBatched(session, messages);
+      uploadedSessions++;
+      uploadedMessages += g.messages.length;
+      console.log(s.listItem(s.success(`${g.name} ${s.dim(`(${g.messages.length} msg)`)}`)));
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      errors.push(`${g.name}: ${msg}`);
+      console.log(s.listItem(s.warn(`${g.name} — ${msg}`)));
+    }
+  }
+
+  // Only mark imported on a fully clean run; leave failures unmarked so a re-run retries.
+  if (errors.length === 0) {
+    for (const t of todo) {
+      state.imported[`${targetWorkspace}::${t.path}`] = t.mtimeMs;
+    }
+    saveState(state);
+  }
+
+  console.log("");
+  console.log(
+    s.success(
+      `Imported ${uploadedMessages} message(s) across ${uploadedSessions} session(s) into ${targetWorkspace}.`
+    )
+  );
+  if (errors.length > 0) {
+    console.log(s.warn(`${errors.length} session(s) failed — re-run to retry (not marked complete).`));
+  }
+  console.log("");
+}
+
+// Only auto-run when invoked directly; the guard lets other modules import
+// findTranscripts/groupIntoSessions without triggering an upload.
+if (import.meta.main) {
+  run().catch((err) => {
+    console.log(s.error(`Backfill failed: ${err instanceof Error ? err.message : String(err)}`));
+    process.exit(1);
+  });
+}

--- a/plugins/honcho/src/skills/setup-runner.ts
+++ b/plugins/honcho/src/skills/setup-runner.ts
@@ -151,8 +151,7 @@ async function setup(): Promise<void> {
 
   try {
     const honcho = new Honcho(getHonchoClientOptions(config));
-    const session = await honcho.session("setup-test");
-    const peer = await honcho.peer(config.peerName);
+    await honcho.workspaces();
     console.log(s.success("Connected to Honcho API"));
     console.log(`  ${s.label("Workspace")}: ${config.workspace}`);
     console.log(`  ${s.label("Peer")}:      ${config.peerName}`);
@@ -198,6 +197,20 @@ async function setup(): Promise<void> {
 
   installStatusline();
   console.log("");
+
+  // Report availability only — importing lives in /honcho:import.
+  try {
+    const { findTranscripts } = await import("./backfill-runner.js");
+    const transcripts = findTranscripts(30);
+    if (transcripts.length > 0) {
+      console.log(s.section("Import past sessions (optional)"));
+      console.log(s.listItem(`Found ${transcripts.length} local Claude Code session(s) from the last 30 days.`));
+      console.log(s.dim("  Run /honcho:import whenever you'd like to add your past work to Honcho."));
+      console.log("");
+    }
+  } catch {
+    // Non-fatal — the import is optional.
+  }
 
   console.log(s.success("Setup complete -- Honcho memory is ready"));
   console.log("");

--- a/plugins/honcho/src/skills/transcript-parse.ts
+++ b/plugins/honcho/src/skills/transcript-parse.ts
@@ -1,0 +1,129 @@
+/**
+ * Parse Claude Code session transcripts (`~/.claude/projects/<dir>/<uuid>.jsonl`)
+ * for the /honcho:import backfill.
+ */
+import { existsSync, readFileSync } from "fs";
+
+export interface TranscriptEntry {
+  type?: string;
+  role?: string;
+  timestamp?: string;
+  isMeta?: boolean;
+  isSidechain?: boolean;
+  cwd?: string;
+  gitBranch?: string;
+  sessionId?: string;
+  message?: {
+    role?: string;
+    content: string | Array<{ type: string; text?: string; name?: string; input?: unknown }>;
+  };
+  content?: string | Array<{ type: string; text?: string }>;
+}
+
+/** Ordered, cleaned message ready to upload. */
+export interface ParsedMessage {
+  role: "user" | "assistant";
+  content: string;
+  timestamp?: string;
+  /** Assistant only: last block of its turn (assistant_response vs assistant_intermediate). */
+  isResponse?: boolean;
+  /** Entry's env, used for session mapping. */
+  cwd?: string;
+  gitBranch?: string;
+}
+
+function entryType(entry: TranscriptEntry): string | undefined {
+  return entry.type || entry.role;
+}
+
+/** True for a real user-typed prompt. Excludes tool_results, isMeta entries, and `<...>` command caveats. */
+function isRealUserPrompt(entry: TranscriptEntry): boolean {
+  if (entry.isMeta) return false;
+  const mc = entry.message?.content ?? entry.content;
+  const text =
+    typeof mc === "string"
+      ? mc
+      : Array.isArray(mc)
+        ? mc.filter((b) => b.type === "text" && b.text).map((b) => b.text!).join("")
+        : "";
+  const trimmed = text.trim();
+  return trimmed.length > 0 && !trimmed.startsWith("<");
+}
+
+function userText(entry: TranscriptEntry): string {
+  const mc = entry.message?.content ?? entry.content;
+  if (typeof mc === "string") return mc;
+  if (Array.isArray(mc)) return mc.filter((p) => p.type === "text").map((p) => p.text || "").join("\n");
+  return "";
+}
+
+function assistantText(entry: TranscriptEntry): string {
+  const mc = entry.message?.content ?? entry.content;
+  if (typeof mc === "string") return mc;
+  if (Array.isArray(mc)) return mc.filter((p) => p.type === "text" && p.text).map((p) => p.text!).join("\n\n");
+  return "";
+}
+
+function readLines(transcriptPath: string): string[] {
+  if (!transcriptPath || !existsSync(transcriptPath)) return [];
+  try {
+    return readFileSync(transcriptPath, "utf-8").split("\n").filter((line) => line.trim());
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Full-conversation parse: user + assistant messages in order, each with its
+ * timestamp and the cwd/gitBranch for session mapping. Skips isMeta / isSidechain
+ * / tool-result-only / `<...>` command caveats.
+ */
+export function parseTranscriptForBackfill(transcriptPath: string): {
+  messages: ParsedMessage[];
+  cwd?: string;
+  gitBranch?: string;
+  sessionId?: string;
+} {
+  const messages: ParsedMessage[] = [];
+  let cwd: string | undefined;
+  let gitBranch: string | undefined;
+  let sessionId: string | undefined;
+
+  for (const line of readLines(transcriptPath)) {
+    let entry: TranscriptEntry;
+    try {
+      entry = JSON.parse(line);
+    } catch {
+      continue;
+    }
+    // Track the latest environment seen — used to name the session.
+    if (entry.cwd) cwd = entry.cwd;
+    if (entry.gitBranch) gitBranch = entry.gitBranch;
+    if (entry.sessionId) sessionId = entry.sessionId;
+
+    if (entry.isMeta || entry.isSidechain) continue;
+    const type = entryType(entry);
+
+    if (type === "user") {
+      if (!isRealUserPrompt(entry)) continue;
+      const content = userText(entry).trim();
+      if (content) {
+        messages.push({ role: "user", content, timestamp: entry.timestamp, cwd: entry.cwd, gitBranch: entry.gitBranch });
+      }
+    } else if (type === "assistant") {
+      const content = assistantText(entry).trim();
+      if (content) {
+        messages.push({ role: "assistant", content, timestamp: entry.timestamp, cwd: entry.cwd, gitBranch: entry.gitBranch });
+      }
+    }
+  }
+
+  // Last assistant block of a turn = response, earlier ones = intermediate.
+  for (let i = 0; i < messages.length; i++) {
+    if (messages[i].role !== "assistant") continue;
+    const next = messages[i + 1];
+    messages[i].isResponse = !next || next.role === "user";
+  }
+
+  return { messages, cwd, gitBranch, sessionId };
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an optional `/honcho:import` workflow to backfill recent Claude Code sessions into Honcho memory.
  - Added dry-run previews, confirmation before upload, time and workspace filtering, and retry-safe importing.
  - Setup now validates the Honcho connection and detects available sessions for optional import.
  - Imported sessions preserve timestamps and align with ongoing session naming.

- **Documentation**
  - Added guidance for importing existing sessions and updated setup instructions with troubleshooting steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->