### PR TITLE
feat: add dialectic summary option for user prompt hook

### DIFF
--- a/plugins/honcho/hooks/hooks.json
+++ b/plugins/honcho/hooks/hooks.json
@@ -36,7 +36,8 @@
           {
             "type": "command",
             "command": "bun run ${CLAUDE_PLUGIN_ROOT}/hooks/post-tool-use.ts",
-            "timeout": 10000
+            "timeout": 10,
+            "async": true
           }
         ]
       }
@@ -59,7 +60,13 @@
           {
             "type": "command",
             "command": "bun run ${CLAUDE_PLUGIN_ROOT}/hooks/user-prompt.ts",
-            "timeout": 7000
+            "timeout": 120
+          },
+          {
+            "type": "command",
+            "command": "bun run ${CLAUDE_PLUGIN_ROOT}/hooks/save-user-message.ts",
+            "timeout": 30000,
+            "async": true
           }
         ]
       }
@@ -92,7 +99,8 @@
           {
             "type": "command",
             "command": "bun run ${CLAUDE_PLUGIN_ROOT}/hooks/stop.ts",
-            "timeout": 10000
+            "timeout": 10,
+            "async": true
           }
         ]
       }

--- a/plugins/honcho/hooks/save-user-message.ts
+++ b/plugins/honcho/hooks/save-user-message.ts
@@ -1,0 +1,6 @@
+#!/usr/bin/env bun
+import { initHook } from "../src/config.js";
+import { handleSaveUserMessage } from "../src/hooks/save-user-message.js";
+
+await initHook();
+await handleSaveUserMessage();

--- a/plugins/honcho/skills/config/SKILL.md
+++ b/plugins/honcho/skills/config/SKILL.md
@@ -171,15 +171,19 @@ AskUserQuestion:
       options:
         - label: "Relevant conclusions"
           description: "Fresh, prompt-scoped memory pulled every turn"
+        - label: "Dialectic recall"
+          description: "A reasoned answer over your history each turn — richer but slower (off by default)"
 ```
 
 Map the selections to component names, then call `set_config` once per surface:
 - Session start → `injection.sessionStart`, mapping "Memory directives"→`directives`, "Session summary"→`summary`, "Peer card"→`peerCard`, "Representation"→`peerRepresentation`.
-- Per turn → `injection.perTurn`, mapping "Relevant conclusions"→`context`.
+- Per turn → `injection.perTurn`, mapping "Relevant conclusions"→`context`, "Dialectic recall"→`dialectic`.
 
 Pass the value as a JSON array (e.g. `["directives","summary","peerCard"]`). An empty selection for a surface means "inject nothing" there — pass `[]`.
 
 Retrieval tuning is intentionally NOT asked here. `injection.searchTopK` (default 10), `injection.maxConclusions` (15), `injection.searchMaxDistance` (0.6, cosine — lower is stricter), and `injection.searchQuerySource` ("prompt" | "topics", default "prompt") are all configurable via `set_config`, but keep the defaults; only mention they're tunable if the user brings it up, and never prompt for them.
+
+If the user enables "Dialectic recall", note the two knobs that shape it — `injection.dialecticTemplate` (the query, with a `%{user_query}` placeholder) and `injection.dialecticReasoning` (tier, default "low") — both via `set_config`. Flag the trade-off: it fires a `chat()` call every non-trivial turn (~12s at medium), on its own budget under the 30s hook ceiling, so it adds real per-turn latency. Keep it off unless the user wants it.
 
 ### Dangerous fields (Host)
 

--- a/plugins/honcho/src/cache.ts
+++ b/plugins/honcho/src/cache.ts
@@ -399,10 +399,31 @@ export const HONCHO_MAX_BATCH = 100;
 
 type SessionLike = { addMessages: (messages: any[]) => Promise<unknown> };
 
-/** Upload messages, split across calls of ≤100 to stay under Honcho's batch cap. */
-export async function addMessagesBatched(session: SessionLike, messages: any[]): Promise<void> {
+/**
+ * Upload messages, split across calls of ≤100 to stay under Honcho's batch cap.
+ *
+ * When `resolveFallback` is given, a batch failure resolves an alternate session
+ * once and retries only the failed batch (and any remaining ones) on it. This
+ * lets callers front a fast noEnsure session and fall back to get-or-create
+ * without ever replaying batches the first session already accepted.
+ */
+export async function addMessagesBatched(
+  session: SessionLike,
+  messages: any[],
+  resolveFallback?: (error: unknown) => Promise<SessionLike>,
+): Promise<void> {
+  let active = session;
+  let usedFallback = false;
   for (let i = 0; i < messages.length; i += HONCHO_MAX_BATCH) {
-    await session.addMessages(messages.slice(i, i + HONCHO_MAX_BATCH));
+    const batch = messages.slice(i, i + HONCHO_MAX_BATCH);
+    try {
+      await active.addMessages(batch);
+    } catch (e) {
+      if (usedFallback || !resolveFallback) throw e;
+      active = await resolveFallback(e);
+      usedFallback = true;
+      await active.addMessages(batch);
+    }
   }
 }
 

--- a/plugins/honcho/src/config.ts
+++ b/plugins/honcho/src/config.ts
@@ -55,12 +55,17 @@ export type SessionStartComponent = (typeof SESSION_START_COMPONENTS)[number];
  * - "context": a fresh, prompt-scoped context() blob (representation + peerCard),
  *   whose semantic retrieval is shaped by the searchTopK/searchMaxDistance/
  *   maxConclusions knobs below.
+ * - "dialectic": a reasoned peer.chat() answer over the representation, seeded
+ *   from `dialecticTemplate` (the prompt substituted into %{user_query}) at the
+ *   `dialecticReasoning` tier. Off by default — chat() is far slower than
+ *   context() (~12s at medium), so it runs on its own budget, not the 4s
+ *   context race, and stays under the 30s UserPromptSubmit harness ceiling.
  *
  * A "search" component (filtered semantic search over inductive conclusions)
  * was scoped out: `level` is not filterable through the API, so it needs a
  * honcho-backend + SDK change before it can ship. See the plan.
  */
-export const PER_TURN_COMPONENTS = ["context"] as const;
+export const PER_TURN_COMPONENTS = ["context", "dialectic"] as const;
 export type PerTurnComponent = (typeof PER_TURN_COMPONENTS)[number];
 
 /**
@@ -83,6 +88,14 @@ export interface InjectionConfig {
   /** What drives the per-turn semantic search: the raw "prompt" (default)
    *  or extracted "topics". */
   searchQuerySource?: "topics" | "prompt";
+  /** Query template for the per-turn "dialectic" component. The user's prompt
+   *  is substituted into every `%{user_query}` (default: surface anything from
+   *  the user's history relevant to the prompt). */
+  dialecticTemplate?: string;
+  /** Reasoning tier for the per-turn "dialectic" chat() call (default: "low").
+   *  Kept separate from the top-level `reasoningLevel` so per-turn dialectic can
+   *  stay cheap on the hot path without lowering the tier used elsewhere. */
+  dialecticReasoning?: ReasoningLevel;
 }
 
 /** Resolved injection defaults: memory-usage directives + session summary +
@@ -96,9 +109,13 @@ export const DEFAULT_INJECTION: Required<InjectionConfig> = {
   maxConclusions: 15,
   searchMaxDistance: 0.6,
   searchQuerySource: "prompt",
+  dialecticTemplate:
+    "Return a compact, factual list of anything from the user's history — preferences, prior decisions, relevant past work — that would help with the following. Write in the third person as background notes; do not address the user, ask questions, or offer next steps. If nothing relevant exists, say so in one line. Relevant to: %{user_query}",
+  dialecticReasoning: "medium",
 };
 
-export type ReasoningLevel = "minimal" | "low" | "medium" | "high" | "max";
+export const REASONING_LEVELS = ["minimal", "low", "medium", "high", "max"] as const;
+export type ReasoningLevel = (typeof REASONING_LEVELS)[number];
 
 export type SessionStrategy = "per-directory" | "git-branch" | "chat-instance";
 
@@ -838,7 +855,7 @@ export function getHonchoClientOptions(config: HonchoCLAUDEConfig): HonchoClient
     apiKey: config.apiKey,
     baseURL: getHonchoBaseUrl(config),
     workspaceId: config.workspace,
-    timeout: 8000,
+    timeout: 120000,
     maxRetries: 1,
   };
 }

--- a/plugins/honcho/src/hooks/save-user-message.ts
+++ b/plugins/honcho/src/hooks/save-user-message.ts
@@ -1,0 +1,98 @@
+import { Honcho, Session, Peer } from "@honcho-ai/sdk";
+import { loadConfig, getSessionName, getHonchoClientOptions, isPluginEnabled, getCachedStdin } from "../config.js";
+import { getInstanceIdForCwd, chunkContent, addMessagesBatched } from "../cache.js";
+import { logHook, logApiCall, setLogContext } from "../log.js";
+
+interface HookInput {
+  prompt?: string;
+  cwd?: string;
+  session_id?: string;
+  workspace_roots?: string[];
+}
+
+/**
+ * Async UserPromptSubmit companion to user-prompt.ts: persists the user's
+ * prompt to Honcho off the turn's critical path.
+ *
+ * This runs as a separate `async: true` hook so the write never blocks the
+ * model's response. It's the write half of UserPromptSubmit; user-prompt.ts is
+ * the read half (context/dialectic injection), which stays synchronous because
+ * its additionalContext must reach the model before it answers this turn.
+ *
+ * Being async, it runs detached — it awaits the upload to completion here
+ * rather than racing process exit, so a slow POST still lands.
+ */
+export async function handleSaveUserMessage(): Promise<void> {
+  const config = loadConfig();
+  if (!config) {
+    process.exit(0);
+  }
+
+  if (!isPluginEnabled() || config.saveMessages === false) {
+    process.exit(0);
+  }
+
+  let hookInput: HookInput = {};
+  try {
+    const input = getCachedStdin() ?? await Bun.stdin.text();
+    if (input.trim()) {
+      hookInput = JSON.parse(input);
+    }
+  } catch {
+    process.exit(0);
+  }
+
+  const prompt = hookInput.prompt || "";
+  if (!prompt.trim()) {
+    process.exit(0);
+  }
+
+  const cwd = hookInput.workspace_roots?.[0] || hookInput.cwd || process.cwd();
+  const instanceId = hookInput.session_id || getInstanceIdForCwd(cwd);
+  const sessionName = getSessionName(cwd, instanceId || undefined);
+
+  setLogContext(cwd, sessionName);
+
+  try {
+    await postUserMessage(config, prompt, instanceId || undefined, sessionName);
+  } catch (e) {
+    logHook("save-user-message", `Upload failed: ${e}`);
+  }
+
+  process.exit(0);
+}
+
+// Upload a user prompt. SessionStart already created the session/peers, so we
+// use local handles with a noEnsure stub to skip the get-or-create round-trip,
+// falling back to a real lookup only if the direct POST fails.
+async function postUserMessage(
+  config: any,
+  prompt: string,
+  instanceId: string | undefined,
+  sessionName: string,
+): Promise<void> {
+  const honcho = new Honcho(getHonchoClientOptions(config));
+  const noEnsure = () => Promise.resolve();
+
+  const userPeer = new Peer(config.peerName, honcho.workspaceId, honcho.http, undefined, undefined, noEnsure);
+  const createdAt = new Date().toISOString();
+  const messages = chunkContent(prompt).map((chunk) =>
+    userPeer.message(chunk, {
+      createdAt,
+      metadata: {
+        instance_id: instanceId || undefined,
+        session_affinity: sessionName,
+      },
+    })
+  );
+
+  logApiCall("session.addMessages", "POST", `user prompt (${prompt.length} chars, ${messages.length} msg, direct)`);
+  try {
+    const session = new Session(sessionName, honcho.workspaceId, honcho.http, undefined, undefined, noEnsure);
+    await addMessagesBatched(session, messages);
+  } catch (e) {
+    logHook("save-user-message", `Direct upload failed, retrying via get-or-create: ${e}`);
+    const session = await honcho.session(sessionName);
+    await addMessagesBatched(session, messages);
+  }
+}

--- a/plugins/honcho/src/hooks/save-user-message.ts
+++ b/plugins/honcho/src/hooks/save-user-message.ts
@@ -87,12 +87,9 @@ async function postUserMessage(
   );
 
   logApiCall("session.addMessages", "POST", `user prompt (${prompt.length} chars, ${messages.length} msg, direct)`);
-  try {
-    const session = new Session(sessionName, honcho.workspaceId, honcho.http, undefined, undefined, noEnsure);
-    await addMessagesBatched(session, messages);
-  } catch (e) {
+  const session = new Session(sessionName, honcho.workspaceId, honcho.http, undefined, undefined, noEnsure);
+  await addMessagesBatched(session, messages, (e) => {
     logHook("save-user-message", `Direct upload failed, retrying via get-or-create: ${e}`);
-    const session = await honcho.session(sessionName);
-    await addMessagesBatched(session, messages);
-  }
+    return honcho.session(sessionName);
+  });
 }

--- a/plugins/honcho/src/hooks/stop.ts
+++ b/plugins/honcho/src/hooks/stop.ts
@@ -162,14 +162,11 @@ export async function handleStop(): Promise<void> {
     );
     logApiCall("session.addMessages", "POST", `${turnMessages.length} assistant msg(s), ${messages.length} chunk(s), direct`);
 
-    try {
-      const session = new Session(sessionName, honcho.workspaceId, honcho.http, undefined, undefined, noEnsure);
-      await addMessagesBatched(session, messages);
-    } catch (e) {
+    const session = new Session(sessionName, honcho.workspaceId, honcho.http, undefined, undefined, noEnsure);
+    await addMessagesBatched(session, messages, (e) => {
       logHook("stop", `Direct upload failed, retrying via get-or-create: ${e}`);
-      const session = await honcho.session(sessionName);
-      await addMessagesBatched(session, messages);
-    }
+      return honcho.session(sessionName);
+    });
 
     logHook("stop", `Saved ${turnMessages.length} assistant message(s)`);
     visStopMessage("out", `saved ${turnMessages.length} assistant msg(s)`);

--- a/plugins/honcho/src/hooks/user-prompt.ts
+++ b/plugins/honcho/src/hooks/user-prompt.ts
@@ -1,4 +1,4 @@
-import { Honcho, Session, Peer } from "@honcho-ai/sdk";
+import { Honcho } from "@honcho-ai/sdk";
 import { readFileSync, existsSync } from "node:fs";
 import { join } from "node:path";
 import { loadConfig, getSessionName, getHonchoClientOptions, isPluginEnabled, getCachedStdin, getObservationMode, getInjectionConfig, type InjectionConfig } from "../config.js";
@@ -6,11 +6,10 @@ import {
   getMessageCount,
   incrementMessageCount,
   getInstanceIdForCwd,
-  chunkContent,
-  addMessagesBatched,
 } from "../cache.js";
 import { logHook, logApiCall, setLogContext } from "../log.js";
-import { visInjectionMessage, visSkipMessage, addSystemMessage, verboseApiResult, verboseList } from "../visual.js";
+import { visInjectionMessage, visDialecticMessage, visSkipMessage, addSystemMessage, verboseApiResult, verboseList } from "../visual.js";
+import type { ReasoningLevel } from "../config.js";
 import { honchoSessionUrl } from "../styles.js";
 import { setMemoryState, setSessionLink } from "../state.js";
 
@@ -28,6 +27,22 @@ const SKIP_CONTEXT_PATTERNS = [
 ];
 
 const FETCH_TIMEOUT_MS = 4000;
+// The dialectic chat() call is far slower than context() (~12s at medium, up to
+// ~120s at max reasoning), so it gets its own budget rather than the 4s context
+// race. Matched to the 120s read-path (UserPromptSubmit) hook ceiling in
+// hooks.json so the richest tiers can complete. This is a synchronous injection,
+// so the user's turn blocks for up to this long when dialectic is enabled. (The
+// prompt upload no longer runs here — it's a separate async hook — so this
+// budget is the whole hook.)
+const DIALECTIC_TIMEOUT_MS = 120000;
+
+/** Resolve a promise with its value, or null if `ms` elapses or it rejects. */
+function raceTimeout<T>(p: Promise<T>, ms: number): Promise<T | null> {
+  return Promise.race([
+    p.catch(() => null),
+    new Promise<null>((resolve) => setTimeout(() => resolve(null), ms)),
+  ]);
+}
 
 /**
  * Extract meaningful topics from a prompt for semantic search. Returns terms
@@ -131,15 +146,8 @@ export async function handleUserPrompt(): Promise<void> {
   logHook("user-prompt", `Prompt received (${prompt.length} chars)`);
   setSessionLink(honchoSessionUrl(config.workspace, sessionName), sessionName, hookInput.session_id);
 
-  // Upload the prompt immediately, concurrent with context retrieval and
-  // awaited before each exit. Log-and-drop on failure, like stop.ts.
-  let uploadPromise: Promise<void> = Promise.resolve();
-  if (config.saveMessages !== false) {
-    uploadPromise = postUserMessage(config, prompt, instanceId || undefined, sessionName)
-      .catch((e) => {
-        logHook("user-prompt", `Immediate upload failed: ${e}`);
-      });
-  }
+  // The prompt upload runs as a separate async hook (save-user-message.ts) so
+  // the write never blocks this turn's injection. This hook is read-only.
 
   // Track message count for threshold-based refresh
   const messageCountBefore = getMessageCount();
@@ -171,90 +179,111 @@ export async function handleUserPrompt(): Promise<void> {
   if (shouldSkipContextRetrieval(prompt)) {
     logHook("user-prompt", "Skipping context (trivial prompt)");
     visSkipMessage("user-prompt", sessionLink ? `${sessionLink} · trivial prompt` : "trivial prompt");
-    await uploadPromise;
     process.exit(0);
   }
 
   const injection = getInjectionConfig(config);
   const wantContext = injection.perTurn.includes("context");
+  const wantDialectic = injection.perTurn.includes("dialectic");
 
-  if (!wantContext) {
+  if (!wantContext && !wantDialectic) {
     logHook("user-prompt", "No per-turn injection components selected");
     visSkipMessage("user-prompt", sessionLink ? `${sessionLink} · injection off` : "injection off");
-    await uploadPromise;
     process.exit(0);
   }
 
   setMemoryState("recalling", undefined, hookInput.session_id);
 
-  const fetchResult = await Promise.race([
-    fetchFreshContext(config, prompt, injection).then(r => ({ ok: true as const, ...r })),
-    new Promise<{ ok: false }>(resolve => setTimeout(() => resolve({ ok: false }), FETCH_TIMEOUT_MS)),
-  ]).catch((): { ok: false } => ({ ok: false }));
+  // Both components run concurrently on independent budgets: context on the tight
+  // 4s race, dialectic on its own ~25s budget. Neither blocks the other, and the
+  // hook completes as soon as the slowest selected component resolves or times out.
+  const [ctxResult, dialectic] = await Promise.all([
+    wantContext ? raceTimeout(fetchFreshContext(config, prompt, injection), FETCH_TIMEOUT_MS) : Promise.resolve(null),
+    wantDialectic ? raceTimeout(fetchDialectic(config, prompt, injection), DIALECTIC_TIMEOUT_MS) : Promise.resolve(null),
+  ]);
 
   const ctx: { context: any; matched?: string[]; queryLabel?: string } | null =
-    fetchResult.ok && fetchResult.context
-      ? { context: fetchResult.context, matched: fetchResult.matched, queryLabel: fetchResult.queryLabel }
+    ctxResult?.context
+      ? { context: ctxResult.context, matched: ctxResult.matched, queryLabel: ctxResult.queryLabel }
       : null;
 
-  emitPerTurn(config.peerName, ctx, sessionLink);
-  await uploadPromise;
+  emitPerTurn(config.peerName, ctx, dialectic, sessionLink);
   process.exit(0);
 }
 
-
-// Upload a user prompt. SessionStart already created the session/peers
-
-async function postUserMessage(
-  config: any,
-  prompt: string,
-  instanceId: string | undefined,
-  sessionName: string,
-): Promise<void> {
-  const honcho = new Honcho(getHonchoClientOptions(config));
-  const noEnsure = () => Promise.resolve();
-
-  const userPeer = new Peer(config.peerName, honcho.workspaceId, honcho.http, undefined, undefined, noEnsure);
-  const createdAt = new Date().toISOString();
-  const messages = chunkContent(prompt).map((chunk) =>
-    userPeer.message(chunk, {
-      createdAt,
-      metadata: {
-        instance_id: instanceId || undefined,
-        session_affinity: sessionName,
-      },
-    })
-  );
-
-  logApiCall("session.addMessages", "POST", `user prompt (${prompt.length} chars, ${messages.length} msg, direct)`);
-  try {
-    const session = new Session(sessionName, honcho.workspaceId, honcho.http, undefined, undefined, noEnsure);
-    await addMessagesBatched(session, messages);
-  } catch (e) {
-    logHook("user-prompt", `Direct upload failed, retrying via get-or-create: ${e}`);
-    const session = await honcho.session(sessionName);
-    await addMessagesBatched(session, messages);
-  }
-}
-
 /**
- * Emit the per-turn "context" injection: the cache/fresh/stale context blob
- * formatted into additionalContext plus its systemMessage. Exits silently when
- * nothing resolved — mirroring the old no-cache fall-through.
+ * Emit the per-turn injection: the selected components ("context" and/or
+ * "dialectic") composed into one additionalContext payload plus a per-component
+ * systemMessage summary. Exits silently when nothing resolved to content —
+ * mirroring the old no-cache fall-through.
  */
 function emitPerTurn(
   peerName: string,
   ctx: { context: any; matched?: string[]; queryLabel?: string } | null,
+  dialectic: DialecticResult | null,
   sessionLink?: string,
 ): void {
-  if (!ctx) return;
+  const parts: string[] = [];
+  const visLines: string[] = [];
 
-  const conclusions = extractConclusions(ctx.context);
-  if (conclusions.length === 0) return;
+  if (ctx) {
+    const conclusions = extractConclusions(ctx.context);
+    if (conclusions.length > 0) {
+      parts.push(`Relevant conclusions: ${conclusions.join("; ")}`);
+      visLines.push(visInjectionMessage("user-prompt", { conclusions, matched: ctx.matched, queryLabel: ctx.queryLabel }));
+    }
+  }
 
-  const parts = [`Relevant conclusions: ${conclusions.join("; ")}`];
-  const visMsg = visInjectionMessage("user-prompt", { conclusions, matched: ctx.matched, queryLabel: ctx.queryLabel });
+  if (dialectic) {
+    parts.push(`Dialectic recall: ${dialectic.answer}`);
+    visLines.push(visDialecticMessage("user-prompt", dialectic.reasoning, dialectic.elapsedMs, dialectic.answer));
+  }
+
+  if (parts.length === 0) return;
+
+  const visMsg = visLines.join("\n");
   outputContext(peerName, parts, sessionLink ? `${sessionLink}\n${visMsg}` : visMsg);
+}
+
+interface DialecticResult {
+  answer: string;
+  reasoning: ReasoningLevel;
+  elapsedMs: number;
+}
+
+/**
+ * Per-turn "dialectic" component: a reasoned peer.chat() answer over the peer's
+ * representation, seeded from `dialecticTemplate` (the prompt substituted into
+ * %{user_query}). Unscoped by session so recall spans the peer's full history,
+ * not just this conversation. Returns null on empty/failed answer.
+ */
+async function fetchDialectic(config: any, prompt: string, injection: InjectionConfig): Promise<DialecticResult | null> {
+  const honcho = new Honcho(getHonchoClientOptions(config));
+  const observationMode = getObservationMode(config);
+
+  // unified: query the user peer directly; directional: the ai peer about the user.
+  const dialecticPeer = observationMode === "unified"
+    ? await honcho.peer(config.peerName)
+    : await honcho.peer(config.aiPeer);
+  const target = observationMode === "unified" ? undefined : config.peerName;
+
+  const reasoning = (injection.dialecticReasoning ?? "low") as ReasoningLevel;
+  const query = (injection.dialecticTemplate ?? "%{user_query}").replace(/%\{user_query\}/g, prompt);
+  const startTime = Date.now();
+
+  try {
+    const answer = await dialecticPeer.chat(query, {
+      ...(target ? { target } : {}),
+      reasoningLevel: reasoning,
+    });
+    const elapsedMs = Date.now() - startTime;
+    logApiCall("peer.chat (dialectic)", "POST", `${reasoning}: ${query.slice(0, 60)}`, elapsedMs, true);
+    if (typeof answer !== "string" || !answer.trim()) return null;
+    return { answer: answer.trim(), reasoning, elapsedMs };
+  } catch (e) {
+    logHook("user-prompt", `Dialectic fetch failed: ${e}`);
+    return null;
+  }
 }
 
 async function fetchFreshContext(config: any, prompt: string, injection: InjectionConfig): Promise<{ context: any; matched: string[]; queryLabel?: string }> {

--- a/plugins/honcho/src/mcp/server.ts
+++ b/plugins/honcho/src/mcp/server.ts
@@ -28,6 +28,7 @@ import {
   type PerTurnComponent,
   SESSION_START_COMPONENTS,
   PER_TURN_COMPONENTS,
+  REASONING_LEVELS,
   getObservationMode,
 } from "../config.js";
 import { honchoSessionUrl } from "../styles.js";
@@ -541,6 +542,26 @@ function handleSetConfig(args: Record<string, unknown>) {
       cfg.injection.searchQuerySource = value;
       break;
 
+    case "injection.dialecticTemplate":
+      previousValue = cfg.injection?.dialecticTemplate;
+      if (!cfg.injection) cfg.injection = {};
+      cfg.injection.dialecticTemplate = String(value);
+      break;
+
+    case "injection.dialecticReasoning": {
+      const level = String(value);
+      if (!REASONING_LEVELS.includes(level as ReasoningLevel)) {
+        return {
+          content: [{ type: "text", text: JSON.stringify({ success: false, error: `injection.dialecticReasoning must be one of: ${REASONING_LEVELS.join(", ")}` }, null, 2) }],
+          isError: true,
+        };
+      }
+      previousValue = cfg.injection?.dialecticReasoning;
+      if (!cfg.injection) cfg.injection = {};
+      cfg.injection.dialecticReasoning = level as ReasoningLevel;
+      break;
+    }
+
     case "sessions.set": {
       const obj = value as Record<string, unknown>;
       const path = obj?.path;
@@ -831,6 +852,8 @@ export async function runMcpServer(): Promise<void> {
                   "injection.maxConclusions",
                   "injection.searchMaxDistance",
                   "injection.searchQuerySource",
+                  "injection.dialecticTemplate",
+                  "injection.dialecticReasoning",
                   "sessions.set",
                   "sessions.remove",
                 ],

--- a/plugins/honcho/src/visual.ts
+++ b/plugins/honcho/src/visual.ts
@@ -75,6 +75,17 @@ export function visInjectionMessage(hookName: string, opts: {
 }
 
 /**
+ * Build the per-turn systemMessage for the "dialectic" component: a status line
+ * (tier · elapsed) followed by the full reasoned answer, so the user sees
+ * exactly what was injected. The answer is prose and can be long — that's the
+ * intended trade-off; it also lands in additionalContext for the model.
+ */
+export function visDialecticMessage(hookName: string, reasoning: string, elapsedMs: number, answer: string): string {
+  const head = formatLine("in", hookName, `injected dialectic (${reasoning} · ${(elapsedMs / 1000).toFixed(1)}s)`);
+  return answer.trim() ? `${head}\n${answer.trim()}` : head;
+}
+
+/**
  * Build the systemMessage for the SessionStart composition: a single status
  * line naming which components were injected (e.g. "injected summary + peer
  * card (12 items)"). Session start is a once-per-session surface, so unlike the


### PR DESCRIPTION
* add dialectic option for per-turn user hook (not yet added to session start hook)
* split up the per-turn hooks with one for posting data to honcho, and one for querying memory and injecting
* the "write" hooks are marked as `async` now

## Testing

I ran this locally and it was working well. I found the best results to come from using `medium` while `low` and `minimal` were not helpful (I set medium as the default).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional dialectic recall to per-turn memory injection, including configurable templates and reasoning levels.
  * Added automatic saving of submitted prompts with asynchronous processing and retry support.
  * Added configuration controls for dialectic recall.
* **Improvements**
  * Context and dialectic memory are fetched concurrently with separate timeout handling.
  * Increased the maximum request timeout for improved reliability.
  * Hook processing now completes more quickly without blocking prompt handling.
* **Documentation**
  * Updated configuration guidance for dialectic recall, JSON selections, and latency considerations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->