### PR TITLE
chore: version bump

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,14 +6,14 @@
   },
   "metadata": {
     "description": "Honcho plugins for Claude Code - memory, development tools, and more",
-    "version": "0.2.6"
+    "version": "0.2.8"
   },
   "plugins": [
     {
       "name": "honcho",
       "source": "./plugins/honcho",
       "description": "Persistent memory for Claude Code sessions using Honcho",
-      "version": "0.2.6",
+      "version": "0.2.8",
       "keywords": ["memory", "context", "persistence"],
       "strict": false
     },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to claude-honcho will be documented in this file.
 
 ## [Unreleased]
 
+## [0.2.8] - 2026-07-27
+
+### Added
+
+- `/honcho:import` skill to backfill past Claude Code sessions into Honcho memory.
+- Composable, config-driven memory injection — `injection` config block with per-surface component menus (`sessionStart` / `perTurn`) and retrieval tuning (`searchTopK`, `maxConclusions`, `searchMaxDistance`).
+- Memory-usage directives now ship automatically as SessionStart context — no more manual CLAUDE.md paste.
+- Optional dialectic summary component for the user-prompt hook.
+- `honcho_remember` MCP tool for mid-conversation recall (batched questions, configurable reasoning tier) — opt in via the `rememberTool` config flag; session-start directives nudge proactive use when enabled.
+
+### Fixed
+
+- Machine plumbing (runtime `<<...>>` sentinels, `[Session ended]` markers) is no longer attributed to the user peer.
+- Batched message uploads no longer replay already-accepted batches after a partial failure.
+- SessionEnd hook does nothing beyond logging and state cleanup, so `/exit` can no longer surface "Hook cancelled".
+
 ## [0.2.7] - 2026-07-22
 
 ### Added

--- a/plugins/honcho/.claude-plugin/plugin.json
+++ b/plugins/honcho/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "honcho",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "description": "Persistent memory for Claude Code sessions using Honcho by Plastic Labs",
   "author": {
     "name": "Plastic Labs",

--- a/plugins/honcho/package.json
+++ b/plugins/honcho/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-honcho",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "description": "Persistent memory for Claude Code sessions using Honcho by Plastic Labs",
   "type": "module",
   "keywords": [


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `/honcho:import` for importing existing Claude Code sessions into memory.
  * Added configurable memory injection, retrieval tuning, and per-surface component menus.
  * Added automatic memory guidance at session start.
  * Added optional dialectic summaries and the `honcho_remember` tool for in-conversation recall.

* **Bug Fixes**
  * Improved attribution and reliability of batched message uploads.
  * Updated session-end handling to prevent “Hook cancelled” messages.

* **Chores**
  * Updated the release version to 0.2.8.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->