### PR TITLE
feat: configurable dashboard URL + suppress session links for local endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,11 @@ All notable changes to claude-honcho will be documented in this file.
 
 ### Added
 
-- Configurable dashboard URL for session links. Self-hosted deployments can point the clickable "view your session" links at their own GUI instead of the hardcoded `app.honcho.dev`. Set it via the `endpoint.dashboardUrl` config field, the `set_config` MCP tool, or the `HONCHO_DASHBOARD_URL` env var (which takes precedence). Useful when the GUI runs on a different host than the API (e.g. API at `honcho.example.com`, dashboard at `dashboard.example.com`). (#67, thanks @djuntgen)
+- `endpoint.dashboardUrl` config field (or `HONCHO_DASHBOARD_URL` env var) to point session links at a self-hosted GUI. (#67, thanks @djuntgen)
 
 ### Fixed
 
-- Session GUI links are no longer printed for local or custom self-hosted endpoints when no dashboard URL is configured — the hosted GUI only exists for `production`, so pointing users at a cloud workspace that does not contain their sessions was misleading. The `user-prompt` hook suppresses the "view your session in honcho GUI" line, `get_config`/`set_config` MCP responses omit `sessionUrl`, and `sessionLine()` falls back to a plain label in those cases. Hosted users see no change. (#31, thanks @smkrv)
+- Session links are suppressed on local/custom endpoints when no dashboard URL is configured, instead of pointing at the hosted GUI. (#31, thanks @smkrv)
 
 ## [0.2.8] - 2026-07-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to claude-honcho will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- Configurable dashboard URL for session links. Self-hosted deployments can point the clickable "view your session" links at their own GUI instead of the hardcoded `app.honcho.dev`. Set it via the `endpoint.dashboardUrl` config field, the `set_config` MCP tool, or the `HONCHO_DASHBOARD_URL` env var (which takes precedence). Useful when the GUI runs on a different host than the API (e.g. API at `honcho.example.com`, dashboard at `dashboard.example.com`). (#67, thanks @djuntgen)
+
+### Fixed
+
+- Session GUI links are no longer printed for local or custom self-hosted endpoints when no dashboard URL is configured — the hosted GUI only exists for `production`, so pointing users at a cloud workspace that does not contain their sessions was misleading. The `user-prompt` hook suppresses the "view your session in honcho GUI" line, `get_config`/`set_config` MCP responses omit `sessionUrl`, and `sessionLine()` falls back to a plain label in those cases. Hosted users see no change. (#31, thanks @smkrv)
+
 ## [0.2.8] - 2026-07-27
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -199,8 +199,10 @@ All configuration lives in a single global file at `~/.honcho/config.json`. You 
 
   // Endpoint
   "endpoint": {
-    "environment": "production"       // "production" | "local"
+    "environment": "production",      // "production" | "local"
     // or: "baseUrl": "http://your-server:8000/v3"
+    // Self-hosted GUI on a different host than the API? Point session links at it:
+    "dashboardUrl": "https://dashboard.your-server.com"
   },
 
   // Miscellaneous
@@ -384,6 +386,7 @@ Environment variables work for initial bootstrap (before a config file exists). 
 | `HONCHO_AI_PEER`       | No       | `claude`      | AI peer name                                                      |
 | `HONCHO_HOST`          | No       | auto-detected | Force host detection: `claude_code`, `cursor`, or `obsidian`      |
 | `HONCHO_ENDPOINT`      | No       | `production`  | `production`, `local`, or a full URL                              |
+| `HONCHO_DASHBOARD_URL` | No       | `https://app.honcho.dev` | GUI base URL for session links (for self-hosted dashboards) |
 | `HONCHO_ENABLED`       | No       | `true`        | Set to `false` to disable                                         |
 | `HONCHO_SAVE_MESSAGES` | No       | `true`        | Set to `false` to stop saving messages                            |
 | `HONCHO_LOGGING`       | No       | `true`        | Set to `false` to disable file logging to `~/.honcho/`            |
@@ -459,6 +462,18 @@ Or via env var:
 export HONCHO_ENDPOINT="local"  # Uses localhost:8000
 # or
 export HONCHO_ENDPOINT="http://your-server:8000/v3"
+```
+
+On the hosted platform, session links printed by the plugin point at
+`https://app.honcho.dev`. On a local or custom endpoint the links are suppressed
+entirely — there's no hosted GUI for your data. If you self-host the dashboard
+(often on a different host than the API), point the links at your own GUI to
+bring them back:
+```json
+{ "endpoint": { "baseUrl": "https://honcho.your-server.com/v3", "dashboardUrl": "https://dashboard.your-server.com" } }
+```
+```bash
+export HONCHO_DASHBOARD_URL="https://dashboard.your-server.com"
 ```
 
 ### Temporarily disabling memory

--- a/plugins/honcho/src/config.ts
+++ b/plugins/honcho/src/config.ts
@@ -128,12 +128,22 @@ export interface HonchoEndpointConfig {
   environment?: HonchoEnvironment;
   /** Custom URL override (takes precedence over environment) */
   baseUrl?: string;
+  /**
+   * Dashboard (GUI) base URL used to build clickable session links.
+   * Self-hosted deployments often serve the GUI on a different host than the
+   * API (e.g. API at honcho.example.com, GUI at dashboard.example.com), so this
+   * is configured independently of `baseUrl`. Defaults to the hosted platform.
+   */
+  dashboardUrl?: string;
 }
 
 const HONCHO_BASE_URLS = {
   production: "https://api.honcho.dev/v3",
   local: "http://localhost:8000/v3",
 } as const;
+
+/** Dashboard (GUI) base URL for the hosted platform. */
+const DEFAULT_DASHBOARD_URL = "https://app.honcho.dev";
 
 // ============================================
 // Host Detection
@@ -483,6 +493,7 @@ export function loadConfigFromEnv(host?: HonchoHost): HonchoCLAUDEConfig | null 
     : process.env.HONCHO_CLAUDE_PEER;
   const aiPeer = process.env.HONCHO_AI_PEER || hostPeerEnv || DEFAULT_AI_PEER[resolvedHost];
   const endpoint = process.env.HONCHO_ENDPOINT;
+  const dashboardUrl = process.env.HONCHO_DASHBOARD_URL;
 
   const config: HonchoCLAUDEConfig = {
     apiKey,
@@ -502,6 +513,10 @@ export function loadConfigFromEnv(host?: HonchoHost): HonchoCLAUDEConfig | null 
     } else if (endpoint.startsWith("http")) {
       config.endpoint = { baseUrl: endpoint };
     }
+  }
+
+  if (dashboardUrl) {
+    config.endpoint = { ...config.endpoint, dashboardUrl };
   }
 
   return config;
@@ -869,6 +884,26 @@ export function getHonchoBaseUrl(config: HonchoCLAUDEConfig): string {
   return getHonchoBaseUrlForEndpoint(config.endpoint);
 }
 
+/**
+ * Get the dashboard (GUI) base URL used for session links.
+ * Priority: HONCHO_DASHBOARD_URL env > endpoint.dashboardUrl > hosted default.
+ * Returns null for local/custom endpoints with no dashboard configured — the
+ * hosted GUI only exists for production, so a link would point at a cloud
+ * workspace that doesn't contain the user's sessions.
+ * Trailing slashes are stripped so callers can safely append a path.
+ */
+export function getDashboardUrlForEndpoint(endpoint?: HonchoEndpointConfig): string | null {
+  const raw = process.env.HONCHO_DASHBOARD_URL || endpoint?.dashboardUrl;
+  if (raw) return raw.replace(/\/+$/, "");
+  if (endpoint?.baseUrl || endpoint?.environment === "local") return null;
+  return DEFAULT_DASHBOARD_URL;
+}
+
+/** Get the dashboard (GUI) base URL for a resolved runtime config. */
+export function getDashboardUrl(config: HonchoCLAUDEConfig): string | null {
+  return getDashboardUrlForEndpoint(config.endpoint);
+}
+
 export function getHonchoClientOptions(config: HonchoCLAUDEConfig): HonchoClientOptions {
   return {
     apiKey: config.apiKey,
@@ -896,10 +931,20 @@ export function getObservationMode(config: HonchoCLAUDEConfig): ObservationMode 
   return config.observationMode ?? "unified";
 }
 
-export function setEndpoint(environment?: HonchoEnvironment, baseUrl?: string): void {
+export function setEndpoint(
+  environment?: HonchoEnvironment,
+  baseUrl?: string,
+  dashboardUrl?: string,
+): void {
   const config = loadConfig();
   if (!config) return;
   if (environment && !VALID_ENVIRONMENTS.has(environment)) return;
-  config.endpoint = { environment, baseUrl };
+  // Preserve an existing custom dashboard URL when the caller doesn't set one —
+  // switching API environment shouldn't silently reset the GUI link target.
+  config.endpoint = {
+    environment,
+    baseUrl,
+    dashboardUrl: dashboardUrl ?? config.endpoint?.dashboardUrl,
+  };
   saveConfig(config);
 }

--- a/plugins/honcho/src/hooks/session-start.ts
+++ b/plugins/honcho/src/hooks/session-start.ts
@@ -1,5 +1,5 @@
 import { Honcho } from "@honcho-ai/sdk";
-import { loadConfig, getSessionForPath, setSessionForPath, getSessionName, getHonchoClientOptions, isPluginEnabled, getCachedStdin, getObservationMode, getInjectionConfig } from "../config.js";
+import { loadConfig, getSessionForPath, setSessionForPath, getSessionName, getHonchoClientOptions, isPluginEnabled, getCachedStdin, getObservationMode, getInjectionConfig, getDashboardUrl } from "../config.js";
 import { renderSessionStart } from "../injection.js";
 import {
   setCachedSessionId,
@@ -80,7 +80,7 @@ export async function handleSessionStart(): Promise<void> {
   const spinner = new Spinner({ style: "neural" });
   spinner.start(`${sessionName} · loading memory`);
   setMemoryState("loading", sessionName, claudeInstanceId);
-  setSessionLink(honchoSessionUrl(config.workspace, sessionName), sessionName, claudeInstanceId);
+  setSessionLink(honchoSessionUrl(config.workspace, sessionName, getDashboardUrl(config)), sessionName, claudeInstanceId);
 
   try {
     logHook("session-start", `Starting session in ${cwd}`, { branch: currentGitState?.branch });

--- a/plugins/honcho/src/hooks/user-prompt.ts
+++ b/plugins/honcho/src/hooks/user-prompt.ts
@@ -1,7 +1,7 @@
 import { Honcho } from "@honcho-ai/sdk";
 import { readFileSync, existsSync } from "node:fs";
 import { join } from "node:path";
-import { loadConfig, getSessionName, getHonchoClientOptions, isPluginEnabled, getCachedStdin, getObservationMode, getInjectionConfig, type InjectionConfig } from "../config.js";
+import { loadConfig, getSessionName, getHonchoClientOptions, isPluginEnabled, getCachedStdin, getObservationMode, getInjectionConfig, getDashboardUrl, type InjectionConfig } from "../config.js";
 import {
   getMessageCount,
   incrementMessageCount,
@@ -171,7 +171,10 @@ export async function handleUserPrompt(): Promise<void> {
   }
 
   logHook("user-prompt", `Prompt received (${prompt.length} chars)`);
-  setSessionLink(honchoSessionUrl(config.workspace, sessionName), sessionName, hookInput.session_id);
+  // Null for local/custom endpoints with no dashboard configured — the link is
+  // suppressed everywhere it would otherwise surface.
+  const sessionUrl = honchoSessionUrl(config.workspace, sessionName, getDashboardUrl(config));
+  setSessionLink(sessionUrl, sessionName, hookInput.session_id);
 
   // The prompt upload runs as a separate async hook (save-user-message.ts) so
   // the write never blocks this turn's injection. This hook is read-only.
@@ -195,11 +198,12 @@ export async function handleUserPrompt(): Promise<void> {
   // The nag flag is written at SessionStart and stable for the session, so
   // its presence on message 2 tells us the link hasn't been shown yet.
   const nag = readVersionNag();
+  const guiLink = sessionUrl ? formatSessionLink(sessionUrl) : undefined;
   const sessionLink =
     messageCountBefore === 0
-      ? nag ?? formatSessionLink(honchoSessionUrl(config.workspace, sessionName))
+      ? nag ?? guiLink
       : messageCountBefore === 1 && nag
-        ? formatSessionLink(honchoSessionUrl(config.workspace, sessionName))
+        ? guiLink
         : undefined;
 
   // Skip trivial prompts — no context needed for "y", "ok", etc.

--- a/plugins/honcho/src/mcp/server.ts
+++ b/plugins/honcho/src/mcp/server.ts
@@ -16,6 +16,7 @@ import {
   configExists,
   getDetectedHost,
   getEndpointInfo,
+  getDashboardUrl,
   getKnownHosts,
   setDetectedHost,
   type HonchoCLAUDEConfig,
@@ -53,6 +54,7 @@ const ENV_SHADOW_MAP: Record<string, string> = {
   saveMessages: "HONCHO_SAVE_MESSAGES",
   "endpoint.baseUrl": "HONCHO_ENDPOINT",
   "endpoint.environment": "HONCHO_ENDPOINT",
+  "endpoint.dashboardUrl": "HONCHO_DASHBOARD_URL",
 };
 
 // Fields that require confirm=true to change
@@ -130,7 +132,8 @@ function handleGetConfig(cwd: string) {
     ? endpointInfo.type === "production" ? "platform" : endpointInfo.type
     : null;
 
-  const sessionUrl = cfg && sessionName ? honchoSessionUrl(cfg.workspace, sessionName) : null;
+  // undefined (omitted from the JSON response) when no dashboard applies
+  const sessionUrl = cfg && sessionName ? honchoSessionUrl(cfg.workspace, sessionName, getDashboardUrl(cfg)) ?? undefined : undefined;
 
   const current = cfg ? {
     workspace: cfg.workspace,
@@ -391,6 +394,18 @@ function handleSetConfig(args: Record<string, unknown>) {
       cacheInvalidation = { cleared: ["all IDs", "all context"], reason: "Endpoint URL changed" };
       break;
 
+    case "endpoint.dashboardUrl": {
+      previousValue = cfg.endpoint?.dashboardUrl;
+      if (!cfg.endpoint) cfg.endpoint = {};
+      // Empty string clears the override, reverting to the hosted default.
+      const dash = String(value).trim();
+      cfg.endpoint.dashboardUrl = dash === "" ? undefined : dash;
+      // endpoint is a global field — write to root (user-directed action).
+      // Display-only (session links); no ID/context cache to invalidate.
+      saveRootField("endpoint", cfg.endpoint);
+      break;
+    }
+
     case "sessionStrategy":
       previousValue = cfg.sessionStrategy ?? "per-directory";
       cfg.sessionStrategy = String(value) as SessionStrategy;
@@ -643,7 +658,7 @@ function handleSetConfig(args: Record<string, unknown>) {
   // Include session URL when session-affecting fields change
   const cwd = getLastActiveCwd() || process.cwd();
   const newSessionName = SESSION_AFFECTING_FIELDS.has(field) ? getSessionName(cwd) : undefined;
-  const sessionUrl = newSessionName ? honchoSessionUrl(cfg.workspace, newSessionName) : undefined;
+  const sessionUrl = newSessionName ? honchoSessionUrl(cfg.workspace, newSessionName, getDashboardUrl(cfg)) ?? undefined : undefined;
 
   return {
     content: [{
@@ -889,6 +904,7 @@ export async function runMcpServer(): Promise<void> {
                   "globalOverride",
                   "endpoint.environment",
                   "endpoint.baseUrl",
+                  "endpoint.dashboardUrl",
                   "sessionStrategy",
                   "sessionPeerPrefix",
                   "enabled",

--- a/plugins/honcho/src/state.ts
+++ b/plugins/honcho/src/state.ts
@@ -38,10 +38,12 @@ export function setMemoryState(phase: MemoryPhase, detail?: string, sessionId?: 
 }
 
 // The hooks own the workspace + session-name math, so they write the resolved
-// web URL here for the statusline to render as a clickable link.
-export function setSessionLink(url: string, name: string | undefined, sessionId?: string): void {
+// web URL here for the statusline to render as a clickable link. A null url
+// (local/custom endpoint, no dashboard configured) writes the name alone and
+// the statusline renders it without a link.
+export function setSessionLink(url: string | null, name: string | undefined, sessionId?: string): void {
   try {
-    writeFileSync(sessionFile(sessionId), JSON.stringify({ url, name }));
+    writeFileSync(sessionFile(sessionId), JSON.stringify({ url: url ?? undefined, name }));
   } catch {
     // best-effort — statusline just omits the link if this is missing
   }

--- a/plugins/honcho/src/styles.ts
+++ b/plugins/honcho/src/styles.ts
@@ -146,11 +146,24 @@ export function highlight(text: string): string {
   return `${colors.peach}${text}${colors.reset}`;
 }
 
+/** Default dashboard (GUI) base URL — the hosted platform. */
+const DEFAULT_DASHBOARD_URL = "https://app.honcho.dev";
+
 /**
- * Build a Honcho app URL for a session
+ * Build a Honcho dashboard URL for a session.
+ * `dashboardBaseUrl` lets self-hosted deployments point links at their own GUI
+ * (resolve it via getDashboardUrl(config)); it defaults to the hosted platform.
+ * Pass null (what getDashboardUrl returns for local/custom endpoints with no
+ * dashboard configured) to get null back, so callers can suppress the link.
  */
-export function honchoSessionUrl(workspace: string, sessionName: string): string {
-  return `https://app.honcho.dev/explore?workspace=${encodeURIComponent(workspace)}&view=sessions&session=${encodeURIComponent(sessionName)}`;
+export function honchoSessionUrl(
+  workspace: string,
+  sessionName: string,
+  dashboardBaseUrl: string | null = DEFAULT_DASHBOARD_URL,
+): string | null {
+  if (dashboardBaseUrl === null) return null;
+  const base = dashboardBaseUrl.replace(/\/+$/, "");
+  return `${base}/explore?workspace=${encodeURIComponent(workspace)}&view=sessions&session=${encodeURIComponent(sessionName)}`;
 }
 
 /**
@@ -161,9 +174,15 @@ export function hyperlink(url: string, text: string): string {
 }
 
 /**
- * Styled session line with clickable hyperlink to Honcho app
+ * Styled session line with clickable hyperlink to Honcho app (when available)
  */
-export function sessionLine(workspace: string, sessionName: string): string {
-  const url = honchoSessionUrl(workspace, sessionName);
-  return `${colors.dim}Honcho session:${colors.reset} ${hyperlink(url, `${colors.skyBlue}${sessionName}${colors.reset}`)}`;
+export function sessionLine(
+  workspace: string,
+  sessionName: string,
+  dashboardBaseUrl?: string | null,
+): string {
+  const url = honchoSessionUrl(workspace, sessionName, dashboardBaseUrl);
+  const label = `${colors.dim}Honcho session:${colors.reset}`;
+  const name = `${colors.skyBlue}${sessionName}${colors.reset}`;
+  return url ? `${label} ${hyperlink(url, name)}` : `${label} ${name}`;
 }


### PR DESCRIPTION
## Summary

Combines #67 (@djuntgen) and #31 (@smkrv), which edit the same function in `styles.ts` and are two halves of one behavior. Both authors are credited as co-authors on the commit.

The session-link resolution in `getDashboardUrlForEndpoint()` is now:

1. `HONCHO_DASHBOARD_URL` env var (wins, trailing slashes stripped)
2. `endpoint.dashboardUrl` config field (settable via the `set_config` MCP tool; empty string clears it)
3. Neither set + local or custom-`baseUrl` endpoint → `null`: the link is suppressed everywhere
4. Production → hosted default `https://app.honcho.dev` — **hosted users see no change**

## From #67 (configurable dashboard URL)

- `endpoint.dashboardUrl` config field + `HONCHO_DASHBOARD_URL` env var, since the GUI often lives on a different host than the API and can't be derived from `endpoint.baseUrl`
- `set_config` MCP field `endpoint.dashboardUrl`; `setEndpoint()` preserves a custom dashboard URL across API-environment switches
- All call sites (`session-start`, `user-prompt`, `mcp/server`) thread the resolved value

## From #31 (suppress link for local/custom endpoints)

- `honchoSessionUrl()` returns `string | null` — the hosted GUI only exists for production, so pointing self-hosted users at a cloud workspace that doesn't contain their sessions was misleading
- `user-prompt` hook skips the "view your session in honcho GUI" line when null
- `get_config` / `set_config` omit `sessionUrl` when null
- `sessionLine()` falls back to a plain styled label; `setSessionLink()` writes the session name without a URL and the statusline renders it link-less (already handled `url` being absent)

The suppression check lives in the config resolver rather than `styles.ts`, so a configured dashboard URL naturally overrides it — configuring a dashboard on a local endpoint brings the links back, pointed at your own GUI.

## Testing

- `bunx tsc --noEmit` passes
- Runtime-verified the full matrix: production default unchanged, explicit production unchanged, local/no-dashboard → null, custom-baseUrl/no-dashboard → null, local+dashboardUrl and custom+dashboardUrl → custom GUI URL, env var wins over local suppression, trailing slashes normalized, `sessionLine(null)` renders plain label

Supersedes #67 and #31.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `endpoint.dashboardUrl` (and `HONCHO_DASHBOARD_URL`) to control where session links point for self-hosted dashboards.
  * Session link URLs are now built from an optional dashboard base URL and normalize trailing slashes.

* **Bug Fixes**
  * Session links are suppressed for local/custom endpoints when no dashboard URL is configured (no clickable hyperlink), while session names still display.

* **Documentation**
  * Updated README and changelog with configuration examples and troubleshooting steps to re-enable session links via `endpoint.baseUrl`/`endpoint.dashboardUrl` or `HONCHO_DASHBOARD_URL`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->