### PR TITLE
fix(hooks): declare hook timeouts in seconds, not milliseconds

### DIFF
--- a/plugins/honcho/hooks/hooks.json
+++ b/plugins/honcho/hooks/hooks.json
@@ -7,12 +7,12 @@
           {
             "type": "command",
             "command": "bash \"${CLAUDE_PLUGIN_ROOT}/scripts/check-version.sh\"",
-            "timeout": 2000
+            "timeout": 5
           },
           {
             "type": "command",
             "command": "bun run ${CLAUDE_PLUGIN_ROOT}/hooks/session-start.ts",
-            "timeout": 30000,
+            "timeout": 30,
             "async": true
           }
         ]
@@ -24,7 +24,7 @@
           {
             "type": "command",
             "command": "bun run ${CLAUDE_PLUGIN_ROOT}/hooks/session-end.ts",
-            "timeout": 30000
+            "timeout": 30
           }
         ]
       }
@@ -49,7 +49,7 @@
           {
             "type": "command",
             "command": "bun run ${CLAUDE_PLUGIN_ROOT}/hooks/pre-tool-honcho.ts",
-            "timeout": 4000
+            "timeout": 4
           }
         ]
       }
@@ -65,7 +65,7 @@
           {
             "type": "command",
             "command": "bun run ${CLAUDE_PLUGIN_ROOT}/hooks/save-user-message.ts",
-            "timeout": 30000,
+            "timeout": 30,
             "async": true
           }
         ]
@@ -78,7 +78,7 @@
           {
             "type": "command",
             "command": "bun run ${CLAUDE_PLUGIN_ROOT}/hooks/pre-compact.ts",
-            "timeout": 20000
+            "timeout": 120
           }
         ]
       },
@@ -88,7 +88,7 @@
           {
             "type": "command",
             "command": "bun run ${CLAUDE_PLUGIN_ROOT}/hooks/pre-compact.ts",
-            "timeout": 20000
+            "timeout": 120
           }
         ]
       }

--- a/plugins/honcho/package.json
+++ b/plugins/honcho/package.json
@@ -14,6 +14,10 @@
   ],
   "author": "Plastic Labs",
   "license": "MIT",
+  "scripts": {
+    "test": "bun test",
+    "typecheck": "tsc --noEmit"
+  },
   "dependencies": {
     "@honcho-ai/sdk": "^2.1.0",
     "@modelcontextprotocol/sdk": "^1.26.0"

--- a/plugins/honcho/src/hooks-manifest.test.ts
+++ b/plugins/honcho/src/hooks-manifest.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Guards hooks.json against millisecond values in the `timeout` field.
+ *
+ * Claude Code's hook `timeout` is in SECONDS ("Seconds before canceling.
+ * Defaults: 600 for `command` ... UserPromptSubmit lowers the default to 30").
+ * The plugin's manifest was originally written with millisecond values, so a
+ * "10 second" intent was spelled `10000` — which Claude Code reads as 10,000
+ * seconds, i.e. ~2.8 hours. The values are only ever an upper bound, so nothing
+ * fails loudly; a hook that hangs simply keeps its slot for hours instead of
+ * being cancelled.
+ *
+ * These tests are deterministic (pure JSON parsing, no network, no SDK) and
+ * exist so the next hook added to the manifest can't silently reintroduce the
+ * unit mix-up.
+ */
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+/** Documented ceiling for a `command` hook's default timeout, in seconds.
+ *  Nothing in this plugin legitimately needs longer, and any value above it is
+ *  far more likely to be milliseconds than a deliberate multi-hour budget. */
+const MAX_REASONABLE_TIMEOUT_SECONDS = 600;
+
+interface HookEntry {
+  type?: string;
+  command?: string;
+  timeout?: number;
+  async?: boolean;
+}
+
+interface Matcher {
+  matcher?: string;
+  hooks?: HookEntry[];
+}
+
+interface Manifest {
+  description?: string;
+  hooks: Record<string, Matcher[]>;
+}
+
+const manifestPath = join(import.meta.dir, "..", "hooks", "hooks.json");
+const manifest: Manifest = JSON.parse(readFileSync(manifestPath, "utf8"));
+
+/** Flatten the manifest to (event, command, entry) triples for table-driven assertions. */
+function allHooks(): Array<{ event: string; label: string; entry: HookEntry }> {
+  const out: Array<{ event: string; label: string; entry: HookEntry }> = [];
+  for (const [event, matchers] of Object.entries(manifest.hooks ?? {})) {
+    for (const matcher of matchers ?? []) {
+      for (const entry of matcher.hooks ?? []) {
+        // Label by script basename so a failure message names the hook, not an index.
+        const label = (entry.command ?? "<no command>").split("/").pop()?.replace(/"$/, "") ?? "<unknown>";
+        out.push({ event, label, entry });
+      }
+    }
+  }
+  return out;
+}
+
+describe("hooks.json manifest", () => {
+  test("is non-empty (guards against a silently broken parse)", () => {
+    expect(allHooks().length).toBeGreaterThan(0);
+  });
+
+  test.each(allHooks().map((h) => [`${h.event} · ${h.label}`, h.entry] as const))(
+    "%s declares its timeout in seconds, not milliseconds",
+    (_name, entry) => {
+      if (entry.timeout === undefined) return; // optional — Claude Code applies its default
+      expect(Number.isInteger(entry.timeout)).toBe(true);
+      expect(entry.timeout).toBeGreaterThan(0);
+      expect(entry.timeout).toBeLessThanOrEqual(MAX_REASONABLE_TIMEOUT_SECONDS);
+    },
+  );
+
+  test("no hook would outlive a single working day", () => {
+    // Restates the bound as one aggregate assertion whose failure message lists
+    // every offender at once, rather than one failing case per hook.
+    const offenders = allHooks()
+      .filter((h) => (h.entry.timeout ?? 0) > MAX_REASONABLE_TIMEOUT_SECONDS)
+      .map((h) => `${h.event}/${h.label}=${h.entry.timeout}s (${((h.entry.timeout ?? 0) / 3600).toFixed(1)}h)`);
+    expect(offenders).toEqual([]);
+  });
+
+  test("every hook entry is structurally complete", () => {
+    for (const { event, label, entry } of allHooks()) {
+      expect(entry.type, `${event}/${label} missing type`).toBe("command");
+      expect(entry.command, `${event}/${label} missing command`).toBeTruthy();
+    }
+  });
+});


### PR DESCRIPTION
## The bug

Claude Code's hook `timeout` is in **seconds** ([docs](https://code.claude.com/docs/en/hooks): *"Seconds before canceling. Defaults: 600 for `command`, `http`, and `mcp_tool`"*), but `hooks/hooks.json` was written with millisecond values, so every intent is inflated 1000×:

| Event / hook | Declared | Actually means |
|---|---|---|
| SessionStart / `check-version.sh` | `2000` | 33 minutes |
| SessionStart / `session-start.ts` | `30000` | 8.3 hours |
| SessionEnd / `session-end.ts` | `30000` | 8.3 hours |
| PreToolUse / `pre-tool-honcho.ts` | `4000` | 1.1 hours |
| UserPromptSubmit / `save-user-message.ts` | `30000` | 8.3 hours |
| PreCompact / `pre-compact.ts` (×2) | `20000` | 5.6 hours |

ebf3bde (#85) converted three entries to seconds (`post-tool-use` 10000 → 10, `user-prompt` 7000 → 120, `stop` 10000 → 10), but the other seven kept their millisecond values — and the `save-user-message` entry added in that same commit was written as `30000`.

## Why it matters (and why it's quiet)

The timeout is only an upper bound, so nothing fails loudly — a wedged hook just holds its slot for hours instead of being cancelled. Severity is uneven:

- `session-end.ts` self-limits internally (12s hard timeout), so its manifest value is a harmless backstop.
- `pre-tool-honcho.ts` does no network I/O at all.
- The ones that actually bite are the **synchronous** hooks with no internal budget — `pre-compact.ts` above all. With an unreachable Honcho endpoint it can stall a turn far past any intended budget. Self-hosted deployments hit this first.

## The change

Six entries are a mechanical ÷1000 back to the author's original intent. **Two deliberate deviations:**

- **`check-version.sh`: 2000 → 5**, not 2. The script's own `curl --max-time 2` means a 2s wrapper budget would kill it mid-fetch.
- **`pre-compact.ts`: 20000 → 120**, not 20. It makes two `peer.chat()` dialectic calls, which this project documents as ~12s at medium and up to ~120s at max reasoning — #72 raised the MCP tool ceiling to 120s for exactly this. A 20s bound would *newly* kill a hook that has been effectively unbounded, losing the memory anchor at the one moment it exists to preserve. 120s matches the ceiling already used for the other dialectic-bearing hook, `user-prompt.ts`.

Happy to change either of those two if you'd rather keep the conversion purely mechanical.

## Regression test

`src/hooks-manifest.test.ts` parses the manifest and asserts every `timeout` is a positive integer ≤ 600 (the documented `command` default), so the next hook added can't silently reintroduce the mix-up. It's deterministic — pure JSON parsing, no network, no SDK.

Written before the fix, it went red on exactly the seven offenders:

```
- []
+ [
+   "SessionStart/check-version.sh=2000s (0.6h)",
+   "SessionStart/session-start.ts=30000s (8.3h)",
+   "SessionEnd/session-end.ts=30000s (8.3h)",
+   "PreToolUse/pre-tool-honcho.ts=4000s (1.1h)",
+   "UserPromptSubmit/save-user-message.ts=30000s (8.3h)",
+   "PreCompact/pre-compact.ts=20000s (5.6h)",
+   "PreCompact/pre-compact.ts=20000s (5.6h)",
+ ]
```

After the fix: `13 pass, 0 fail`. Mutation-checked by restoring one ms value — it goes red again and names it.

Since the package had no `scripts` block, this also adds `test` (`bun test`) and `typecheck` (`tsc --noEmit`, currently clean) so the guard is runnable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Reduced lifecycle hook timeouts to help commands complete more quickly and avoid extended waits.

* **Tests**
  * Added validation to ensure hook timeouts use reasonable values and all hook entries are properly configured.

* **Chores**
  * Added commands for running automated tests and TypeScript checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->