### PR TITLE
fix: as suggested in #66 make sure harness injected turns are not used in retrieval queries

### DIFF
--- a/plugins/honcho/src/hooks/user-prompt.ts
+++ b/plugins/honcho/src/hooks/user-prompt.ts
@@ -202,10 +202,11 @@ export async function handleUserPrompt(): Promise<void> {
         ? formatSessionLink(honchoSessionUrl(config.workspace, sessionName))
         : undefined;
 
-  // Skip trivial prompts — no context needed for "y", "ok", etc.
-  if (shouldSkipContextRetrieval(prompt)) {
-    logHook("user-prompt", "Skipping context (trivial prompt)");
-    visSkipMessage("user-prompt", sessionLink ? `${sessionLink} · trivial prompt` : "trivial prompt");
+  // Skip trivial prompts — no context needed for "y", "ok", etc. Harness-injected
+  // turns are excluded from storage; don't use them as retrieval queries either.
+  if (isHarnessInjected(prompt) || shouldSkipContextRetrieval(prompt)) {
+    logHook("user-prompt", "Skipping context (harness-injected or trivial prompt)");
+    visSkipMessage("user-prompt", sessionLink ? `${sessionLink} · skipped` : "skipped");
     process.exit(0);
   }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved prompt handling by skipping unnecessary context retrieval for both automated prompts and trivial prompts.
  * Updated skip messages and logging to accurately reflect why context retrieval was bypassed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->