### PR TITLE
fix: drop the dead transcript parse from SessionEnd

### DIFF
--- a/plugins/honcho/src/hooks/session-end.ts
+++ b/plugins/honcho/src/hooks/session-end.ts
@@ -1,8 +1,5 @@
 import { loadConfig, getSessionName, isPluginEnabled, getCachedStdin } from "../config.js";
-import { existsSync, readFileSync } from "fs";
-import {
-  getInstanceIdForCwd,
-} from "../cache.js";
+import { getInstanceIdForCwd } from "../cache.js";
 import { clearSessionFiles } from "../state.js";
 import { logHook, setLogContext } from "../log.js";
 
@@ -15,95 +12,12 @@ interface HookInput {
   workspace_roots?: string[];
 }
 
-interface TranscriptEntry {
-  type: string;
-  timestamp?: string;
-  message?: {
-    role?: string;
-    content: string | Array<{ type: string; text?: string; name?: string; input?: any }>;
-  };
-  role?: string;
-  content?: string | Array<{ type: string; text?: string }>;
-}
-
-function parseTranscript(transcriptPath: string): Array<{ role: string; content: string; timestamp?: string }> {
-  const messages: Array<{ role: string; content: string; timestamp?: string }> = [];
-
-  if (!transcriptPath || !existsSync(transcriptPath)) {
-    return messages;
-  }
-
-  try {
-    const content = readFileSync(transcriptPath, "utf-8");
-    const lines = content.split("\n").filter((line) => line.trim());
-
-    for (const line of lines) {
-      try {
-        const entry: TranscriptEntry = JSON.parse(line);
-        const entryType = entry.type || entry.role;
-        const messageContent = entry.message?.content || entry.content;
-
-        if (entryType === "user" && messageContent) {
-          const userContent =
-            typeof messageContent === "string"
-              ? messageContent
-              : messageContent
-                  .filter((p) => p.type === "text")
-                  .map((p) => p.text || "")
-                  .join("\n");
-          if (userContent && userContent.trim()) {
-            messages.push({ role: "user", content: userContent, timestamp: entry.timestamp });
-          }
-        } else if (entryType === "assistant" && messageContent) {
-          let assistantContent = "";
-
-          if (typeof messageContent === "string") {
-            assistantContent = messageContent;
-          } else if (Array.isArray(messageContent)) {
-            const textBlocks = messageContent
-              .filter((p) => p.type === "text" && p.text)
-              .map((p) => p.text!)
-              .join("\n\n");
-
-            const toolUses = messageContent
-              .filter((p) => p.type === "tool_use")
-              .map((p: any) => p.name)
-              .filter(Boolean);
-
-            assistantContent = textBlocks;
-
-            if (toolUses.length > 0 && textBlocks.length < 100) {
-              assistantContent = textBlocks + (textBlocks ? "\n" : "") + `[Used tools: ${toolUses.join(", ")}]`;
-            }
-          }
-
-          if (assistantContent && assistantContent.trim()) {
-            // Counted for the end-marker message tally only — assistant
-            // messages upload live from the stop hook, not here.
-            messages.push({
-              role: "assistant",
-              content: assistantContent,
-              timestamp: entry.timestamp,
-            });
-          }
-        }
-      } catch {
-        continue;
-      }
-    }
-  } catch {
-    // Failed to read transcript
-  }
-
-  return messages;
-}
-
 /**
- * SessionEnd hook — structured for resilience against cancellation.
- *
- * Priority order (most critical first):
- *   1. Parallel: cooldown animation + API uploads (critical data first)
- *   2. Session end marker (nice-to-have metadata)
+ * SessionEnd hook — must return instantly. On /exit the harness aborts slow
+ * hooks and surfaces "SessionEnd hook failed: Hook cancelled", so nothing here
+ * touches the network. Messages upload live from the other hooks, and the old
+ * [Session ended] marker only ever derived lifecycle exhaust ("claude's
+ * session ended at ...") — write-only telemetry, never read back.
  */
 export async function handleSessionEnd(): Promise<void> {
   const config = loadConfig();
@@ -127,25 +41,13 @@ export async function handleSessionEnd(): Promise<void> {
 
   const cwd = hookInput.workspace_roots?.[0] || hookInput.cwd || process.cwd();
   const reason = hookInput.reason || "unknown";
-  const transcriptPath = hookInput.transcript_path;
   const instanceId = hookInput.session_id || getInstanceIdForCwd(cwd);
   const sessionName = getSessionName(cwd, instanceId || undefined);
 
   setLogContext(cwd, sessionName);
   logHook("session-end", `Session ending`, { reason });
 
-  // =========================================================
-  // Phase 1: parse transcript for the end-marker message count.
-  // The on-disk local work summary was retired here — nothing consumed it, and
-  // the server-side session.summaries() long summary now stays fresh on its own
-  // since we upload every turn live.
-  // =========================================================
-  const transcriptMessages = transcriptPath ? parseTranscript(transcriptPath) : [];
-
-  // No end-of-session upload: messages are saved live by the other hooks, and
-  // the [Session ended] marker only ever derived lifecycle exhaust
-  // ("claude's session ended at ...") — write-only telemetry, never read back.
-  logHook("session-end", `Session ended (${transcriptMessages.length} msgs handled live)`);
   clearSessionFiles(hookInput.session_id);
+  logHook("session-end", "Session ended — no upload (messages saved live)");
   process.exit(0);
 }


### PR DESCRIPTION
## Problem

`/exit` still triggers:

```
SessionEnd hook [bun run ${CLAUDE_PLUGIN_ROOT}/hooks/session-end.ts] failed: Hook cancelled
```

## Fix

Nothing really needs to happen at session end anymore: messages upload live during the session, and the end marker + cooldown animation are already gone from main. The one thing left was a full transcript parse used only to put a message count in a log line.

This PR removes it. SessionEnd now just logs and clears session state — ~20ms, zero I/O beyond stdin — so the harness abort window on `/exit` can never cancel it, regardless of transcript size.

The `@honcho-ai/sdk` 2.1.0 → 2.2.0 bump was deliberately left out — it'll ride along with the Node-compatible-bundle work, where it lands without vendored node_modules churn.

## Verification

Live-tested with real interactive sessions (`script`-driven pty, typing `/exit`):

- **Old hook (pre-#77 code): reproduces the exact error** — `SessionEnd hook [bun run ${CLAUDE_PLUGIN_ROOT}/hooks/session-end.ts] failed: Hook cancelled` appears in the terminal on exit.
- **This branch: no error.** Clean exit; activity.log shows `reason: prompt_input_exit` with both session-end log lines 1ms apart.
- `tsc --noEmit` clean; direct smoke run exits 0 in ~20ms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)