### PR TITLE
feat(honcho): composable, config-driven memory injection

### DIFF
--- a/plugins/honcho/skills/config/SKILL.md
+++ b/plugins/honcho/skills/config/SKILL.md
@@ -39,7 +39,7 @@ AskUserQuestion:
     - label: "Workspace"
       description: "Data space and session scope (currently: {resolved.workspace})"
     - label: "Memory injection"
-      description: "What Honcho injects at session start and per turn (currently: start [{injection.sessionStart}], turn [{injection.perTurn}])"
+      description: "What Honcho injects at session start and per turn (currently: start [{resolved.injection.sessionStart}], turn [{resolved.injection.perTurn}])"
 ```
 
 For the "Memory injection" description, use the *effective* values: if `injection.sessionStart` is unset it is `["summary", "peerCard"]`, and if `injection.perTurn` is unset it is `["context"]` (conclusions on).
@@ -150,24 +150,25 @@ If confirmed, call `set_config` again WITH `confirm: true`.
 
 Ask BOTH questions in a SINGLE `AskUserQuestion` call — two multi-select questions — so the user configures both surfaces at once. This is the only injection prompt; do not add follow-ups.
 
-```
-AskUserQuestion (both questions multiSelect: true):
-  Q1:
-    question: "What should Honcho inject at the start of each session?"
-    header: "Session start"
-    options:
-      - label: "Session summary"
-        description: "Rolling long summary of prior sessions"
-      - label: "Peer card"
-        description: "Your identity + attributes list"
-      - label: "Representation"
-        description: "Honcho's derived prose profile of you"
-  Q2:
-    question: "What should Honcho inject on each user turn?"
-    header: "Per turn"
-    options:
-      - label: "Relevant conclusions"
-        description: "Fresh, prompt-scoped memory pulled every turn"
+```yaml
+AskUserQuestion:
+  questions:
+    - question: "What should Honcho inject at the start of each session?"
+      header: "On start"          # ≤12 chars
+      multiSelect: true
+      options:
+        - label: "Session summary"
+          description: "Rolling long summary of prior sessions"
+        - label: "Peer card"
+          description: "Your identity + attributes list"
+        - label: "Representation"
+          description: "Honcho's derived prose profile of you"
+    - question: "What should Honcho inject on each user turn?"
+      header: "Per turn"
+      multiSelect: true
+      options:
+        - label: "Relevant conclusions"
+          description: "Fresh, prompt-scoped memory pulled every turn"
 ```
 
 Map the selections to component names, then call `set_config` once per surface:

--- a/plugins/honcho/skills/config/SKILL.md
+++ b/plugins/honcho/skills/config/SKILL.md
@@ -38,7 +38,11 @@ AskUserQuestion:
       description: "How sessions are named — per directory, git branch, or per chat (currently: {resolved.sessionStrategy})"
     - label: "Workspace"
       description: "Data space and session scope (currently: {resolved.workspace})"
+    - label: "Memory injection"
+      description: "What Honcho injects at session start and per turn (currently: start [{injection.sessionStart}], turn [{injection.perTurn}])"
 ```
+
+For the "Memory injection" description, use the *effective* values: if `injection.sessionStart` is unset it is `[]` (nothing), and if `injection.perTurn` is unset it is `["context"]` (conclusions on).
 
 If the user selects "Other", present advanced options:
 
@@ -141,6 +145,38 @@ AskUserQuestion:
 ```
 
 If confirmed, call `set_config` again WITH `confirm: true`.
+
+### Memory injection
+
+Ask BOTH questions in a SINGLE `AskUserQuestion` call — two multi-select questions — so the user configures both surfaces at once. This is the only injection prompt; do not add follow-ups.
+
+```
+AskUserQuestion (both questions multiSelect: true):
+  Q1:
+    question: "What should Honcho inject at the start of each session?"
+    header: "Session start"
+    options:
+      - label: "Session summary"
+        description: "Rolling long summary of prior sessions"
+      - label: "Peer card"
+        description: "Your identity + attributes list"
+      - label: "Representation"
+        description: "Honcho's derived prose profile of you"
+  Q2:
+    question: "What should Honcho inject on each user turn?"
+    header: "Per turn"
+    options:
+      - label: "Relevant conclusions"
+        description: "Fresh, prompt-scoped memory pulled every turn"
+```
+
+Map the selections to component names, then call `set_config` once per surface:
+- Session start → `injection.sessionStart`, mapping "Session summary"→`summary`, "Peer card"→`peerCard`, "Representation"→`peerRepresentation`.
+- Per turn → `injection.perTurn`, mapping "Relevant conclusions"→`context`.
+
+Pass the value as a JSON array (e.g. `["summary","peerCard"]`). An empty selection for a surface means "inject nothing" there — pass `[]`.
+
+Retrieval tuning is intentionally NOT asked here. `injection.searchTopK` (default 10), `injection.maxConclusions` (15), and `injection.searchMaxDistance` (0.4, cosine — lower is stricter) are all configurable via `set_config`, but keep the defaults; only mention they're tunable if the user brings it up, and never prompt for them.
 
 ### Dangerous fields (Host)
 

--- a/plugins/honcho/skills/config/SKILL.md
+++ b/plugins/honcho/skills/config/SKILL.md
@@ -177,7 +177,7 @@ Map the selections to component names, then call `set_config` once per surface:
 
 Pass the value as a JSON array (e.g. `["summary","peerCard"]`). An empty selection for a surface means "inject nothing" there — pass `[]`.
 
-Retrieval tuning is intentionally NOT asked here. `injection.searchTopK` (default 10), `injection.maxConclusions` (15), and `injection.searchMaxDistance` (0.4, cosine — lower is stricter) are all configurable via `set_config`, but keep the defaults; only mention they're tunable if the user brings it up, and never prompt for them.
+Retrieval tuning is intentionally NOT asked here. `injection.searchTopK` (default 10), `injection.maxConclusions` (15), `injection.searchMaxDistance` (0.6, cosine — lower is stricter), and `injection.searchQuerySource` ("prompt" | "topics", default "prompt") are all configurable via `set_config`, but keep the defaults; only mention they're tunable if the user brings it up, and never prompt for them.
 
 ### Dangerous fields (Host)
 

--- a/plugins/honcho/skills/config/SKILL.md
+++ b/plugins/honcho/skills/config/SKILL.md
@@ -42,7 +42,7 @@ AskUserQuestion:
       description: "What Honcho injects at session start and per turn (currently: start [{injection.sessionStart}], turn [{injection.perTurn}])"
 ```
 
-For the "Memory injection" description, use the *effective* values: if `injection.sessionStart` is unset it is `[]` (nothing), and if `injection.perTurn` is unset it is `["context"]` (conclusions on).
+For the "Memory injection" description, use the *effective* values: if `injection.sessionStart` is unset it is `["summary", "peerCard"]`, and if `injection.perTurn` is unset it is `["context"]` (conclusions on).
 
 If the user selects "Other", present advanced options:
 

--- a/plugins/honcho/src/cache.ts
+++ b/plugins/honcho/src/cache.ts
@@ -121,23 +121,17 @@ interface ContextCache {
   claudeContext?: { data: any; fetchedAt: number };
   summaries?: { data: any; fetchedAt: number };
   messageCount?: number; // Track messages since last refresh
-  lastRefreshMessageCount?: number; // Message count at last knowledge graph refresh
 }
 
-// These are now configurable via config.json, with defaults in getContextRefreshConfig()
+// Now configurable via config.json, with defaults in getContextRefreshConfig()
 function getContextTTL(): number {
   const config = getContextRefreshConfig();
   return (config.ttlSeconds ?? 300) * 1000; // Convert to ms
 }
 
-function getMessageRefreshThreshold(): number {
-  const config = getContextRefreshConfig();
-  return config.messageThreshold ?? 50;
-}
-
 // Known keys in ContextCache — anything else is a ghost from older versions
 const CONTEXT_CACHE_KNOWN_KEYS = new Set([
-  "userContext", "claudeContext", "summaries", "messageCount", "lastRefreshMessageCount",
+  "userContext", "claudeContext", "summaries", "messageCount",
 ]);
 
 export function loadContextCache(): ContextCache {
@@ -169,26 +163,6 @@ export function saveContextCache(cache: ContextCache): void {
   writeFileSync(CONTEXT_CACHE_FILE, JSON.stringify(cache, null, 2));
 }
 
-export function getCachedUserContext(): any | null {
-  const cache = loadContextCache();
-  if (cache.userContext && Date.now() - cache.userContext.fetchedAt < getContextTTL()) {
-    return cache.userContext.data;
-  }
-  return null;
-}
-
-/** Return cached context even if expired (for timeout fallback) */
-export function getStaleCachedUserContext(): any | null {
-  const cache = loadContextCache();
-  return cache.userContext?.data ?? null;
-}
-
-export function setCachedUserContext(data: any): void {
-  const cache = loadContextCache();
-  cache.userContext = { data, fetchedAt: Date.now() };
-  saveContextCache(cache);
-}
-
 export function getCachedClaudeContext(): any | null {
   const cache = loadContextCache();
   if (cache.claudeContext && Date.now() - cache.claudeContext.fetchedAt < getContextTTL()) {
@@ -201,12 +175,6 @@ export function setCachedClaudeContext(data: any): void {
   const cache = loadContextCache();
   cache.claudeContext = { data, fetchedAt: Date.now() };
   saveContextCache(cache);
-}
-
-export function isContextCacheStale(): boolean {
-  const cache = loadContextCache();
-  if (!cache.userContext) return true;
-  return Date.now() - cache.userContext.fetchedAt >= getContextTTL();
 }
 
 // Track message count for threshold-based refresh
@@ -222,25 +190,9 @@ export function getMessageCount(): number {
   return cache.messageCount || 0;
 }
 
-export function shouldRefreshKnowledgeGraph(): boolean {
-  const cache = loadContextCache();
-  const currentCount = cache.messageCount || 0;
-  const lastRefresh = cache.lastRefreshMessageCount || 0;
-
-  // Refresh if we've sent threshold messages since last refresh
-  return (currentCount - lastRefresh) >= getMessageRefreshThreshold();
-}
-
-export function markKnowledgeGraphRefreshed(): void {
-  const cache = loadContextCache();
-  cache.lastRefreshMessageCount = cache.messageCount || 0;
-  saveContextCache(cache);
-}
-
 export function resetMessageCount(): void {
   const cache = loadContextCache();
   cache.messageCount = 0;
-  cache.lastRefreshMessageCount = 0;
   saveContextCache(cache);
 }
 
@@ -294,50 +246,6 @@ export function appendClaudeWork(workDescription: string): void {
   }
 
   saveClaudeLocalContext(existing + entry);
-}
-
-export function generateClaudeSummary(
-  sessionName: string,
-  workItems: string[],
-  assistantMessages: string[]
-): string {
-  const timestamp = new Date().toISOString();
-
-  // Extract key actions from assistant messages
-  const actions: string[] = [];
-  for (const msg of assistantMessages.slice(-10)) {
-    // Look for action indicators
-    if (msg.includes("Created") || msg.includes("Updated") || msg.includes("Fixed")) {
-      const firstSentence = msg.split(/[.!?\n]/)[0];
-      if (firstSentence.length < 200) {
-        actions.push(firstSentence);
-      }
-    }
-  }
-
-  let summary = `# CLAUDE Work Context
-
-Last updated: ${timestamp}
-Session: ${sessionName}
-
-## What CLAUDE Was Working On
-
-`;
-
-  if (workItems.length > 0) {
-    summary += workItems.map((w) => `- ${w}`).join("\n");
-    summary += "\n\n";
-  }
-
-  if (actions.length > 0) {
-    summary += "## Recent Actions\n\n";
-    summary += actions.slice(-10).map((a) => `- ${a}`).join("\n");
-    summary += "\n\n";
-  }
-
-  summary += "## Recent Activity\n";
-
-  return summary;
 }
 
 // ============================================

--- a/plugins/honcho/src/cache.ts
+++ b/plugins/honcho/src/cache.ts
@@ -131,7 +131,7 @@ function getContextTTL(): number {
 
 // Known keys in ContextCache — anything else is a ghost from older versions
 const CONTEXT_CACHE_KNOWN_KEYS = new Set([
-  "userContext", "claudeContext", "summaries", "messageCount",
+  "claudeContext", "summaries", "messageCount",
 ]);
 
 export function loadContextCache(): ContextCache {

--- a/plugins/honcho/src/config.ts
+++ b/plugins/honcho/src/config.ts
@@ -66,7 +66,7 @@ export type PerTurnComponent = (typeof PER_TURN_COMPONENTS)[number];
  * components; the retrieval knobs shape whatever those components emit.
  */
 export interface InjectionConfig {
-  /** Components emitted once at session open (default: []). */
+  /** Components emitted once at session open (default: ["summary", "peerCard"]). */
   sessionStart?: SessionStartComponent[];
   /** Components emitted per non-trivial prompt (default: ["context"]). */
   perTurn?: PerTurnComponent[];
@@ -79,12 +79,13 @@ export interface InjectionConfig {
   searchMaxDistance?: number;
 }
 
-/** Resolved injection defaults: nothing at session start, a fresh context()
- *  per turn. Retrieval knobs are tuned for a lean, high-precision per-turn
- *  block — topK 10 (up from the old literal 5) for recall, and a tight 0.4
- *  cosine distance (down from 0.7) to cut low-relevance conclusions. */
+/** Resolved injection defaults: session summary + peer card at session start,
+ *  a fresh context() per turn. Retrieval knobs are tuned for a lean,
+ *  high-precision per-turn block — topK 10 (up from the old literal 5) for
+ *  recall, and a tight 0.4 cosine distance (down from 0.7) to cut
+ *  low-relevance conclusions. */
 export const DEFAULT_INJECTION: Required<InjectionConfig> = {
-  sessionStart: [],
+  sessionStart: ["summary", "peerCard"],
   perTurn: ["context"],
   searchTopK: 10,
   maxConclusions: 15,

--- a/plugins/honcho/src/config.ts
+++ b/plugins/honcho/src/config.ts
@@ -77,6 +77,9 @@ export interface InjectionConfig {
   /** Max cosine distance for context()'s semantic search — lower is stricter
    *  (default: 0.4). */
   searchMaxDistance?: number;
+  /** What drives the per-turn semantic search: extracted "topics" (default)
+   *  or the raw "prompt". */
+  searchQuerySource?: "topics" | "prompt";
 }
 
 /** Resolved injection defaults: session summary + peer card at session start,
@@ -90,6 +93,7 @@ export const DEFAULT_INJECTION: Required<InjectionConfig> = {
   searchTopK: 10,
   maxConclusions: 15,
   searchMaxDistance: 0.4,
+  searchQuerySource: "topics",
 };
 
 export type ReasoningLevel = "minimal" | "low" | "medium" | "high" | "max";

--- a/plugins/honcho/src/config.ts
+++ b/plugins/honcho/src/config.ts
@@ -75,25 +75,24 @@ export interface InjectionConfig {
   /** Max conclusions injected per context() call (default: 15). */
   maxConclusions?: number;
   /** Max cosine distance for context()'s semantic search — lower is stricter
-   *  (default: 0.4). */
+   *  (default: 0.6). */
   searchMaxDistance?: number;
-  /** What drives the per-turn semantic search: extracted "topics" (default)
-   *  or the raw "prompt". */
+  /** What drives the per-turn semantic search: the raw "prompt" (default)
+   *  or extracted "topics". */
   searchQuerySource?: "topics" | "prompt";
 }
 
 /** Resolved injection defaults: session summary + peer card at session start,
- *  a fresh context() per turn. Retrieval knobs are tuned for a lean,
- *  high-precision per-turn block — topK 10 (up from the old literal 5) for
- *  recall, and a tight 0.4 cosine distance (down from 0.7) to cut
- *  low-relevance conclusions. */
+ *  a fresh context() per turn. Retrieval knobs are tuned for a lean per-turn
+ *  block — topK 10 for recall, a 0.6 cosine distance, searching on the raw
+ *  prompt. */
 export const DEFAULT_INJECTION: Required<InjectionConfig> = {
   sessionStart: ["summary", "peerCard"],
   perTurn: ["context"],
   searchTopK: 10,
   maxConclusions: 15,
-  searchMaxDistance: 0.4,
-  searchQuerySource: "topics",
+  searchMaxDistance: 0.6,
+  searchQuerySource: "prompt",
 };
 
 export type ReasoningLevel = "minimal" | "low" | "medium" | "high" | "max";

--- a/plugins/honcho/src/config.ts
+++ b/plugins/honcho/src/config.ts
@@ -31,6 +31,66 @@ export interface LocalContextConfig {
   maxEntries?: number;
 }
 
+// ============================================
+// Composable injection (DEV-2088 + DEV-2024)
+// ============================================
+
+/**
+ * Components the SessionStart hook may emit once per session. The tuple is the
+ * single source of truth: the union type derives from it, and set_config
+ * validation builds its allow-set and error text from the same array — so
+ * adding a component is a one-line edit with no drift between layers.
+ * - "summary": the SDK `session.summaries().long` narrative.
+ * - "peerCard" / "peerRepresentation": the two fields of a single context() call,
+ *   each injected at full length (no per-field caps — inclusion is the only lever).
+ */
+export const SESSION_START_COMPONENTS = ["summary", "peerCard", "peerRepresentation"] as const;
+export type SessionStartComponent = (typeof SESSION_START_COMPONENTS)[number];
+
+/**
+ * Components the UserPromptSubmit hook may emit per non-trivial prompt.
+ * - "context": a fresh, prompt-scoped context() blob (representation + peerCard),
+ *   whose semantic retrieval is shaped by the searchTopK/searchMaxDistance/
+ *   maxConclusions knobs below.
+ *
+ * A "search" component (filtered semantic search over inductive conclusions)
+ * was scoped out: `level` is not filterable through the API, so it needs a
+ * honcho-backend + SDK change before it can ship. See the plan.
+ */
+export const PER_TURN_COMPONENTS = ["context"] as const;
+export type PerTurnComponent = (typeof PER_TURN_COMPONENTS)[number];
+
+/**
+ * The `injection` config block: turns the two hardcoded injection surfaces
+ * into a composable, config-driven menu. Each surface selects zero or more
+ * components; the retrieval knobs shape whatever those components emit.
+ */
+export interface InjectionConfig {
+  /** Components emitted once at session open (default: []). */
+  sessionStart?: SessionStartComponent[];
+  /** Components emitted per non-trivial prompt (default: ["context"]). */
+  perTurn?: PerTurnComponent[];
+  /** Top-K conclusions pulled by context()'s semantic search (default: 10). */
+  searchTopK?: number;
+  /** Max conclusions injected per context() call (default: 15). */
+  maxConclusions?: number;
+  /** Max cosine distance for context()'s semantic search — lower is stricter
+   *  (default: 0.4). */
+  searchMaxDistance?: number;
+}
+
+/** Resolved injection defaults: nothing at session start, a fresh context()
+ *  per turn. Retrieval knobs are tuned for a lean, high-precision per-turn
+ *  block — topK 10 (up from the old literal 5) for recall, and a tight 0.4
+ *  cosine distance (down from 0.7) to cut low-relevance conclusions. */
+export const DEFAULT_INJECTION: Required<InjectionConfig> = {
+  sessionStart: [],
+  perTurn: ["context"],
+  searchTopK: 10,
+  maxConclusions: 15,
+  searchMaxDistance: 0.4,
+};
+
 export type ReasoningLevel = "minimal" | "low" | "medium" | "high" | "max";
 
 export type SessionStrategy = "per-directory" | "git-branch" | "chat-instance";
@@ -91,6 +151,8 @@ export interface HostConfig {
   contextRefresh?: ContextRefreshConfig;
   localContext?: LocalContextConfig;
   endpoint?: HonchoEndpointConfig;
+  /** Composable injection config (session-start + per-turn component menus). */
+  injection?: InjectionConfig;
 }
 
 let _detectedHost: HonchoHost | null = null;
@@ -189,6 +251,8 @@ interface HonchoFileConfig {
   observationMode?: ObservationMode;
   /** Memory statusLine visibility: "on" (default) · "off" */
   statusline?: StatuslineMode;
+  /** Composable injection config (session-start + per-turn component menus). */
+  injection?: InjectionConfig;
   hosts?: Record<string, HostConfig>;
   /** When true, flat workspace/aiPeer fields apply to ALL hosts,
    *  ignoring host-specific blocks. When false (default), each host
@@ -240,6 +304,8 @@ export interface HonchoCLAUDEConfig {
   endpoint?: HonchoEndpointConfig;
   /** Local claude-context.md settings */
   localContext?: LocalContextConfig;
+  /** Composable injection config (session-start + per-turn component menus) */
+  injection?: InjectionConfig;
   /** Temporarily disable plugin (default: true) */
   enabled?: boolean;
   /** Enable file logging to ~/.honcho/ (default: true) */
@@ -351,6 +417,7 @@ function resolveConfig(raw: HonchoFileConfig, host: HonchoHost): HonchoCLAUDECon
     contextRefresh: hostBlock?.contextRefresh ?? raw.contextRefresh,
     endpoint: hostBlock?.endpoint ?? raw.endpoint,
     localContext: hostBlock?.localContext ?? raw.localContext,
+    injection: hostBlock?.injection ?? raw.injection,
     enabled: hostBlock?.enabled ?? raw.enabled,
     logging: hostBlock?.logging ?? raw.logging,
     globalOverride: raw.globalOverride,
@@ -510,6 +577,7 @@ export function saveConfig(config: HonchoCLAUDEConfig): void {
   setHostIfExplicit("contextRefresh", config.contextRefresh, existing.contextRefresh);
   setHostIfExplicit("localContext", config.localContext, existing.localContext);
   setHostIfExplicit("endpoint", config.endpoint, existing.endpoint);
+  setHostIfExplicit("injection", config.injection, existing.injection);
 
   // Preserve a host-scoped apiKey already on disk. This integration never writes
   // apiKey (config.apiKey is the *resolved* key — env/root — and must not be
@@ -650,6 +718,20 @@ export function getLocalContextConfig(): LocalContextConfig {
   return {
     maxEntries: config?.localContext?.maxEntries ?? 50,
   };
+}
+
+/**
+ * Resolved injection config with every field defaulted. Callers get a fully
+ * populated object so they never repeat the fallback literals. Config comes
+ * from parsed JSON, so absent keys simply don't appear — the spread over
+ * DEFAULT_INJECTION defaults them, while an explicit `[]` is preserved.
+ *
+ * Pass the already-loaded config (hooks have it in scope) to avoid a second
+ * disk read + parse on the per-turn hot path; omit it for a standalone lookup.
+ */
+export function getInjectionConfig(config?: HonchoCLAUDEConfig | null): Required<InjectionConfig> {
+  const injection = (config === undefined ? loadConfig() : config)?.injection;
+  return { ...DEFAULT_INJECTION, ...(injection ?? {}) };
 }
 
 export function isLoggingEnabled(): boolean {

--- a/plugins/honcho/src/hooks/session-end.ts
+++ b/plugins/honcho/src/hooks/session-end.ts
@@ -2,9 +2,6 @@ import { Honcho } from "@honcho-ai/sdk";
 import { loadConfig, getSessionName, getHonchoClientOptions, isPluginEnabled, getCachedStdin } from "../config.js";
 import { existsSync, readFileSync } from "fs";
 import {
-  generateClaudeSummary,
-  saveClaudeLocalContext,
-  loadClaudeLocalContext,
   getInstanceIdForCwd,
   addMessagesBatched,
 } from "../cache.js";
@@ -32,44 +29,8 @@ interface TranscriptEntry {
   content?: string | Array<{ type: string; text?: string }>;
 }
 
-/**
- * Check if assistant content is meaningful prose vs just tool acknowledgment
- */
-function isMeaningfulAssistantContent(content: string): boolean {
-  if (content.length < 50) return false;
-
-  const toolAnnouncements = [
-    /^(I'll|Let me|I'm going to|I will|Now I'll|First,? I'll)\s+(run|use|execute|check|read|look at|search|edit|write|create)/i,
-    /^Running\s+/i,
-    /^Checking\s+/i,
-    /^Looking at\s+/i,
-  ];
-  for (const pattern of toolAnnouncements) {
-    if (pattern.test(content.trim()) && content.length < 200) {
-      return false;
-    }
-  }
-
-  if (/^(The command|The file|The output|This shows|Here's what)/i.test(content.trim()) && content.length < 150) {
-    return false;
-  }
-
-  const meaningfulPatterns = [
-    /\b(because|since|therefore|however|although|this means|in summary|to summarize|the issue is|the problem is|I recommend|you should|we should|this approach|the solution|key point|important|note that)\b/i,
-    /\b(implemented|fixed|resolved|completed|added|created|updated|changed|modified|refactored)\b/i,
-    /\b(error|bug|issue|problem|solution|fix|improvement|optimization)\b/i,
-  ];
-  for (const pattern of meaningfulPatterns) {
-    if (pattern.test(content)) {
-      return true;
-    }
-  }
-
-  return content.length >= 200;
-}
-
-function parseTranscript(transcriptPath: string): Array<{ role: string; content: string; isMeaningful?: boolean; timestamp?: string }> {
-  const messages: Array<{ role: string; content: string; isMeaningful?: boolean; timestamp?: string }> = [];
+function parseTranscript(transcriptPath: string): Array<{ role: string; content: string; timestamp?: string }> {
+  const messages: Array<{ role: string; content: string; timestamp?: string }> = [];
 
   if (!transcriptPath || !existsSync(transcriptPath)) {
     return messages;
@@ -120,12 +81,11 @@ function parseTranscript(transcriptPath: string): Array<{ role: string; content:
           }
 
           if (assistantContent && assistantContent.trim()) {
-            // Feeds the local work summary only — assistant messages upload live
-            // from the stop hook, not here.
+            // Counted for the end-marker message tally only — assistant
+            // messages upload live from the stop hook, not here.
             messages.push({
               role: "assistant",
               content: assistantContent,
-              isMeaningful: isMeaningfulAssistantContent(assistantContent),
               timestamp: entry.timestamp,
             });
           }
@@ -141,37 +101,12 @@ function parseTranscript(transcriptPath: string): Array<{ role: string; content:
   return messages;
 }
 
-function extractWorkItems(assistantMessages: string[]): string[] {
-  const workItems: string[] = [];
-  const actionPatterns = [
-    /(?:created|wrote|added)\s+(?:file\s+)?([^\n.]+)/gi,
-    /(?:edited|modified|updated|fixed)\s+([^\n.]+)/gi,
-    /(?:implemented|built|developed)\s+([^\n.]+)/gi,
-    /(?:refactored|optimized|improved)\s+([^\n.]+)/gi,
-  ];
-
-  for (const msg of assistantMessages.slice(-15)) {
-    for (const pattern of actionPatterns) {
-      const matches = msg.matchAll(pattern);
-      for (const match of matches) {
-        const item = match[1]?.trim();
-        if (item && item.length < 100 && !workItems.includes(item)) {
-          workItems.push(item);
-        }
-      }
-    }
-  }
-
-  return workItems.slice(0, 10);
-}
-
 /**
  * SessionEnd hook — structured for resilience against cancellation.
  *
  * Priority order (most critical first):
- *   1. Local summary (instant, zero risk — survives any cancellation)
- *   2. Parallel: cooldown animation + API uploads (critical data first)
- *   3. Session end marker (nice-to-have metadata)
+ *   1. Parallel: cooldown animation + API uploads (critical data first)
+ *   2. Session end marker (nice-to-have metadata)
  */
 export async function handleSessionEnd(): Promise<void> {
   const config = loadConfig();
@@ -203,34 +138,12 @@ export async function handleSessionEnd(): Promise<void> {
   logHook("session-end", `Session ending`, { reason });
 
   // =========================================================
-  // Phase 1: LOCAL WORK (instant, survives any cancellation)
+  // Phase 1: parse transcript for the end-marker message count.
+  // The on-disk local work summary was retired here — nothing consumed it, and
+  // the server-side session.summaries() long summary now stays fresh on its own
+  // since we upload every turn live.
   // =========================================================
   const transcriptMessages = transcriptPath ? parseTranscript(transcriptPath) : [];
-  const allAssistant = transcriptMessages.filter((msg) => msg.role === "assistant");
-  const meaningful = allAssistant.filter((msg) => msg.isMeaningful);
-  const other = allAssistant.filter((msg) => !msg.isMeaningful);
-  const assistantMessages = [
-    ...meaningful.slice(-25),
-    ...other.slice(-15),
-  ].slice(-40);
-
-  // Save local summary FIRST — even if the hook gets killed after this,
-  // the next session-start will have context about what happened.
-  const workItems = extractWorkItems(assistantMessages.map((m) => m.content));
-  const existingContext = loadClaudeLocalContext();
-  let recentActivity = "";
-  if (existingContext) {
-    const activityMatch = existingContext.match(/## Recent Activity\n([\s\S]*)/);
-    if (activityMatch) {
-      recentActivity = activityMatch[1];
-    }
-  }
-  const newSummary = generateClaudeSummary(
-    sessionName,
-    workItems,
-    assistantMessages.map((m) => m.content)
-  );
-  saveClaudeLocalContext(newSummary + recentActivity);
 
   // =========================================================
   // Phase 2: PARALLEL API UPLOADS + ANIMATION
@@ -281,7 +194,7 @@ export async function handleSessionEnd(): Promise<void> {
         }
       };
 
-      // Force exit if the upload hangs (local summary already saved above).
+      // Force exit if the upload hangs.
       const hardTimeout = setTimeout(() => {
         logHook("session-end", "Hard timeout reached — forcing exit");
         removeSigHandlers();
@@ -298,12 +211,12 @@ export async function handleSessionEnd(): Promise<void> {
       ]);
     }
 
-    logHook("session-end", `Session ended — end marker saved (${assistantMessages.length} assistant msgs handled live)`);
+    logHook("session-end", `Session ended — end marker saved (${transcriptMessages.length} msgs handled live)`);
     clearSessionFiles(hookInput.session_id);
     process.exit(0);
   } catch (error) {
     logHook("session-end", `Error: ${error}`, { error: String(error) });
-    // Local summary was already saved in phase 1 — not a total loss.
+    // Messages already uploaded live during the session — the end marker is metadata.
     clearSessionFiles(hookInput.session_id);
     process.exit(0);
   }

--- a/plugins/honcho/src/hooks/session-start.ts
+++ b/plugins/honcho/src/hooks/session-start.ts
@@ -177,10 +177,11 @@ export async function handleSessionStart(): Promise<void> {
 
     const fetchDuration = Date.now() - fetchStart;
     const asyncResults = [
-      { name: contextLabel, success: userContextResult.status === "fulfilled" },
+      ...(wantContext ? [{ name: contextLabel, success: userContextResult.status === "fulfilled" }] : []),
+      ...(wantSummary ? [{ name: "session.summaries()", success: summaryResult.status === "fulfilled" }] : []),
     ];
     const successCount = asyncResults.filter(r => r.success).length;
-    logAsync("context-fetch", `Context: ${successCount}/1 succeeded in ${fetchDuration}ms`, asyncResults);
+    logAsync("context-fetch", `Fetched ${successCount}/${asyncResults.length} in ${fetchDuration}ms`, asyncResults);
 
     // Verbose output (file-based — ~/.honcho/verbose.log)
     if (userContextResult.status === "fulfilled" && userContextResult.value) {

--- a/plugins/honcho/src/hooks/session-start.ts
+++ b/plugins/honcho/src/hooks/session-start.ts
@@ -1,7 +1,7 @@
 import { Honcho } from "@honcho-ai/sdk";
-import { loadConfig, getSessionForPath, setSessionForPath, getSessionName, getHonchoClientOptions, isPluginEnabled, getCachedStdin, getObservationMode } from "../config.js";
+import { loadConfig, getSessionForPath, setSessionForPath, getSessionName, getHonchoClientOptions, isPluginEnabled, getCachedStdin, getObservationMode, getInjectionConfig } from "../config.js";
+import { renderSessionStart } from "../injection.js";
 import {
-  setCachedUserContext,
   setCachedSessionId,
   resetMessageCount,
   setClaudeInstanceId,
@@ -12,9 +12,9 @@ import {
 import { Spinner } from "../spinner.js";
 import { setMemoryState, setSessionLink } from "../state.js";
 import { honchoSessionUrl } from "../styles.js";
-import { captureGitState, getRecentCommits, isGitRepo, inferFeatureContext } from "../git.js";
-import { logHook, logApiCall, logCache, logFlow, logAsync, setLogContext } from "../log.js";
-import { verboseApiResult, verboseList, clearVerboseLog } from "../visual.js";
+import { captureGitState } from "../git.js";
+import { logHook, logApiCall, logFlow, logAsync, setLogContext } from "../log.js";
+import { verboseApiResult, verboseList, clearVerboseLog, visComposedInjection } from "../visual.js";
 
 
 interface HookInput {
@@ -70,10 +70,6 @@ export async function handleSessionStart(): Promise<void> {
   const previousGitState = getCachedGitState(cwd);
   const currentGitState = captureGitState(cwd);
   const gitChanges = currentGitState ? detectGitChanges(previousGitState, currentGitState) : [];
-  const recentCommits = isGitRepo(cwd) ? getRecentCommits(cwd, 5) : [];
-
-  // Infer feature context from git state
-  const featureContext = currentGitState ? inferFeatureContext(currentGitState, recentCommits) : null;
 
   // Update git state cache
   if (currentGitState) {
@@ -150,61 +146,41 @@ export async function handleSessionStart(): Promise<void> {
       }
     }
 
-    // Step 5: Warm caches + trigger dialectic reasoning.
-    // context() results are cached for user-prompt hook (sole injection point).
-    // chat() triggers Honcho's dialectic engine — the results aren't displayed
-    // but the reasoning feeds back into the knowledge graph.
+    // Step 5: Fetch only what the configured session-start components need —
+    // the SDK long summary and/or the context() representation + peer card.
+    // Nothing is cached here; the per-turn hook does its own fresh,
+    // prompt-scoped fetch, so a session with no context components pays for no
+    // context round-trip.
     spinner.update(`${sessionName} · fetching context`);
 
-    const branchContext = currentGitState ? ` on branch '${currentGitState.branch}'` : "";
-    const featureHint = featureContext && featureContext.confidence !== "low"
-      ? ` Working on: ${featureContext.type} - ${featureContext.description}.`
-      : "";
+    const injection = getInjectionConfig(config);
+    const startComponents = injection.sessionStart;
+    const wantSummary = startComponents.includes("summary");
+    const wantContext =
+      startComponents.includes("peerCard") || startComponents.includes("peerRepresentation");
 
-    logAsync("context-fetch", "Starting context fetch + 2 dialectic fire-and-forget");
+    logAsync("context-fetch", `Starting context fetch${wantSummary ? " + summary" : ""}`);
 
     const fetchStart = Date.now();
-    const dialecticLevel = config.reasoningLevel ?? "low";
 
     // unified: user observes self — use userPeer, no target.
     // directional: aiPeer observes user — use aiPeer with target.
     const contextLabel = observationMode === "unified" ? "userPeer.context()" : "aiPeer.context(target=user)";
-    const [userContextResult] = await Promise.allSettled([
-      observationMode === "unified"
-        ? userPeer.context({ maxConclusions: 25, includeMostFrequent: true })
-        : aiPeer.context({ target: config.peerName, maxConclusions: 25, includeMostFrequent: true }),
+    const [userContextResult, summaryResult] = await Promise.allSettled([
+      wantContext
+        ? (observationMode === "unified"
+            ? userPeer.context({ maxConclusions: 25, includeMostFrequent: true })
+            : aiPeer.context({ target: config.peerName, maxConclusions: 25, includeMostFrequent: true }))
+        : Promise.resolve(null),
+      wantSummary ? session.summaries() : Promise.resolve(null),
     ]);
-
-    // Dialectic: fire-and-forget. Results feed the knowledge graph;
-    // we don't need them for cache or display.
-    if (observationMode === "unified") {
-      userPeer.chat(
-        `Summarize what you know about ${config.peerName}. Focus on preferences, current projects, and working style.${branchContext}${featureHint}`,
-        { session, reasoningLevel: dialecticLevel }
-      ).catch((e) => logHook("session-start", `Dialectic (user) failed: ${e}`));
-
-      userPeer.chat(
-        `What has ${config.peerName} been working on recently?${branchContext}${featureHint} Summarize recent activities relevant to the current work.`,
-        { session, reasoningLevel: dialecticLevel }
-      ).catch((e) => logHook("session-start", `Dialectic (recent work) failed: ${e}`));
-    } else {
-      aiPeer.chat(
-        `Summarize what you know about ${config.peerName}. Focus on preferences, current projects, and working style.${branchContext}${featureHint}`,
-        { target: config.peerName, session, reasoningLevel: dialecticLevel }
-      ).catch((e) => logHook("session-start", `Dialectic (user) failed: ${e}`));
-
-      aiPeer.chat(
-        `What has ${config.peerName} been working on recently?${branchContext}${featureHint} Summarize recent activities relevant to the current work.`,
-        { target: config.peerName, session, reasoningLevel: dialecticLevel }
-      ).catch((e) => logHook("session-start", `Dialectic (recent work) failed: ${e}`));
-    }
 
     const fetchDuration = Date.now() - fetchStart;
     const asyncResults = [
       { name: contextLabel, success: userContextResult.status === "fulfilled" },
     ];
     const successCount = asyncResults.filter(r => r.success).length;
-    logAsync("context-fetch", `Context: ${successCount}/1 succeeded in ${fetchDuration}ms (dialectic fire-and-forget)`, asyncResults);
+    logAsync("context-fetch", `Context: ${successCount}/1 succeeded in ${fetchDuration}ms`, asyncResults);
 
     // Verbose output (file-based — ~/.honcho/verbose.log)
     if (userContextResult.status === "fulfilled" && userContextResult.value) {
@@ -213,20 +189,32 @@ export async function handleSessionStart(): Promise<void> {
       verboseList(`${contextLabel} → peerCard`, ctx.peerCard);
     }
 
-    // Cache results for user-prompt hook
-    if (userContextResult.status === "fulfilled" && userContextResult.value) {
-      const context = userContextResult.value as any;
-      setCachedUserContext(context);
-      const rep = context.representation;
-      const count = typeof rep === "string" ? rep.split("\n").filter((l: string) => l.trim() && !l.startsWith("#")).length : 0;
-      logCache("write", "userContext", `${count} conclusions`);
-    }
+    // Compose the configured session-start injection. Default [] renders to an
+    // empty payload — nothing injected at session start.
+    const contextValue = userContextResult.status === "fulfilled" ? (userContextResult.value as any) : null;
+    const summaryValue = summaryResult.status === "fulfilled" ? (summaryResult.value as any) : null;
+    const rendered = renderSessionStart(startComponents, {
+      summary: summaryValue?.longSummary?.content ?? null,
+      peerCard: contextValue?.peerCard ?? null,
+      representation: contextValue?.representation ?? null,
+    });
 
-    // Stop spinner; avoid stdout writes here to prevent UI artifacts.
+    // Stop the spinner before any stdout write — a live spinner would corrupt
+    // the hook's JSON and leave UI artifacts.
     spinner.stop();
     setMemoryState("idle", undefined, claudeInstanceId);
 
-    logFlow("complete", `Cache warmed: ${successCount}/1 context + 2 dialectic (fire-and-forget)`);
+    if (rendered.content) {
+      console.log(JSON.stringify({
+        hookSpecificOutput: {
+          hookEventName: "SessionStart",
+          additionalContext: `[Honcho Memory for ${config.peerName}]: ${rendered.content}`,
+        },
+        systemMessage: visComposedInjection("session-start", rendered.labels),
+      }));
+    }
+
+    logFlow("complete", `Cache warmed: ${successCount}/1 context · injected: ${rendered.labels.join(", ") || "none"}`);
     process.exit(0);
   } catch (error) {
     logHook("session-start", `Error: ${error}`, { error: String(error) });

--- a/plugins/honcho/src/hooks/user-prompt.ts
+++ b/plugins/honcho/src/hooks/user-prompt.ts
@@ -192,9 +192,9 @@ export async function handleUserPrompt(): Promise<void> {
     new Promise<{ ok: false }>(resolve => setTimeout(() => resolve({ ok: false }), FETCH_TIMEOUT_MS)),
   ]).catch((): { ok: false } => ({ ok: false }));
 
-  const ctx: { context: any; matched?: string[] } | null =
+  const ctx: { context: any; matched?: string[]; queryLabel?: string } | null =
     fetchResult.ok && fetchResult.context
-      ? { context: fetchResult.context, matched: fetchResult.matched }
+      ? { context: fetchResult.context, matched: fetchResult.matched, queryLabel: fetchResult.queryLabel }
       : null;
 
   emitPerTurn(config.peerName, ctx, sessionLink);
@@ -244,7 +244,7 @@ async function postUserMessage(
  */
 function emitPerTurn(
   peerName: string,
-  ctx: { context: any; matched?: string[] } | null,
+  ctx: { context: any; matched?: string[]; queryLabel?: string } | null,
   sessionLink?: string,
 ): void {
   if (!ctx) return;
@@ -253,11 +253,11 @@ function emitPerTurn(
   if (conclusions.length === 0) return;
 
   const parts = [`Relevant conclusions: ${conclusions.join("; ")}`];
-  const visMsg = visInjectionMessage("user-prompt", { conclusions, matched: ctx.matched });
+  const visMsg = visInjectionMessage("user-prompt", { conclusions, matched: ctx.matched, queryLabel: ctx.queryLabel });
   outputContext(peerName, parts, sessionLink ? `${sessionLink}\n${visMsg}` : visMsg);
 }
 
-async function fetchFreshContext(config: any, prompt: string, injection: InjectionConfig): Promise<{ context: any; matched: string[] }> {
+async function fetchFreshContext(config: any, prompt: string, injection: InjectionConfig): Promise<{ context: any; matched: string[]; queryLabel?: string }> {
   const honcho = new Honcho(getHonchoClientOptions(config));
   const observationMode = getObservationMode(config);
 
@@ -275,8 +275,11 @@ async function fetchFreshContext(config: any, prompt: string, injection: Injecti
   // the raw prompt. `includeMostFrequent` is OFF so frequency-based conclusions
   // ("task completed" repeats) don't crowd out what the distance gate selects —
   // relevance/recency drives the block, not raw frequency.
-  const { topics, precise } = extractTopics(prompt);
-  const searchQuery = topics.length > 0 ? topics.join(" ") : prompt;
+  // "prompt" mode searches with the raw prompt (no topic extraction);
+  // "topics" mode (default) prefers extracted topics, falling back to the prompt.
+  const usePrompt = injection.searchQuerySource === "prompt";
+  const { topics, precise } = usePrompt ? { topics: [], precise: false } : extractTopics(prompt);
+  const searchQuery = usePrompt || topics.length === 0 ? prompt : topics.join(" ");
 
   let contextResult: any = null;
   // Topics shown to the user as the match — only set when the topics are
@@ -303,7 +306,7 @@ async function fetchFreshContext(config: any, prompt: string, injection: Injecti
     verboseList("peer.context() -> peerCard (fresh)", (contextResult as any).peerCard);
   }
 
-  return { context: contextResult, matched };
+  return { context: contextResult, matched, queryLabel: usePrompt ? "prompt" : undefined };
 }
 
 // Per-turn context injects representation-derived conclusions ONLY. The full

--- a/plugins/honcho/src/hooks/user-prompt.ts
+++ b/plugins/honcho/src/hooks/user-prompt.ts
@@ -1,22 +1,16 @@
 import { Honcho, Session, Peer } from "@honcho-ai/sdk";
 import { readFileSync, existsSync } from "node:fs";
 import { join } from "node:path";
-import { loadConfig, getSessionName, getHonchoClientOptions, isPluginEnabled, getCachedStdin, getObservationMode } from "../config.js";
+import { loadConfig, getSessionName, getHonchoClientOptions, isPluginEnabled, getCachedStdin, getObservationMode, getInjectionConfig, type InjectionConfig } from "../config.js";
 import {
-  getCachedUserContext,
-  getStaleCachedUserContext,
-  isContextCacheStale,
-  setCachedUserContext,
   getMessageCount,
   incrementMessageCount,
-  shouldRefreshKnowledgeGraph,
-  markKnowledgeGraphRefreshed,
   getInstanceIdForCwd,
   chunkContent,
   addMessagesBatched,
 } from "../cache.js";
-import { logHook, logApiCall, logCache, setLogContext } from "../log.js";
-import { visContextLine, visSkipMessage, addSystemMessage, verboseApiResult, verboseList } from "../visual.js";
+import { logHook, logApiCall, setLogContext } from "../log.js";
+import { visInjectionMessage, visSkipMessage, addSystemMessage, verboseApiResult, verboseList } from "../visual.js";
 import { honchoSessionUrl } from "../styles.js";
 import { setMemoryState, setSessionLink } from "../state.js";
 
@@ -36,10 +30,14 @@ const SKIP_CONTEXT_PATTERNS = [
 const FETCH_TIMEOUT_MS = 4000;
 
 /**
- * Extract meaningful topics from a prompt for semantic search.
- * Returns terms that are high-signal for conclusion matching.
+ * Extract meaningful topics from a prompt for semantic search. Returns terms
+ * that are high-signal for conclusion matching. `precise` is true when topics
+ * came from high-signal patterns (file paths, quoted strings, tech terms,
+ * errors) rather than the fuzzy word fallback; the fallback still drives
+ * search, but callers use `precise` to decide whether the topics are worth
+ * showing to the user as a match.
  */
-function extractTopics(prompt: string): string[] {
+function extractTopics(prompt: string): { topics: string[]; precise: boolean } {
   const topics: string[] = [];
 
   // File paths (high signal)
@@ -59,13 +57,13 @@ function extractTopics(prompt: string): string[] {
   topics.push(...errors.slice(0, 2));
 
   if (topics.length > 0) {
-    return [...new Set(topics)];
+    return { topics: [...new Set(topics)], precise: true };
   }
 
   // Fallback: meaningful words >3 chars minus stopwords
   const stopwords = new Set(['the', 'and', 'for', 'that', 'this', 'with', 'from', 'have', 'are', 'was', 'were', 'been', 'being', 'has', 'had', 'does', 'did', 'will', 'would', 'could', 'should', 'can', 'may', 'might', 'must', 'shall', 'need', 'want', 'like', 'just', 'also', 'more', 'some', 'what', 'when', 'where', 'which', 'who', 'how', 'why', 'all', 'each', 'every', 'both', 'few', 'most', 'other', 'into', 'over', 'such', 'only', 'same', 'than', 'very', 'your', 'make', 'take', 'come', 'give', 'look', 'think', 'know']);
   const words = prompt.toLowerCase().match(/\b[a-z]{4,}\b/g) || [];
-  return [...new Set(words.filter(w => !stopwords.has(w)))].slice(0, 10);
+  return { topics: [...new Set(words.filter(w => !stopwords.has(w)))].slice(0, 10), precise: false };
 }
 
 function shouldSkipContextRetrieval(prompt: string): boolean {
@@ -177,51 +175,29 @@ export async function handleUserPrompt(): Promise<void> {
     process.exit(0);
   }
 
-  // Decide whether to refresh: TTL expired or message threshold hit
-  const forceRefresh = shouldRefreshKnowledgeGraph();
-  const cachedContext = getCachedUserContext();
-  const cacheIsStale = isContextCacheStale();
+  const injection = getInjectionConfig(config);
+  const wantContext = injection.perTurn.includes("context");
 
-  if (cachedContext && !cacheIsStale && !forceRefresh) {
-    // Fresh cache — serve instantly, no API call
-    logCache("hit", "userContext", "fresh cache");
-    verboseApiResult("peer.context() -> representation (cached)", cachedContext?.representation);
-    verboseList("peer.context() -> peerCard (cached)", cachedContext?.peerCard);
-
-    serveContext(config.peerName, cachedContext, true, sessionLink);
+  if (!wantContext) {
+    logHook("user-prompt", "No per-turn injection components selected");
+    visSkipMessage("user-prompt", sessionLink ? `${sessionLink} · injection off` : "injection off");
     await uploadPromise;
     process.exit(0);
   }
 
-  // Cache is stale or threshold reached — try a fresh fetch with timeout
-  logCache("miss", "userContext", forceRefresh ? "threshold refresh" : "stale cache");
   setMemoryState("recalling", undefined, hookInput.session_id);
 
   const fetchResult = await Promise.race([
-    fetchFreshContext(config, prompt).then(r => ({ ok: true as const, ...r })),
+    fetchFreshContext(config, prompt, injection).then(r => ({ ok: true as const, ...r })),
     new Promise<{ ok: false }>(resolve => setTimeout(() => resolve({ ok: false }), FETCH_TIMEOUT_MS)),
   ]).catch((): { ok: false } => ({ ok: false }));
 
-  if (fetchResult.ok) {
-    const { context } = fetchResult;
-    if (forceRefresh) {
-      markKnowledgeGraphRefreshed();
-    }
-    if (context) {
-      serveContext(config.peerName, context, false, sessionLink);
-      await uploadPromise;
-      process.exit(0);
-    }
-  }
+  const ctx: { context: any; matched?: string[] } | null =
+    fetchResult.ok && fetchResult.context
+      ? { context: fetchResult.context, matched: fetchResult.matched }
+      : null;
 
-  // Fetch failed or timed out — silently fall back to stale cache
-  const staleContext = getStaleCachedUserContext();
-  if (staleContext) {
-    logHook("user-prompt", "Serving stale cache after timeout");
-    serveContext(config.peerName, staleContext, true, sessionLink);
-  }
-  // No cache at all — exit silently, context will arrive after session-start completes
-
+  emitPerTurn(config.peerName, ctx, sessionLink);
   await uploadPromise;
   process.exit(0);
 }
@@ -262,22 +238,26 @@ async function postUserMessage(
 }
 
 /**
- * Format and output context injection to Claude.
+ * Emit the per-turn "context" injection: the cache/fresh/stale context blob
+ * formatted into additionalContext plus its systemMessage. Exits silently when
+ * nothing resolved — mirroring the old no-cache fall-through.
  */
-function serveContext(
+function emitPerTurn(
   peerName: string,
-  context: any,
-  cached: boolean,
+  ctx: { context: any; matched?: string[] } | null,
   sessionLink?: string,
 ): void {
-  const { parts: contextParts } = formatCachedContext(context, peerName);
-  if (contextParts.length === 0) return;
+  if (!ctx) return;
 
-  const visMsg = visContextLine("user-prompt", { cached });
-  outputContext(peerName, contextParts, sessionLink ? `${sessionLink}\n${visMsg}` : visMsg);
+  const conclusions = extractConclusions(ctx.context);
+  if (conclusions.length === 0) return;
+
+  const parts = [`Relevant conclusions: ${conclusions.join("; ")}`];
+  const visMsg = visInjectionMessage("user-prompt", { conclusions, matched: ctx.matched });
+  outputContext(peerName, parts, sessionLink ? `${sessionLink}\n${visMsg}` : visMsg);
 }
 
-async function fetchFreshContext(config: any, prompt: string): Promise<{ context: any }> {
+async function fetchFreshContext(config: any, prompt: string, injection: InjectionConfig): Promise<{ context: any; matched: string[] }> {
   const honcho = new Honcho(getHonchoClientOptions(config));
   const observationMode = getObservationMode(config);
 
@@ -291,67 +271,57 @@ async function fetchFreshContext(config: any, prompt: string): Promise<{ context
 
   const startTime = Date.now();
 
-  // Try search-based context first — returns conclusions relevant to the prompt
-  const topics = extractTopics(prompt);
-  const searchQuery = topics.length > 0 ? topics.join(" ") : undefined;
+  // Always search-scope the fetch: high-signal topics when we have them, else
+  // the raw prompt. `includeMostFrequent` is OFF so frequency-based conclusions
+  // ("task completed" repeats) don't crowd out what the distance gate selects —
+  // relevance/recency drives the block, not raw frequency.
+  const { topics, precise } = extractTopics(prompt);
+  const searchQuery = topics.length > 0 ? topics.join(" ") : prompt;
 
   let contextResult: any = null;
+  // Topics shown to the user as the match — only set when the topics are
+  // high-signal, so we never surface fuzzy fallback words as a real match.
+  let matched: string[] = [];
 
-  if (searchQuery) {
-    try {
-      contextResult = await contextPeer.context({
-        ...(contextTarget ? { target: contextTarget } : {}),
-        searchQuery,
-        searchTopK: 5,
-        searchMaxDistance: 0.7,
-        maxConclusions: 15,
-        includeMostFrequent: true,
-      });
-      logApiCall(contextLabel, "GET", `search: ${searchQuery.slice(0, 60)}`, Date.now() - startTime, true);
-    } catch (e) {
-      // Search failed — fall through to static context
-      logHook("user-prompt", `Search context failed, falling back to static: ${e}`);
-    }
-  }
-
-  // Fallback: static context (no search query)
-  if (!contextResult) {
+  try {
     contextResult = await contextPeer.context({
       ...(contextTarget ? { target: contextTarget } : {}),
-      maxConclusions: 15,
-      includeMostFrequent: true,
+      searchQuery,
+      searchTopK: injection.searchTopK,
+      searchMaxDistance: injection.searchMaxDistance,
+      maxConclusions: injection.maxConclusions,
+      includeMostFrequent: false,
     });
-    logApiCall(contextLabel, "GET", `static context`, Date.now() - startTime, true);
+    matched = precise ? topics : [];
+    logApiCall(contextLabel, "GET", `search: ${searchQuery.slice(0, 60)}`, Date.now() - startTime, true);
+  } catch (e) {
+    logHook("user-prompt", `Context fetch failed: ${e}`);
   }
 
   if (contextResult) {
-    setCachedUserContext(contextResult);
     verboseApiResult("peer.context() -> representation (fresh)", (contextResult as any).representation);
     verboseList("peer.context() -> peerCard (fresh)", (contextResult as any).peerCard);
   }
 
-  return { context: contextResult };
+  return { context: contextResult, matched };
 }
 
-function formatCachedContext(context: any, peerName: string): { parts: string[]; conclusionCount: number } {
-  const parts: string[] = [];
-  let conclusionCount = 0;
+// Per-turn context injects representation-derived conclusions ONLY. The full
+// peer card is stable identity and belongs to the SessionStart surface (the
+// "peerCard" component) — re-sending its 40+ items every turn was a recurring
+// slug of low-turn-relevance tokens (DEV-2024). context() returns
+// `representation` and `peerCard` as separate fields, so excluding the card is
+// simply not reading it — no string surgery.
+//
+// The conclusion count is bounded upstream by the maxConclusions knob passed to
+// context(), so no client-side cap is applied here.
+function extractConclusions(context: any): string[] {
   const rep = context?.representation;
-
-  if (typeof rep === "string" && rep.trim()) {
-    const lines = rep.split("\n").filter((l: string) => l.trim() && !l.startsWith("#"));
-    const selected = lines.slice(0, 5);
-    conclusionCount = selected.length;
-    const summary = selected.map((l: string) => l.replace(/^\[.*?\]\s*/, "").replace(/^- /, "")).join("; ");
-    if (summary) parts.push(`Relevant conclusions: ${summary}`);
-  }
-
-  const peerCard = context?.peerCard;
-  if (peerCard?.length) {
-    parts.push(`Profile: ${peerCard.join("; ")}`);
-  }
-
-  return { parts, conclusionCount };
+  if (typeof rep !== "string" || !rep.trim()) return [];
+  return rep
+    .split("\n")
+    .filter((l: string) => l.trim() && !l.startsWith("#"))
+    .map((l: string) => l.replace(/^\[.*?\]\s*/, "").replace(/^- /, ""));
 }
 
 // Set once per session to nudge active use of the honcho MCP tools.

--- a/plugins/honcho/src/injection.ts
+++ b/plugins/honcho/src/injection.ts
@@ -1,0 +1,78 @@
+/**
+ * Composable memory injection — the render layer shared by the injection hooks.
+ *
+ * The hooks own the SDK client, caching, and timeouts; this module owns the
+ * pure mapping from a fetched-data bundle plus a selected component set to the
+ * injected `additionalContext` payload and its visibility labels. Keeping the
+ * composition here — rather than as scattered conditionals inside each hook —
+ * makes the per-surface component menu a single source of truth, and keeps the
+ * "which component renders how" decision in one place as the menu grows.
+ */
+import type { SessionStartComponent } from "./config.js";
+
+/**
+ * Data the session-start components render from. Every field is optional: a
+ * component's data is only fetched when that component is selected, so an
+ * unselected component simply has nothing to render.
+ */
+export interface SessionStartData {
+  /** SDK `session.summaries().long` narrative (null on a fresh session). */
+  summary?: string | null;
+  /** `context().peerCard` — structured identity/attribute list, full length. */
+  peerCard?: string[] | null;
+  /** `context().representation` — derived prose doc, full length. */
+  representation?: string | null;
+}
+
+/** The output of a composition: the payload Claude consumes plus the labels
+ *  naming what was injected (for the user-facing systemMessage summary). */
+export interface RenderedInjection {
+  /** additionalContext payload. Empty string means "inject nothing". */
+  content: string;
+  /** Short labels of the emitted components, in injection order. */
+  labels: string[];
+}
+
+/**
+ * Render the SessionStart components, in the configured order, into one payload.
+ * Components whose data is missing/empty are silently skipped (e.g. no summary
+ * yet on a fresh session), so the labels reflect what was *actually* injected.
+ */
+export function renderSessionStart(
+  components: SessionStartComponent[],
+  data: SessionStartData,
+): RenderedInjection {
+  const parts: string[] = [];
+  const labels: string[] = [];
+
+  for (const component of components) {
+    switch (component) {
+      case "summary": {
+        const summary = data.summary?.trim();
+        if (summary) {
+          parts.push(`Session summary: ${summary}`);
+          labels.push("summary");
+        }
+        break;
+      }
+      case "peerRepresentation": {
+        const rep = data.representation?.trim();
+        if (rep) {
+          parts.push(`Honcho stored representation of the user:\n${rep}`);
+          labels.push("representation");
+        }
+        break;
+      }
+      case "peerCard": {
+        const card = (data.peerCard ?? []).filter((item) => item?.trim());
+        if (card.length) {
+          parts.push(`Profile: ${card.join("; ")}`);
+          labels.push(`peer card (${card.length} items)`);
+        }
+        break;
+      }
+    }
+  }
+
+  return { content: parts.join("\n\n"), labels };
+}

--- a/plugins/honcho/src/mcp/server.ts
+++ b/plugins/honcho/src/mcp/server.ts
@@ -529,6 +529,18 @@ function handleSetConfig(args: Record<string, unknown>) {
       cfg.injection.searchMaxDistance = Number(value);
       break;
 
+    case "injection.searchQuerySource":
+      if (value !== "topics" && value !== "prompt") {
+        return {
+          content: [{ type: "text", text: JSON.stringify({ success: false, error: `injection.searchQuerySource must be "topics" or "prompt"` }, null, 2) }],
+          isError: true,
+        };
+      }
+      previousValue = cfg.injection?.searchQuerySource;
+      if (!cfg.injection) cfg.injection = {};
+      cfg.injection.searchQuerySource = value;
+      break;
+
     case "sessions.set": {
       const obj = value as Record<string, unknown>;
       const path = obj?.path;
@@ -818,6 +830,7 @@ export async function runMcpServer(): Promise<void> {
                   "injection.searchTopK",
                   "injection.maxConclusions",
                   "injection.searchMaxDistance",
+                  "injection.searchQuerySource",
                   "sessions.set",
                   "sessions.remove",
                 ],

--- a/plugins/honcho/src/mcp/server.ts
+++ b/plugins/honcho/src/mcp/server.ts
@@ -24,6 +24,10 @@ import {
   type HonchoEnvironment,
   type ObservationMode,
   type StatuslineMode,
+  type SessionStartComponent,
+  type PerTurnComponent,
+  SESSION_START_COMPONENTS,
+  PER_TURN_COMPONENTS,
   getObservationMode,
 } from "../config.js";
 import { honchoSessionUrl } from "../styles.js";
@@ -111,6 +115,7 @@ function handleGetConfig(cwd: string) {
     observationMode: cfg.observationMode ?? "unified",
     statusline: cfg.statusline ?? "on",
     localContext: cfg.localContext ?? {},
+    injection: cfg.injection ?? {},
     enabled: cfg.enabled !== false,
     logging: cfg.logging !== false,
     saveMessages: cfg.saveMessages !== false,
@@ -233,6 +238,42 @@ function handleGetConfig(cwd: string) {
 // ============================================
 // set_config handler
 // ============================================
+
+/**
+ * Coerce a set_config `value` into a string array. The `value` field is
+ * schema-less, so MCP clients may deliver an array as a real array OR as a
+ * JSON-encoded string (e.g. '["summary","peerCard"]'); accept both. Returns
+ * null when the value is neither, so the caller can report a shape error.
+ */
+function coerceStringArray(value: unknown): string[] | null {
+  let v = value;
+  if (typeof v === "string") {
+    try { v = JSON.parse(v); } catch { return null; }
+  }
+  return Array.isArray(v) ? v.map(String) : null;
+}
+
+/**
+ * Validate a component-array set_config value against the allowed component
+ * names (the SESSION_START_COMPONENTS / PER_TURN_COMPONENTS tuples). Returns the
+ * validated array, or an isError tool result describing the shape/enum problem.
+ */
+function validateComponentArray(
+  value: unknown,
+  allowed: readonly string[],
+  field: string,
+): string[] | { content: { type: "text"; text: string }[]; isError: true } {
+  const example = JSON.stringify(allowed.slice(0, 2));
+  const err = (msg: string) => ({
+    content: [{ type: "text" as const, text: JSON.stringify({ success: false, error: msg }, null, 2) }],
+    isError: true as const,
+  });
+  const arr = coerceStringArray(value);
+  if (!arr) return err(`${field} must be an array of component names, e.g. ${example}`);
+  const bad = arr.filter((v) => !allowed.includes(v));
+  if (bad.length) return err(`${field} entries must be one of: ${allowed.join(", ")} (got: ${bad.join(", ")})`);
+  return arr;
+}
 
 function handleSetConfig(args: Record<string, unknown>) {
   const field = args.field;
@@ -452,6 +493,42 @@ function handleSetConfig(args: Record<string, unknown>) {
       cfg.localContext.maxEntries = Number(value);
       break;
 
+    case "injection.sessionStart": {
+      const arr = validateComponentArray(value, SESSION_START_COMPONENTS, field);
+      if (!Array.isArray(arr)) return arr;
+      previousValue = cfg.injection?.sessionStart;
+      if (!cfg.injection) cfg.injection = {};
+      cfg.injection.sessionStart = arr as SessionStartComponent[];
+      break;
+    }
+
+    case "injection.perTurn": {
+      const arr = validateComponentArray(value, PER_TURN_COMPONENTS, field);
+      if (!Array.isArray(arr)) return arr;
+      previousValue = cfg.injection?.perTurn;
+      if (!cfg.injection) cfg.injection = {};
+      cfg.injection.perTurn = arr as PerTurnComponent[];
+      break;
+    }
+
+    case "injection.searchTopK":
+      previousValue = cfg.injection?.searchTopK;
+      if (!cfg.injection) cfg.injection = {};
+      cfg.injection.searchTopK = Number(value);
+      break;
+
+    case "injection.maxConclusions":
+      previousValue = cfg.injection?.maxConclusions;
+      if (!cfg.injection) cfg.injection = {};
+      cfg.injection.maxConclusions = Number(value);
+      break;
+
+    case "injection.searchMaxDistance":
+      previousValue = cfg.injection?.searchMaxDistance;
+      if (!cfg.injection) cfg.injection = {};
+      cfg.injection.searchMaxDistance = Number(value);
+      break;
+
     case "sessions.set": {
       const obj = value as Record<string, unknown>;
       const path = obj?.path;
@@ -512,6 +589,7 @@ function handleSetConfig(args: Record<string, unknown>) {
     observationMode: cfg.observationMode ?? "unified",
     statusline: cfg.statusline ?? "on",
     localContext: cfg.localContext ?? {},
+    injection: cfg.injection ?? {},
     enabled: cfg.enabled !== false,
     logging: cfg.logging !== false,
     saveMessages: cfg.saveMessages !== false,
@@ -735,12 +813,17 @@ export async function runMcpServer(): Promise<void> {
                   "reasoningLevel",
                   "observationMode",
                   "localContext.maxEntries",
+                  "injection.sessionStart",
+                  "injection.perTurn",
+                  "injection.searchTopK",
+                  "injection.maxConclusions",
+                  "injection.searchMaxDistance",
                   "sessions.set",
                   "sessions.remove",
                 ],
               },
               value: {
-                description: "New value. For sessions.set: {path, name}. For sessions.remove: {path}.",
+                description: "New value. For sessions.set: {path, name}. For sessions.remove: {path}. For injection.sessionStart / injection.perTurn: a string array of component names (e.g. [\"summary\",\"peerCard\"]).",
               },
               confirm: {
                 type: "boolean",

--- a/plugins/honcho/src/visual.ts
+++ b/plugins/honcho/src/visual.ts
@@ -59,12 +59,16 @@ export function visMessage(direction: HookDirection, hookName: string, message: 
 export function visInjectionMessage(hookName: string, opts: {
   conclusions: string[];
   matched?: string[];
+  /** Overrides the matched suffix, e.g. "prompt" → "(query: prompt)". */
+  queryLabel?: string;
 }): string {
   const count = opts.conclusions.length;
   const noun = count === 1 ? "conclusion" : "conclusions";
-  const head = opts.matched?.length
-    ? `injected ${count} ${noun} (matched: ${opts.matched.join(", ")})`
-    : `injected ${count} ${noun}`;
+  const head = opts.queryLabel
+    ? `injected ${count} ${noun} (query: ${opts.queryLabel})`
+    : opts.matched?.length
+      ? `injected ${count} ${noun} (matched: ${opts.matched.join(", ")})`
+      : `injected ${count} ${noun}`;
   const summary = formatLine("in", hookName, head);
   const body = opts.conclusions.map(c => `  ${sym.bullet} ${c}`).join("\n");
   return body ? `${summary}\n${body}` : summary;

--- a/plugins/honcho/src/visual.ts
+++ b/plugins/honcho/src/visual.ts
@@ -50,14 +50,35 @@ export function visMessage(direction: HookDirection, hookName: string, message: 
 }
 
 /**
- * Build context injection status string
- * Used by user-prompt hook (which outputs JSON systemMessage — works)
+ * Build the injection systemMessage for the user-prompt hook: a one-line status
+ * summary followed by the injected conclusions as bullets. The stable profile
+ * block is intentionally omitted here — it lives in the injection log, not in
+ * every turn's transcript. `matched` is only set for high-signal topics, so a
+ * low-signal fuzzy fallback query is never surfaced as a bogus match.
  */
-export function visContextLine(hookName: string, opts: {
-  cached?: boolean;
+export function visInjectionMessage(hookName: string, opts: {
+  conclusions: string[];
+  matched?: string[];
 }): string {
-  const suffix = opts.cached ? " (cached)" : "";
-  return formatLine("in", hookName, `injected conclusions${suffix}`);
+  const count = opts.conclusions.length;
+  const noun = count === 1 ? "conclusion" : "conclusions";
+  const head = opts.matched?.length
+    ? `injected ${count} ${noun} (matched: ${opts.matched.join(", ")})`
+    : `injected ${count} ${noun}`;
+  const summary = formatLine("in", hookName, head);
+  const body = opts.conclusions.map(c => `  ${sym.bullet} ${c}`).join("\n");
+  return body ? `${summary}\n${body}` : summary;
+}
+
+/**
+ * Build the systemMessage for the SessionStart composition: a single status
+ * line naming which components were injected (e.g. "injected summary + peer
+ * card (12 items)"). Session start is a once-per-session surface, so unlike the
+ * per-turn line it stays terse — the payload itself goes to additionalContext.
+ */
+export function visComposedInjection(hookName: string, labels: string[]): string {
+  const summary = labels.length ? `injected ${labels.join(" + ")}` : "nothing to inject";
+  return formatLine("in", hookName, summary);
 }
 
 /**


### PR DESCRIPTION
## What 

- Updated config to have an `injection` block
- **session-start**: composes the configured components (SDK **long summary**, **peer card**, **representation**) into `additionalContext` + a terse one-line `systemMessage`. The context fetch is gated per component (no round-trip when nothing needs it) and nothing is cached. Removed the two dead dialectic calls.
- User prompt hooks use `peer.context({ searchQuery, searchMaxDistance })` for injection per turn. This also lists out the n conclusions that were inejcted, but there's no way to get it formatted really nicely with the current SDK 
- Removed the **session-end** on-disk local summary.
- Removed some dead code in `cache.ts` in `session-end.ts`).
- Updated honcho:config skill to ask user for configuration of new injection hooks.

New defaults:
- **session start**: peer card + long summary injected
- **per turn**: `peer.context({ searchQuery })` injected

## Notes
- `level` wasn't filterable through the SDK when I tried so we can't filter to inductive

## Testing

`tsc --noEmit` clean; all hook + MCP bundles build. Session-start composition and the per-turn fresh fetch verified end-to-end via the session transcript and `~/.honcho` logs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added configurable “memory injection” for session startup and per-turn behavior, including selectable injection surfaces and the option to inject nothing.
  * Expanded configuration support via MCP for injection fields and tuning options.
* **Documentation**
  * Updated the configuration guide with a new Memory injection selection flow and documented effective defaults.
* **Bug Fixes**
  * Improved per-turn context generation to use fresh, topic-focused searches and clearer injected-status messaging.
  * Updated session end handling to rely on transcript-derived end-marker metadata. 
* **Refactor**
  * Simplified internal cache/refresh behavior to focus on message-count tracking only.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->