### PR TITLE
build: self contained npm plugin build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,48 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: plugins/honcho
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Type check
+        run: bunx tsc --noEmit
+
+      - name: Build release stage
+        run: bun run scripts/build.ts
+
+      - name: Validate plugins
+        run: |
+          npm install -g @anthropic-ai/claude-code
+          claude plugin validate .stage --strict
+          claude plugin validate . --strict
+          claude plugin validate ../honcho-dev --strict
+
+      # Every bundled hook must run from a bare directory: no node_modules on
+      # the resolution path, config disabled so hooks exit without network.
+      - name: Smoke test bundled hooks
+        run: |
+          SMOKE="$(mktemp -d)"
+          cp -R .stage/. "$SMOKE"
+          export HOME="$(mktemp -d)"
+          mkdir -p "$HOME/.honcho"
+          echo '{"apiKey":"smoke","enabled":false}' > "$HOME/.honcho/config.json"
+          cd "$SMOKE"
+          for hook in dist/hooks/*.js; do
+            echo "smoke: $hook"
+            echo '{"session_id":"ci","cwd":"/tmp","hook_event_name":"SessionStart","source":"startup"}' | bun run "$hook"
+          done

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
           cd "$SMOKE"
           for hook in dist/hooks/*.js; do
             echo "smoke: $hook"
-            echo '{"session_id":"ci","cwd":"/tmp","hook_event_name":"SessionStart","source":"startup"}' | node "$hook"
+            echo '{"session_id":"ci","cwd":"/tmp","hook_event_name":"SessionStart","source":"startup"}' | timeout 15 node "$hook"
           done
           echo "smoke: dist/mcp-server.js"
           printf '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"smoke","version":"0"}}}\n' \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,10 @@ jobs:
 
       - uses: oven-sh/setup-bun@v2
 
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
@@ -32,9 +36,10 @@ jobs:
           claude plugin validate . --strict
           claude plugin validate ../honcho-dev --strict
 
-      # Every bundled hook must run from a bare directory: no node_modules on
-      # the resolution path, config disabled so hooks exit without network.
-      - name: Smoke test bundled hooks
+      # Every bundled entry point must run under node (the shipped runtime)
+      # from a bare directory: no node_modules on the resolution path, config
+      # disabled so hooks exit without network.
+      - name: Smoke test bundled entry points
         run: |
           SMOKE="$(mktemp -d)"
           cp -R .stage/. "$SMOKE"
@@ -44,5 +49,8 @@ jobs:
           cd "$SMOKE"
           for hook in dist/hooks/*.js; do
             echo "smoke: $hook"
-            echo '{"session_id":"ci","cwd":"/tmp","hook_event_name":"SessionStart","source":"startup"}' | bun run "$hook"
+            echo '{"session_id":"ci","cwd":"/tmp","hook_event_name":"SessionStart","source":"startup"}' | node "$hook"
           done
+          echo "smoke: dist/mcp-server.js"
+          printf '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"smoke","version":"0"}}}\n' \
+            | timeout 15 node dist/mcp-server.js | grep -q '"serverInfo"'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,21 +36,5 @@ jobs:
           claude plugin validate . --strict
           claude plugin validate ../honcho-dev --strict
 
-      # Every bundled entry point must run under node (the shipped runtime)
-      # from a bare directory: no node_modules on the resolution path, config
-      # disabled so hooks exit without network.
       - name: Smoke test bundled entry points
-        run: |
-          SMOKE="$(mktemp -d)"
-          cp -R .stage/. "$SMOKE"
-          export HOME="$(mktemp -d)"
-          mkdir -p "$HOME/.honcho"
-          echo '{"apiKey":"smoke","enabled":false}' > "$HOME/.honcho/config.json"
-          cd "$SMOKE"
-          for hook in dist/hooks/*.js; do
-            echo "smoke: $hook"
-            echo '{"session_id":"ci","cwd":"/tmp","hook_event_name":"SessionStart","source":"startup"}' | timeout 15 node "$hook"
-          done
-          echo "smoke: dist/mcp-server.js"
-          printf '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"smoke","version":"0"}}}\n' \
-            | timeout 15 node dist/mcp-server.js | grep -q '"serverInfo"'
+        run: bash scripts/smoke.sh .stage

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,121 @@
+name: Release
+
+# Releases the honcho plugin: bumps the single version field in
+# plugins/honcho/package.json, builds the self-contained stage, publishes it
+# to npm (with provenance) and to the release/honcho branch, then commits the
+# bump, tags, and cuts a GitHub Release. The npm publish comes after the bump
+# commit so a failed publish leaves a committed version that a rerun with
+# bump=none can retry.
+#
+# Requires the NPM_TOKEN secret: an npm automation token with publish rights
+# on the @honcho-ai scope.
+
+on:
+  workflow_dispatch:
+    inputs:
+      bump:
+        description: Version bump (none reuses the committed version, e.g. to retry a failed publish)
+        type: choice
+        required: true
+        default: patch
+        options: [patch, minor, major, prepatch, preminor, premajor, prerelease, none]
+      dist-tag:
+        description: npm dist-tag (use next for release candidates)
+        type: choice
+        required: true
+        default: latest
+        options: [latest, next]
+
+concurrency:
+  group: release
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  id-token: write # npm provenance
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: plugins/honcho
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - uses: oven-sh/setup-bun@v2
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          registry-url: https://registry.npmjs.org
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Bump version
+        id: version
+        run: |
+          if [ "${{ inputs.bump }}" != "none" ]; then
+            npm version "${{ inputs.bump }}" --preid=rc --no-git-tag-version
+          fi
+          echo "version=$(node -p "require('./package.json').version")" >> "$GITHUB_OUTPUT"
+
+      - name: Build release stage
+        run: bun run scripts/build.ts
+
+      - name: Validate staged plugin
+        run: |
+          npm install -g @anthropic-ai/claude-code
+          claude plugin validate .stage --strict
+
+      - name: Smoke test bundled entry points
+        run: |
+          SMOKE="$(mktemp -d)"
+          cp -R .stage/. "$SMOKE"
+          export HOME="$(mktemp -d)"
+          mkdir -p "$HOME/.honcho"
+          echo '{"apiKey":"smoke","enabled":false}' > "$HOME/.honcho/config.json"
+          cd "$SMOKE"
+          for hook in dist/hooks/*.js; do
+            echo '{"session_id":"ci","cwd":"/tmp","hook_event_name":"SessionStart","source":"startup"}' | node "$hook"
+          done
+          printf '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"smoke","version":"0"}}}\n' \
+            | timeout 15 node dist/mcp-server.js | grep -q '"serverInfo"'
+
+      - name: Commit bump and tag
+        if: inputs.bump != 'none'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add package.json
+          git commit -m "chore(release): honcho v${{ steps.version.outputs.version }}"
+          git tag "honcho-v${{ steps.version.outputs.version }}"
+          git push origin main --follow-tags
+
+      - name: Publish to npm
+        run: npm publish .stage --provenance --access public --tag "${{ inputs.dist-tag }}"
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      # Standby distribution channel: the same staged tree on an orphan
+      # branch, so marketplace.json can switch to a github source with a
+      # one-line change if npm distribution ever becomes a problem.
+      - name: Push release branch
+        run: |
+          cd .stage
+          git init -b release/honcho
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add -A
+          git commit -m "honcho v${{ steps.version.outputs.version }}"
+          git push -f "https://x-access-token:${{ github.token }}@github.com/${{ github.repository }}.git" release/honcho
+
+      - name: Create GitHub Release
+        if: inputs.bump != 'none'
+        run: gh release create "honcho-v${{ steps.version.outputs.version }}" --generate-notes --title "honcho v${{ steps.version.outputs.version }}" ${{ inputs.dist-tag == 'next' && '--prerelease' || '' }}
+        env:
+          GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,11 +1,12 @@
 name: Release
 
-# Releases the honcho plugin: bumps the single version field in
-# plugins/honcho/package.json, builds the self-contained stage, publishes it
-# to npm (with provenance) and to the release/honcho branch, then commits the
-# bump and cuts a GitHub Release (which creates the tag). The publish and
-# release steps are idempotent, so a rerun with bump=none retries whatever a
-# failed run left undone without burning a version number.
+# Releases the honcho plugin. Source carries no release version: the version
+# is a dispatch input, stamped into the staged plugin.json and package.json
+# at build time, so a release never commits anything to main. The registry
+# and the GitHub Releases page are the record of what is published.
+#
+# Publish and release creation are idempotent, so re-dispatching the same
+# version completes whatever a failed run left undone.
 #
 # The npm dist-tag is derived from the version: prerelease versions publish
 # under next, stable versions under latest.
@@ -16,19 +17,17 @@ name: Release
 on:
   workflow_dispatch:
     inputs:
-      bump:
-        description: Version bump (none reuses the committed version, e.g. to retry a failed publish)
-        type: choice
+      version:
+        description: "Version to release (e.g. 0.3.0 or 0.3.0-rc.1)"
+        type: string
         required: true
-        default: patch
-        options: [patch, minor, major, prepatch, preminor, premajor, prerelease, none]
 
 concurrency:
   group: release
   cancel-in-progress: false
 
 permissions:
-  contents: write
+  contents: write # release/honcho branch, tag + GitHub Release
   id-token: write # npm provenance
 
 jobs:
@@ -43,9 +42,6 @@ jobs:
         working-directory: plugins/honcho
     steps:
       - uses: actions/checkout@v4
-        with:
-          ref: main
-          fetch-depth: 0
 
       - uses: oven-sh/setup-bun@v2
 
@@ -54,28 +50,42 @@ jobs:
           node-version: 22
           registry-url: https://registry.npmjs.org
 
-      - name: Install dependencies
-        run: bun install --frozen-lockfile
-
-      - name: Bump version
+      # npm's latest tag points at the most recently published version, not
+      # the semver max, so a non-monotonic stable release would repoint
+      # latest backwards. Prereleases are exempt (they publish under next).
+      - name: Validate version
         id: version
         run: |
-          if [ "${{ inputs.bump }}" != "none" ]; then
-            npm version "${{ inputs.bump }}" --preid=rc --no-git-tag-version
+          VERSION="${{ inputs.version }}"
+          if ! echo "$VERSION" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$'; then
+            echo "::error::'$VERSION' is not a valid semver version"
+            exit 1
           fi
-          VERSION="$(node -p "require('./package.json').version")"
           case "$VERSION" in
             *-*) DIST_TAG=next; PRERELEASE=true ;;
             *)   DIST_TAG=latest; PRERELEASE=false ;;
           esac
+          CURRENT="$(npm view @honcho-ai/claude-plugin dist-tags.latest 2>/dev/null || true)"
+          if [ "$DIST_TAG" = "latest" ] && [ -n "$CURRENT" ]; then
+            HIGHEST="$(printf '%s\n%s\n' "$CURRENT" "$VERSION" | sort -V | tail -n1)"
+            if [ "$HIGHEST" != "$VERSION" ] || [ "$CURRENT" = "$VERSION" ]; then
+              echo "::error::$VERSION is not greater than the published latest ($CURRENT)"
+              exit 1
+            fi
+          fi
           {
             echo "version=$VERSION"
             echo "dist-tag=$DIST_TAG"
             echo "prerelease=$PRERELEASE"
           } >> "$GITHUB_OUTPUT"
 
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
       - name: Build release stage
         run: bun run scripts/build.ts
+        env:
+          RELEASE_VERSION: ${{ steps.version.outputs.version }}
 
       - name: Validate staged plugin
         run: |
@@ -97,17 +107,6 @@ jobs:
           echo "smoke: dist/mcp-server.js"
           printf '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"smoke","version":"0"}}}\n' \
             | timeout 15 node dist/mcp-server.js | grep -q '"serverInfo"'
-
-      - name: Commit bump
-        id: commit
-        if: inputs.bump != 'none'
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add package.json
-          git commit -m "chore(release): honcho v${{ steps.version.outputs.version }}"
-          git push origin main
-          echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
       - name: Publish to npm
         run: |
@@ -139,12 +138,11 @@ jobs:
         run: |
           VERSION="${{ steps.version.outputs.version }}"
           TAG="honcho-v$VERSION"
-          TARGET="${{ steps.commit.outputs.sha || github.sha }}"
           if gh release view "$TAG" >/dev/null 2>&1; then
             echo "$TAG release already exists; skipping"
           else
             gh release create "$TAG" \
-              --target "$TARGET" \
+              --target "${{ github.sha }}" \
               --title "honcho v$VERSION" \
               --generate-notes \
               $([ "${{ steps.version.outputs.prerelease }}" = "true" ] && echo --prerelease)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,8 +55,9 @@ jobs:
       # latest backwards. Prereleases are exempt (they publish under next).
       - name: Validate version
         id: version
+        env:
+          VERSION: ${{ inputs.version }}
         run: |
-          VERSION="${{ inputs.version }}"
           if ! echo "$VERSION" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$'; then
             echo "::error::'$VERSION' is not a valid semver version"
             exit 1
@@ -65,11 +66,14 @@ jobs:
             *-*) DIST_TAG=next; PRERELEASE=true ;;
             *)   DIST_TAG=latest; PRERELEASE=false ;;
           esac
+          # Equal versions pass through: re-dispatching a published version is
+          # the retry path, and the later publish/release steps skip what
+          # already exists.
           CURRENT="$(npm view @honcho-ai/claude-plugin dist-tags.latest 2>/dev/null || true)"
-          if [ "$DIST_TAG" = "latest" ] && [ -n "$CURRENT" ]; then
+          if [ "$DIST_TAG" = "latest" ] && [ -n "$CURRENT" ] && [ "$CURRENT" != "$VERSION" ]; then
             HIGHEST="$(printf '%s\n%s\n' "$CURRENT" "$VERSION" | sort -V | tail -n1)"
-            if [ "$HIGHEST" != "$VERSION" ] || [ "$CURRENT" = "$VERSION" ]; then
-              echo "::error::$VERSION is not greater than the published latest ($CURRENT)"
+            if [ "$HIGHEST" != "$VERSION" ]; then
+              echo "::error::$VERSION is lower than the published latest ($CURRENT)"
               exit 1
             fi
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,7 +69,7 @@ jobs:
           # Equal versions pass through: re-dispatching a published version is
           # the retry path, and the later publish/release steps skip what
           # already exists.
-          CURRENT="$(npm view @honcho-ai/claude-plugin dist-tags.latest 2>/dev/null || true)"
+          CURRENT="$(npm view @honcho-ai/claude-honcho dist-tags.latest 2>/dev/null || true)"
           if [ "$DIST_TAG" = "latest" ] && [ -n "$CURRENT" ] && [ "$CURRENT" != "$VERSION" ]; then
             HIGHEST="$(printf '%s\n%s\n' "$CURRENT" "$VERSION" | sort -V | tail -n1)"
             if [ "$HIGHEST" != "$VERSION" ]; then
@@ -97,25 +97,12 @@ jobs:
           claude plugin validate .stage --strict
 
       - name: Smoke test bundled entry points
-        run: |
-          SMOKE="$(mktemp -d)"
-          cp -R .stage/. "$SMOKE"
-          export HOME="$(mktemp -d)"
-          mkdir -p "$HOME/.honcho"
-          echo '{"apiKey":"smoke","enabled":false}' > "$HOME/.honcho/config.json"
-          cd "$SMOKE"
-          for hook in dist/hooks/*.js; do
-            echo "smoke: $hook"
-            echo '{"session_id":"ci","cwd":"/tmp","hook_event_name":"SessionStart","source":"startup"}' | timeout 15 node "$hook"
-          done
-          echo "smoke: dist/mcp-server.js"
-          printf '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"smoke","version":"0"}}}\n' \
-            | timeout 15 node dist/mcp-server.js | grep -q '"serverInfo"'
+        run: bash scripts/smoke.sh .stage
 
       - name: Publish to npm
         run: |
           VERSION="${{ steps.version.outputs.version }}"
-          if npm view "@honcho-ai/claude-plugin@$VERSION" version >/dev/null 2>&1; then
+          if npm view "@honcho-ai/claude-honcho@$VERSION" version >/dev/null 2>&1; then
             echo "$VERSION already on npm; skipping publish"
           else
             npm publish .stage --provenance --access public --tag "${{ steps.version.outputs.dist-tag }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,9 +3,12 @@ name: Release
 # Releases the honcho plugin: bumps the single version field in
 # plugins/honcho/package.json, builds the self-contained stage, publishes it
 # to npm (with provenance) and to the release/honcho branch, then commits the
-# bump, tags, and cuts a GitHub Release. The npm publish comes after the bump
-# commit so a failed publish leaves a committed version that a rerun with
-# bump=none can retry.
+# bump and cuts a GitHub Release (which creates the tag). The publish and
+# release steps are idempotent, so a rerun with bump=none retries whatever a
+# failed run left undone without burning a version number.
+#
+# The npm dist-tag is derived from the version: prerelease versions publish
+# under next, stable versions under latest.
 #
 # Requires the NPM_TOKEN secret: an npm automation token with publish rights
 # on the @honcho-ai scope.
@@ -19,12 +22,6 @@ on:
         required: true
         default: patch
         options: [patch, minor, major, prepatch, preminor, premajor, prerelease, none]
-      dist-tag:
-        description: npm dist-tag (use next for release candidates)
-        type: choice
-        required: true
-        default: latest
-        options: [latest, next]
 
 concurrency:
   group: release
@@ -36,7 +33,11 @@ permissions:
 
 jobs:
   release:
+    # Dispatch runs the workflow definition from the selected ref; only the
+    # reviewed copy on main may perform a release.
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     defaults:
       run:
         working-directory: plugins/honcho
@@ -62,7 +63,16 @@ jobs:
           if [ "${{ inputs.bump }}" != "none" ]; then
             npm version "${{ inputs.bump }}" --preid=rc --no-git-tag-version
           fi
-          echo "version=$(node -p "require('./package.json').version")" >> "$GITHUB_OUTPUT"
+          VERSION="$(node -p "require('./package.json').version")"
+          case "$VERSION" in
+            *-*) DIST_TAG=next; PRERELEASE=true ;;
+            *)   DIST_TAG=latest; PRERELEASE=false ;;
+          esac
+          {
+            echo "version=$VERSION"
+            echo "dist-tag=$DIST_TAG"
+            echo "prerelease=$PRERELEASE"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Build release stage
         run: bun run scripts/build.ts
@@ -81,23 +91,32 @@ jobs:
           echo '{"apiKey":"smoke","enabled":false}' > "$HOME/.honcho/config.json"
           cd "$SMOKE"
           for hook in dist/hooks/*.js; do
-            echo '{"session_id":"ci","cwd":"/tmp","hook_event_name":"SessionStart","source":"startup"}' | node "$hook"
+            echo "smoke: $hook"
+            echo '{"session_id":"ci","cwd":"/tmp","hook_event_name":"SessionStart","source":"startup"}' | timeout 15 node "$hook"
           done
+          echo "smoke: dist/mcp-server.js"
           printf '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"smoke","version":"0"}}}\n' \
             | timeout 15 node dist/mcp-server.js | grep -q '"serverInfo"'
 
-      - name: Commit bump and tag
+      - name: Commit bump
+        id: commit
         if: inputs.bump != 'none'
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add package.json
           git commit -m "chore(release): honcho v${{ steps.version.outputs.version }}"
-          git tag "honcho-v${{ steps.version.outputs.version }}"
-          git push origin main --follow-tags
+          git push origin main
+          echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
       - name: Publish to npm
-        run: npm publish .stage --provenance --access public --tag "${{ inputs.dist-tag }}"
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          if npm view "@honcho-ai/claude-plugin@$VERSION" version >/dev/null 2>&1; then
+            echo "$VERSION already on npm; skipping publish"
+          else
+            npm publish .stage --provenance --access public --tag "${{ steps.version.outputs.dist-tag }}"
+          fi
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
@@ -114,8 +133,21 @@ jobs:
           git commit -m "honcho v${{ steps.version.outputs.version }}"
           git push -f "https://x-access-token:${{ github.token }}@github.com/${{ github.repository }}.git" release/honcho
 
+      # gh release create makes the tag server-side at --target, so the tag
+      # always lands on the exact commit that was published.
       - name: Create GitHub Release
-        if: inputs.bump != 'none'
-        run: gh release create "honcho-v${{ steps.version.outputs.version }}" --generate-notes --title "honcho v${{ steps.version.outputs.version }}" ${{ inputs.dist-tag == 'next' && '--prerelease' || '' }}
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          TAG="honcho-v$VERSION"
+          TARGET="${{ steps.commit.outputs.sha || github.sha }}"
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            echo "$TAG release already exists; skipping"
+          else
+            gh release create "$TAG" \
+              --target "$TARGET" \
+              --title "honcho v$VERSION" \
+              --generate-notes \
+              $([ "${{ steps.version.outputs.prerelease }}" = "true" ] && echo --prerelease)
+          fi
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,7 +58,9 @@ jobs:
         env:
           VERSION: ${{ inputs.version }}
         run: |
-          if ! echo "$VERSION" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$'; then
+          # Whole-string match: [[ =~ ]] anchors reject embedded CR/LF, which
+          # a line-based grep would let through into GITHUB_OUTPUT.
+          if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
             echo "::error::'$VERSION' is not a valid semver version"
             exit 1
           fi
@@ -68,8 +70,20 @@ jobs:
           esac
           # Equal versions pass through: re-dispatching a published version is
           # the retry path, and the later publish/release steps skip what
-          # already exists.
-          CURRENT="$(npm view @honcho-ai/claude-honcho dist-tags.latest 2>/dev/null || true)"
+          # already exists. Lookups fail closed: only a confirmed E404 (no
+          # package yet) counts as absence.
+          set +e
+          CURRENT_OUT="$(npm view @honcho-ai/claude-honcho dist-tags.latest 2>&1)"
+          CURRENT_STATUS=$?
+          set -e
+          if [ "$CURRENT_STATUS" -eq 0 ]; then
+            CURRENT="$CURRENT_OUT"
+          elif echo "$CURRENT_OUT" | grep -q "E404"; then
+            CURRENT=""
+          else
+            echo "::error::npm lookup for dist-tags.latest failed: $CURRENT_OUT"
+            exit 1
+          fi
           if [ "$DIST_TAG" = "latest" ] && [ -n "$CURRENT" ] && [ "$CURRENT" != "$VERSION" ]; then
             HIGHEST="$(printf '%s\n%s\n' "$CURRENT" "$VERSION" | sort -V | tail -n1)"
             if [ "$HIGHEST" != "$VERSION" ]; then
@@ -100,34 +114,48 @@ jobs:
         run: bash scripts/smoke.sh .stage
 
       - name: Publish to npm
-        run: |
-          VERSION="${{ steps.version.outputs.version }}"
-          if npm view "@honcho-ai/claude-honcho@$VERSION" version >/dev/null 2>&1; then
-            echo "$VERSION already on npm; skipping publish"
-          else
-            npm publish .stage --provenance --access public --tag "${{ steps.version.outputs.dist-tag }}"
-          fi
         env:
+          VERSION: ${{ steps.version.outputs.version }}
+          DIST_TAG: ${{ steps.version.outputs.dist-tag }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          # Fail closed: publish only on a confirmed E404 for this version.
+          set +e
+          EXISTS_OUT="$(npm view "@honcho-ai/claude-honcho@$VERSION" version 2>&1)"
+          EXISTS_STATUS=$?
+          set -e
+          if [ "$EXISTS_STATUS" -eq 0 ] && [ -n "$EXISTS_OUT" ]; then
+            echo "$VERSION already on npm; skipping publish"
+          elif [ "$EXISTS_STATUS" -ne 0 ] && ! echo "$EXISTS_OUT" | grep -q "E404"; then
+            echo "::error::npm lookup for $VERSION failed: $EXISTS_OUT"
+            exit 1
+          else
+            npm publish .stage --provenance --access public --tag "$DIST_TAG"
+          fi
 
       # Standby distribution channel: the same staged tree on an orphan
       # branch, so marketplace.json can switch to a github source with a
       # one-line change if npm distribution ever becomes a problem.
       - name: Push release branch
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
         run: |
           cd .stage
           git init -b release/honcho
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add -A
-          git commit -m "honcho v${{ steps.version.outputs.version }}"
+          git commit -m "honcho v$VERSION"
           git push -f "https://x-access-token:${{ github.token }}@github.com/${{ github.repository }}.git" release/honcho
 
       # gh release create makes the tag server-side at --target, so the tag
       # always lands on the exact commit that was published.
       - name: Create GitHub Release
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+          PRERELEASE: ${{ steps.version.outputs.prerelease }}
+          GH_TOKEN: ${{ github.token }}
         run: |
-          VERSION="${{ steps.version.outputs.version }}"
           TAG="honcho-v$VERSION"
           if gh release view "$TAG" >/dev/null 2>&1; then
             echo "$TAG release already exists; skipping"
@@ -136,7 +164,5 @@ jobs:
               --target "${{ github.sha }}" \
               --title "honcho v$VERSION" \
               --generate-notes \
-              $([ "${{ steps.version.outputs.prerelease }}" = "true" ] && echo --prerelease)
+              $([ "$PRERELEASE" = "true" ] && echo --prerelease)
           fi
-        env:
-          GH_TOKEN: ${{ github.token }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Build output
 /dist/
+.stage/
 
 
 # Bun

--- a/plugins/honcho/.claude-plugin/plugin.json
+++ b/plugins/honcho/.claude-plugin/plugin.json
@@ -10,7 +10,6 @@
   "repository": "https://github.com/plastic-labs/claude-honcho",
   "license": "MIT",
   "keywords": ["memory", "context", "ai", "honcho", "persistence"],
-  "hooks": "./hooks/hooks.json",
   "mcpServers": "./mcp-servers.json",
   "skills": "./skills/"
 }

--- a/plugins/honcho/scripts/build.ts
+++ b/plugins/honcho/scripts/build.ts
@@ -1,0 +1,86 @@
+#!/usr/bin/env bun
+// Stage a self-contained release tree in .stage/: bundle every hook entry
+// point and the MCP server, rewrite manifest paths to the bundled output,
+// and stamp the version from package.json. Nothing in .stage/ is committed.
+import { cp, mkdir, readdir, rm } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+
+const ROOT = join(import.meta.dir, "..");
+const STAGE = join(ROOT, ".stage");
+
+const version = (await Bun.file(join(ROOT, "package.json")).json()).version as string;
+
+await rm(STAGE, { recursive: true, force: true });
+await mkdir(join(STAGE, ".claude-plugin"), { recursive: true });
+
+// Bundle: one self-contained entry per hook wrapper, plus the MCP server.
+const hookEntries = (await readdir(join(ROOT, "hooks")))
+  .filter((f) => f.endsWith(".ts"))
+  .map((f) => join(ROOT, "hooks", f));
+
+const result = await Bun.build({
+  entrypoints: [...hookEntries, join(ROOT, "mcp-server.ts")],
+  outdir: join(STAGE, "dist"),
+  root: ROOT,
+  target: "bun",
+  splitting: true,
+  sourcemap: "linked",
+});
+if (!result.success) {
+  for (const log of result.logs) console.error(log);
+  process.exit(1);
+}
+
+// Manifests: rewrite source entry points to their bundled locations, then
+// verify every rewritten path exists in the stage.
+async function stageManifest(relPath: string): Promise<void> {
+  let text = await Bun.file(join(ROOT, relPath)).text();
+  text = text.replace(
+    /\$\{CLAUDE_PLUGIN_ROOT\}\/(hooks\/[\w-]+|mcp-server)\.ts/g,
+    "${CLAUDE_PLUGIN_ROOT}/dist/$1.js",
+  );
+  for (const [, staged] of text.matchAll(/\$\{CLAUDE_PLUGIN_ROOT\}\/(dist\/[\w/-]+\.js)/g)) {
+    if (!existsSync(join(STAGE, staged))) {
+      console.error(`${relPath} references ${staged}, which the build did not produce`);
+      process.exit(1);
+    }
+  }
+  await Bun.write(join(STAGE, relPath), text);
+}
+await stageManifest("hooks/hooks.json");
+await stageManifest("mcp-servers.json");
+
+// plugin.json: version stamped from package.json. hooks/hooks.json and
+// skills/ are auto-discovered, so neither needs a manifest field.
+const pluginManifest = await Bun.file(join(ROOT, ".claude-plugin/plugin.json")).json();
+await Bun.write(
+  join(STAGE, ".claude-plugin/plugin.json"),
+  JSON.stringify({ ...pluginManifest, version }, null, 2) + "\n",
+);
+
+// package.json: publish manifest for the npm source. Deps are bundled, so
+// none are declared.
+await Bun.write(
+  join(STAGE, "package.json"),
+  JSON.stringify(
+    {
+      name: "@honcho-ai/claude-plugin",
+      version,
+      description: pluginManifest.description,
+      author: "Plastic Labs <hello@plasticlabs.ai>",
+      license: pluginManifest.license,
+      repository: pluginManifest.repository,
+      keywords: pluginManifest.keywords,
+    },
+    null,
+    2,
+  ) + "\n",
+);
+
+await cp(join(ROOT, "skills"), join(STAGE, "skills"), { recursive: true });
+await mkdir(join(STAGE, "scripts"), { recursive: true });
+await cp(join(ROOT, "scripts/check-version.sh"), join(STAGE, "scripts/check-version.sh"));
+
+const bundled = result.outputs.reduce((sum, artifact) => sum + artifact.size, 0);
+console.log(`staged ${version} -> .stage/ (${result.outputs.length} files, ${(bundled / 1024 / 1024).toFixed(1)} MB bundled)`);

--- a/plugins/honcho/scripts/build.ts
+++ b/plugins/honcho/scripts/build.ts
@@ -1,9 +1,10 @@
 #!/usr/bin/env bun
-// Stage a self-contained release tree in .stage/: bundle every hook entry
-// point and the MCP server, rewrite manifest paths to the bundled output,
-// and stamp the version. The version comes from RELEASE_VERSION (set by the
-// release workflow; source carries no release version), falling back to
-// package.json for local builds. Nothing in .stage/ is committed.
+// Stage a self-contained release tree in .stage/: bundle every entry point
+// (hooks, MCP server, skill runners), rewrite manifest and skill paths to
+// the bundled output, and stamp the version. The version comes from
+// RELEASE_VERSION (set by the release workflow), falling back to
+// package.json for local builds; the version fields left in source are
+// dev-only fallbacks, never published. Nothing in .stage/ is committed.
 import { cp, mkdir, readdir, rm } from "node:fs/promises";
 import { existsSync } from "node:fs";
 import { join } from "node:path";
@@ -36,28 +37,55 @@ if (!result.success) {
   process.exit(1);
 }
 
-// Manifests: rewrite source entry points to their bundled locations (the
-// stage runs under node, dev runs .ts under bun), then verify every
-// rewritten path exists in the stage.
+// Skill runners: separate build rooted at src/ so entries land in
+// dist/skills/, where setup-runner's ../../scripts hop finds the staged
+// statusline script.
+const runnerEntries = (await readdir(join(ROOT, "src/skills")))
+  .filter((f) => f.endsWith("-runner.ts"))
+  .map((f) => join(ROOT, "src/skills", f));
+
+const runnerResult = await Bun.build({
+  entrypoints: runnerEntries,
+  outdir: join(STAGE, "dist"),
+  root: join(ROOT, "src"),
+  target: "node",
+  splitting: true,
+  sourcemap: "linked",
+});
+if (!runnerResult.success) {
+  for (const log of runnerResult.logs) console.error(log);
+  process.exit(1);
+}
+
+// Scripts stage before the manifests so the resolution check below can see
+// them.
+await mkdir(join(STAGE, "scripts"), { recursive: true });
+await cp(join(ROOT, "scripts/check-version.sh"), join(STAGE, "scripts/check-version.sh"));
+await cp(join(ROOT, "scripts/honcho-statusline.sh"), join(STAGE, "scripts/honcho-statusline.sh"));
+
+// Every ${CLAUDE_PLUGIN_ROOT} reference in a staged file must resolve within
+// the stage, and none may point at source TypeScript (a rewrite miss).
 function assertStagedPaths(relPath: string, text: string): void {
-  // A rewrite miss leaves a .ts reference behind, which the stage can't serve.
-  const missed = text.match(/"[^"]*\$\{CLAUDE_PLUGIN_ROOT\}[^"]*\.ts[^"]*"/);
-  if (missed) {
-    console.error(`${relPath} still references source TypeScript after rewrite: ${missed[0]}`);
-    process.exit(1);
-  }
-  for (const [, staged] of text.matchAll(/\$\{CLAUDE_PLUGIN_ROOT\}\/(dist\/[\w/-]+\.js)/g)) {
+  for (const [token] of text.matchAll(/\$\{CLAUDE_PLUGIN_ROOT\}\/[^\s"'`)\\]+/g)) {
+    const staged = token.replace("${CLAUDE_PLUGIN_ROOT}/", "");
+    if (staged.endsWith(".ts")) {
+      console.error(`${relPath} still references source TypeScript after rewrite: ${token}`);
+      process.exit(1);
+    }
     if (!existsSync(join(STAGE, staged))) {
-      console.error(`${relPath} references ${staged}, which the build did not produce`);
+      console.error(`${relPath} references ${staged}, which is not in the stage`);
       process.exit(1);
     }
   }
 }
 
-const hooksJson = (await Bun.file(join(ROOT, "hooks/hooks.json")).text()).replace(
-  /bun run \$\{CLAUDE_PLUGIN_ROOT\}\/(hooks\/[\w-]+)\.ts/g,
-  "node ${CLAUDE_PLUGIN_ROOT}/dist/$1.js",
-);
+function rewriteEntryPoints(text: string): string {
+  return text
+    .replace(/bun run ("?)\$\{CLAUDE_PLUGIN_ROOT\}\/(hooks\/[\w-]+|mcp-server)\.ts\1/g, 'node $1${CLAUDE_PLUGIN_ROOT}/dist/$2.js$1')
+    .replace(/bun run ("?)\$\{CLAUDE_PLUGIN_ROOT\}\/src\/(skills\/[\w-]+)\.ts\1/g, 'node $1${CLAUDE_PLUGIN_ROOT}/dist/$2.js$1');
+}
+
+const hooksJson = rewriteEntryPoints(await Bun.file(join(ROOT, "hooks/hooks.json")).text());
 assertStagedPaths("hooks/hooks.json", hooksJson);
 await Bun.write(join(STAGE, "hooks/hooks.json"), hooksJson);
 
@@ -87,7 +115,7 @@ await Bun.write(
   join(STAGE, "package.json"),
   JSON.stringify(
     {
-      name: "@honcho-ai/claude-plugin",
+      name: "@honcho-ai/claude-honcho",
       version,
       type: "module",
       description: pluginManifest.description,
@@ -101,9 +129,17 @@ await Bun.write(
   ) + "\n",
 );
 
+// Skills: copy verbatim except SKILL.md, which gets the same entry-point
+// rewrite and resolution check as the manifests.
 await cp(join(ROOT, "skills"), join(STAGE, "skills"), { recursive: true });
-await mkdir(join(STAGE, "scripts"), { recursive: true });
-await cp(join(ROOT, "scripts/check-version.sh"), join(STAGE, "scripts/check-version.sh"));
+for (const skill of await readdir(join(STAGE, "skills"))) {
+  const skillMd = join(STAGE, "skills", skill, "SKILL.md");
+  if (!existsSync(skillMd)) continue;
+  const text = rewriteEntryPoints(await Bun.file(skillMd).text());
+  assertStagedPaths(`skills/${skill}/SKILL.md`, text);
+  await Bun.write(skillMd, text);
+}
 
-const bundled = result.outputs.reduce((sum, artifact) => sum + artifact.size, 0);
-console.log(`staged ${version} -> .stage/ (${result.outputs.length} files, ${(bundled / 1024 / 1024).toFixed(1)} MB bundled)`);
+const outputs = [...result.outputs, ...runnerResult.outputs];
+const bundled = outputs.reduce((sum, artifact) => sum + artifact.size, 0);
+console.log(`staged ${version} -> .stage/ (${outputs.length} files, ${(bundled / 1024 / 1024).toFixed(1)} MB bundled)`);

--- a/plugins/honcho/scripts/build.ts
+++ b/plugins/honcho/scripts/build.ts
@@ -36,6 +36,12 @@ if (!result.success) {
 // stage runs under node, dev runs .ts under bun), then verify every
 // rewritten path exists in the stage.
 function assertStagedPaths(relPath: string, text: string): void {
+  // A rewrite miss leaves a .ts reference behind, which the stage can't serve.
+  const missed = text.match(/"[^"]*\$\{CLAUDE_PLUGIN_ROOT\}[^"]*\.ts[^"]*"/);
+  if (missed) {
+    console.error(`${relPath} still references source TypeScript after rewrite: ${missed[0]}`);
+    process.exit(1);
+  }
   for (const [, staged] of text.matchAll(/\$\{CLAUDE_PLUGIN_ROOT\}\/(dist\/[\w/-]+\.js)/g)) {
     if (!existsSync(join(STAGE, staged))) {
       console.error(`${relPath} references ${staged}, which the build did not produce`);

--- a/plugins/honcho/scripts/build.ts
+++ b/plugins/honcho/scripts/build.ts
@@ -93,7 +93,7 @@ await Bun.write(
       description: pluginManifest.description,
       author: "Plastic Labs <hello@plasticlabs.ai>",
       license: pluginManifest.license,
-      repository: pluginManifest.repository,
+      repository: { type: "git", url: `git+${pluginManifest.repository}.git` },
       keywords: pluginManifest.keywords,
     },
     null,

--- a/plugins/honcho/scripts/build.ts
+++ b/plugins/honcho/scripts/build.ts
@@ -1,7 +1,9 @@
 #!/usr/bin/env bun
 // Stage a self-contained release tree in .stage/: bundle every hook entry
 // point and the MCP server, rewrite manifest paths to the bundled output,
-// and stamp the version from package.json. Nothing in .stage/ is committed.
+// and stamp the version. The version comes from RELEASE_VERSION (set by the
+// release workflow; source carries no release version), falling back to
+// package.json for local builds. Nothing in .stage/ is committed.
 import { cp, mkdir, readdir, rm } from "node:fs/promises";
 import { existsSync } from "node:fs";
 import { join } from "node:path";
@@ -9,7 +11,9 @@ import { join } from "node:path";
 const ROOT = join(import.meta.dir, "..");
 const STAGE = join(ROOT, ".stage");
 
-const version = (await Bun.file(join(ROOT, "package.json")).json()).version as string;
+const version =
+  process.env.RELEASE_VERSION ||
+  ((await Bun.file(join(ROOT, "package.json")).json()).version as string);
 
 await rm(STAGE, { recursive: true, force: true });
 await mkdir(join(STAGE, ".claude-plugin"), { recursive: true });

--- a/plugins/honcho/scripts/build.ts
+++ b/plugins/honcho/scripts/build.ts
@@ -23,7 +23,7 @@ const result = await Bun.build({
   entrypoints: [...hookEntries, join(ROOT, "mcp-server.ts")],
   outdir: join(STAGE, "dist"),
   root: ROOT,
-  target: "bun",
+  target: "node",
   splitting: true,
   sourcemap: "linked",
 });
@@ -32,24 +32,36 @@ if (!result.success) {
   process.exit(1);
 }
 
-// Manifests: rewrite source entry points to their bundled locations, then
-// verify every rewritten path exists in the stage.
-async function stageManifest(relPath: string): Promise<void> {
-  let text = await Bun.file(join(ROOT, relPath)).text();
-  text = text.replace(
-    /\$\{CLAUDE_PLUGIN_ROOT\}\/(hooks\/[\w-]+|mcp-server)\.ts/g,
-    "${CLAUDE_PLUGIN_ROOT}/dist/$1.js",
-  );
+// Manifests: rewrite source entry points to their bundled locations (the
+// stage runs under node, dev runs .ts under bun), then verify every
+// rewritten path exists in the stage.
+function assertStagedPaths(relPath: string, text: string): void {
   for (const [, staged] of text.matchAll(/\$\{CLAUDE_PLUGIN_ROOT\}\/(dist\/[\w/-]+\.js)/g)) {
     if (!existsSync(join(STAGE, staged))) {
       console.error(`${relPath} references ${staged}, which the build did not produce`);
       process.exit(1);
     }
   }
-  await Bun.write(join(STAGE, relPath), text);
 }
-await stageManifest("hooks/hooks.json");
-await stageManifest("mcp-servers.json");
+
+const hooksJson = (await Bun.file(join(ROOT, "hooks/hooks.json")).text()).replace(
+  /bun run \$\{CLAUDE_PLUGIN_ROOT\}\/(hooks\/[\w-]+)\.ts/g,
+  "node ${CLAUDE_PLUGIN_ROOT}/dist/$1.js",
+);
+assertStagedPaths("hooks/hooks.json", hooksJson);
+await Bun.write(join(STAGE, "hooks/hooks.json"), hooksJson);
+
+const mcpServers = await Bun.file(join(ROOT, "mcp-servers.json")).json();
+for (const server of Object.values(mcpServers) as Array<{ command: string; args: string[] }>) {
+  if (server.command !== "bun") continue;
+  server.command = "node";
+  server.args = server.args
+    .filter((arg) => arg !== "run")
+    .map((arg) => arg.replace(/\$\{CLAUDE_PLUGIN_ROOT\}\/([\w-]+)\.ts/, "${CLAUDE_PLUGIN_ROOT}/dist/$1.js"));
+}
+const mcpJson = JSON.stringify(mcpServers, null, 2) + "\n";
+assertStagedPaths("mcp-servers.json", mcpJson);
+await Bun.write(join(STAGE, "mcp-servers.json"), mcpJson);
 
 // plugin.json: version stamped from package.json. hooks/hooks.json and
 // skills/ are auto-discovered, so neither needs a manifest field.
@@ -67,6 +79,7 @@ await Bun.write(
     {
       name: "@honcho-ai/claude-plugin",
       version,
+      type: "module",
       description: pluginManifest.description,
       author: "Plastic Labs <hello@plasticlabs.ai>",
       license: pluginManifest.license,

--- a/plugins/honcho/scripts/smoke.sh
+++ b/plugins/honcho/scripts/smoke.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Smoke-test a staged plugin tree: every bundled entry point must run under
+# node from a bare directory (no node_modules on the resolution path), with
+# config states that exit before any network call.
+set -euo pipefail
+
+STAGE_DIR="${1:?usage: smoke.sh <staged-plugin-dir>}"
+
+# timeout(1) is absent on macOS; bound each invocation where available.
+bounded() {
+  if command -v timeout >/dev/null 2>&1; then timeout 15 "$@"; else "$@"; fi
+}
+
+SMOKE="$(mktemp -d)"
+cp -R "$STAGE_DIR/." "$SMOKE"
+cd "$SMOKE"
+
+# Hooks + MCP server: disabled config, exits after config load.
+export HOME="$(mktemp -d)"
+mkdir -p "$HOME/.honcho"
+echo '{"apiKey":"smoke","enabled":false}' > "$HOME/.honcho/config.json"
+
+for hook in dist/hooks/*.js; do
+  echo "smoke: $hook"
+  echo '{"session_id":"smoke","cwd":"/tmp","hook_event_name":"SessionStart","source":"startup"}' \
+    | bounded node "$hook"
+done
+
+echo "smoke: dist/mcp-server.js"
+printf '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"smoke","version":"0"}}}\n' \
+  | bounded node dist/mcp-server.js | grep -q '"serverInfo"'
+
+# Backfill needs a config to start; dry-run over an empty transcript dir
+# makes no network calls.
+echo "smoke: dist/skills/backfill-runner.js"
+bounded node dist/skills/backfill-runner.js --dry-run </dev/null >/dev/null
+
+# Setup and status with no config and no key exercise their offline
+# not-configured paths (a configured run would validate the connection).
+export HOME="$(mktemp -d)"
+unset HONCHO_API_KEY
+
+# Setup exits 1 by design when no key is found; assert it reached that
+# decision rather than expecting success.
+echo "smoke: dist/skills/setup-runner.js"
+(bounded node dist/skills/setup-runner.js </dev/null || true) | grep -q "No API key found"
+echo "smoke: dist/skills/status-runner.js"
+bounded node dist/skills/status-runner.js </dev/null | grep -q "Not configured"
+
+echo "smoke: all entry points OK"

--- a/plugins/honcho/scripts/smoke.sh
+++ b/plugins/honcho/scripts/smoke.sh
@@ -16,7 +16,9 @@ cp -R "$STAGE_DIR/." "$SMOKE"
 cd "$SMOKE"
 
 # Hooks + MCP server: disabled config, exits after config load.
-export HOME="$(mktemp -d)"
+# (Standalone assignment so a mktemp failure propagates under set -e.)
+TMP_HOME="$(mktemp -d)"
+export HOME="$TMP_HOME"
 mkdir -p "$HOME/.honcho"
 echo '{"apiKey":"smoke","enabled":false}' > "$HOME/.honcho/config.json"
 
@@ -37,7 +39,8 @@ bounded node dist/skills/backfill-runner.js --dry-run </dev/null >/dev/null
 
 # Setup and status with no config and no key exercise their offline
 # not-configured paths (a configured run would validate the connection).
-export HOME="$(mktemp -d)"
+TMP_HOME="$(mktemp -d)"
+export HOME="$TMP_HOME"
 unset HONCHO_API_KEY
 
 # Setup exits 1 by design when no key is found; assert it reached that

--- a/plugins/honcho/src/config.ts
+++ b/plugins/honcho/src/config.ts
@@ -235,13 +235,20 @@ export function getCachedStdin(): string | null {
   return _stdinText;
 }
 
+/** Runtime-agnostic stdin read (hooks run under bun in dev, node when bundled). */
+export async function readStdinText(): Promise<string> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of process.stdin) chunks.push(chunk as Buffer);
+  return Buffer.concat(chunks).toString("utf-8");
+}
+
 /**
  * Shared hook entry point initialization.
  * Reads stdin once, caches it, detects host, and exits early for unsupported hosts.
  * Must be called at the top of every hook entry point before the handler.
  */
 export async function initHook(): Promise<void> {
-  const stdinText = await Bun.stdin.text();
+  const stdinText = await readStdinText();
   cacheStdin(stdinText);
   let input: Record<string, unknown> = {};
   try { input = JSON.parse(stdinText || "{}"); } catch { process.exit(0); }

--- a/plugins/honcho/src/hooks/post-tool-use.ts
+++ b/plugins/honcho/src/hooks/post-tool-use.ts
@@ -1,5 +1,5 @@
 import { Honcho } from "@honcho-ai/sdk";
-import { loadConfig, getSessionForPath, getSessionName, getHonchoClientOptions, isPluginEnabled, getCachedStdin } from "../config.js";
+import { loadConfig, getSessionForPath, getSessionName, getHonchoClientOptions, isPluginEnabled, getCachedStdin, readStdinText } from "../config.js";
 import { appendClaudeWork, getClaudeInstanceId } from "../cache.js";
 import { logHook, logApiCall, setLogContext } from "../log.js";
 import { visCapture } from "../visual.js";
@@ -198,7 +198,7 @@ export async function handlePostToolUse(): Promise<void> {
 
   let hookInput: HookInput = {};
   try {
-    const input = getCachedStdin() ?? await Bun.stdin.text();
+    const input = getCachedStdin() ?? await readStdinText();
     if (input.trim()) {
       hookInput = JSON.parse(input);
     }

--- a/plugins/honcho/src/hooks/pre-compact.ts
+++ b/plugins/honcho/src/hooks/pre-compact.ts
@@ -1,5 +1,5 @@
 import { Honcho } from "@honcho-ai/sdk";
-import { loadConfig, getSessionForPath, getSessionName, getHonchoClientOptions, isPluginEnabled, getCachedStdin, getObservationMode } from "../config.js";
+import { loadConfig, getSessionForPath, getSessionName, getHonchoClientOptions, isPluginEnabled, getCachedStdin, readStdinText, getObservationMode } from "../config.js";
 import { Spinner } from "../spinner.js";
 import { setMemoryState } from "../state.js";
 import { logHook, logApiCall, setLogContext } from "../log.js";
@@ -99,7 +99,7 @@ export async function handlePreCompact(): Promise<void> {
 
   let hookInput: HookInput = {};
   try {
-    const input = getCachedStdin() ?? await Bun.stdin.text();
+    const input = getCachedStdin() ?? await readStdinText();
     if (input.trim()) {
       hookInput = JSON.parse(input);
     }

--- a/plugins/honcho/src/hooks/save-user-message.ts
+++ b/plugins/honcho/src/hooks/save-user-message.ts
@@ -1,5 +1,5 @@
 import { Honcho, Session, Peer } from "@honcho-ai/sdk";
-import { loadConfig, getSessionName, getHonchoClientOptions, isPluginEnabled, getCachedStdin } from "../config.js";
+import { loadConfig, getSessionName, getHonchoClientOptions, isPluginEnabled, getCachedStdin, readStdinText } from "../config.js";
 import { getInstanceIdForCwd, chunkContent, addMessagesBatched } from "../cache.js";
 import { logHook, logApiCall, setLogContext } from "../log.js";
 import { isHarnessInjected, isTerseReply } from "./user-prompt.js";
@@ -35,7 +35,7 @@ export async function handleSaveUserMessage(): Promise<void> {
 
   let hookInput: HookInput = {};
   try {
-    const input = getCachedStdin() ?? await Bun.stdin.text();
+    const input = getCachedStdin() ?? await readStdinText();
     if (input.trim()) {
       hookInput = JSON.parse(input);
     }

--- a/plugins/honcho/src/hooks/session-end.ts
+++ b/plugins/honcho/src/hooks/session-end.ts
@@ -1,4 +1,4 @@
-import { loadConfig, getSessionName, isPluginEnabled, getCachedStdin } from "../config.js";
+import { loadConfig, getSessionName, isPluginEnabled, getCachedStdin, readStdinText } from "../config.js";
 import { getInstanceIdForCwd } from "../cache.js";
 import { clearSessionFiles } from "../state.js";
 import { logHook, setLogContext } from "../log.js";
@@ -31,7 +31,7 @@ export async function handleSessionEnd(): Promise<void> {
 
   let hookInput: HookInput = {};
   try {
-    const input = getCachedStdin() ?? await Bun.stdin.text();
+    const input = getCachedStdin() ?? await readStdinText();
     if (input.trim()) {
       hookInput = JSON.parse(input);
     }

--- a/plugins/honcho/src/hooks/session-start.ts
+++ b/plugins/honcho/src/hooks/session-start.ts
@@ -1,5 +1,5 @@
 import { Honcho } from "@honcho-ai/sdk";
-import { loadConfig, getSessionForPath, setSessionForPath, getSessionName, getHonchoClientOptions, isPluginEnabled, getCachedStdin, getObservationMode, getInjectionConfig } from "../config.js";
+import { loadConfig, getSessionForPath, setSessionForPath, getSessionName, getHonchoClientOptions, isPluginEnabled, getCachedStdin, readStdinText, getObservationMode, getInjectionConfig } from "../config.js";
 import { renderSessionStart } from "../injection.js";
 import {
   setCachedSessionId,
@@ -39,7 +39,7 @@ export async function handleSessionStart(): Promise<void> {
 
   let hookInput: HookInput = {};
   try {
-    const input = getCachedStdin() ?? await Bun.stdin.text();
+    const input = getCachedStdin() ?? await readStdinText();
     if (input.trim()) {
       hookInput = JSON.parse(input);
     }

--- a/plugins/honcho/src/hooks/stop.ts
+++ b/plugins/honcho/src/hooks/stop.ts
@@ -1,5 +1,5 @@
 import { Honcho, Session, Peer } from "@honcho-ai/sdk";
-import { loadConfig, getSessionForPath, getSessionName, getHonchoClientOptions, isPluginEnabled, getCachedStdin } from "../config.js";
+import { loadConfig, getSessionForPath, getSessionName, getHonchoClientOptions, isPluginEnabled, getCachedStdin, readStdinText } from "../config.js";
 import { existsSync, readFileSync } from "fs";
 import { getInstanceIdForCwd, chunkContent, addMessagesBatched } from "../cache.js";
 import { logHook, logApiCall, setLogContext } from "../log.js";
@@ -107,7 +107,7 @@ export async function handleStop(): Promise<void> {
 
   let hookInput: HookInput = {};
   try {
-    const input = getCachedStdin() ?? await Bun.stdin.text();
+    const input = getCachedStdin() ?? await readStdinText();
     if (input.trim()) {
       hookInput = JSON.parse(input);
     }

--- a/plugins/honcho/src/hooks/user-prompt.ts
+++ b/plugins/honcho/src/hooks/user-prompt.ts
@@ -1,7 +1,7 @@
 import { Honcho } from "@honcho-ai/sdk";
 import { readFileSync, existsSync } from "node:fs";
 import { join } from "node:path";
-import { loadConfig, getSessionName, getHonchoClientOptions, isPluginEnabled, getCachedStdin, getObservationMode, getInjectionConfig, type InjectionConfig } from "../config.js";
+import { loadConfig, getSessionName, getHonchoClientOptions, isPluginEnabled, getCachedStdin, readStdinText, getObservationMode, getInjectionConfig, type InjectionConfig } from "../config.js";
 import {
   getMessageCount,
   incrementMessageCount,
@@ -151,7 +151,7 @@ export async function handleUserPrompt(): Promise<void> {
 
   let hookInput: HookInput = {};
   try {
-    const input = getCachedStdin() ?? await Bun.stdin.text();
+    const input = getCachedStdin() ?? await readStdinText();
     if (input.trim()) {
       hookInput = JSON.parse(input);
     }

--- a/plugins/honcho/src/log.ts
+++ b/plugins/honcho/src/log.ts
@@ -9,7 +9,7 @@
 
 import { homedir } from "os";
 import { join } from "path";
-import { existsSync, appendFileSync, mkdirSync, readFileSync, writeFileSync } from "fs";
+import { existsSync, appendFileSync, mkdirSync, readFileSync, statSync, writeFileSync } from "fs";
 import { symbols, arrows, box } from "./unicode.js";
 import { isLoggingEnabled } from "./config.js";
 
@@ -138,11 +138,11 @@ export function logActivity(
   try {
     // Check file size and truncate if needed
     if (existsSync(LOG_FILE)) {
-      const stats = Bun.file(LOG_FILE).size;
+      const stats = statSync(LOG_FILE).size;
       if (stats > MAX_LOG_SIZE) {
         const content = readFileSync(LOG_FILE, "utf-8");
         const truncated = content.slice(-50 * 1024);
-        Bun.write(LOG_FILE, truncated);
+        writeFileSync(LOG_FILE, truncated);
       }
     }
 

--- a/plugins/honcho/src/mcp/server.ts
+++ b/plugins/honcho/src/mcp/server.ts
@@ -713,6 +713,8 @@ const REMEMBER_TOOL = {
 
 /** Plugin version from the manifest next to the running entry point. */
 function pluginVersion(): string {
+  // ".." resolves for the bundled layout (dist/mcp-server.js), "../.." for
+  // dev source (src/mcp/server.ts).
   for (const dir of ["..", "../.."]) {
     const manifest = fileURLToPath(new URL(`${dir}/.claude-plugin/plugin.json`, import.meta.url));
     try {

--- a/plugins/honcho/src/mcp/server.ts
+++ b/plugins/honcho/src/mcp/server.ts
@@ -6,6 +6,7 @@ import {
 } from "@modelcontextprotocol/sdk/types.js";
 import { Honcho } from "@honcho-ai/sdk";
 import { existsSync, readFileSync } from "fs";
+import { fileURLToPath } from "url";
 import {
   loadConfig,
   saveConfig,
@@ -713,7 +714,7 @@ const REMEMBER_TOOL = {
 /** Plugin version from the manifest next to the running entry point. */
 function pluginVersion(): string {
   for (const dir of ["..", "../.."]) {
-    const manifest = new URL(`${dir}/.claude-plugin/plugin.json`, import.meta.url).pathname;
+    const manifest = fileURLToPath(new URL(`${dir}/.claude-plugin/plugin.json`, import.meta.url));
     try {
       return JSON.parse(readFileSync(manifest, "utf-8")).version ?? "unknown";
     } catch {

--- a/plugins/honcho/src/mcp/server.ts
+++ b/plugins/honcho/src/mcp/server.ts
@@ -710,6 +710,19 @@ const REMEMBER_TOOL = {
   },
 };
 
+/** Plugin version from the manifest next to the running entry point. */
+function pluginVersion(): string {
+  for (const dir of ["..", "../.."]) {
+    const manifest = new URL(`${dir}/.claude-plugin/plugin.json`, import.meta.url).pathname;
+    try {
+      return JSON.parse(readFileSync(manifest, "utf-8")).version ?? "unknown";
+    } catch {
+      // Try the next candidate
+    }
+  }
+  return "unknown";
+}
+
 export async function runMcpServer(): Promise<void> {
   setDetectedHost("claude_code");
   const config = loadConfig();
@@ -721,7 +734,7 @@ export async function runMcpServer(): Promise<void> {
   const server = new Server(
     {
       name: "honcho",
-      version: "0.2.6",
+      version: pluginVersion(),
     },
     {
       capabilities: {

--- a/plugins/honcho/src/skills/backfill-runner.ts
+++ b/plugins/honcho/src/skills/backfill-runner.ts
@@ -28,6 +28,7 @@ import { parseTranscriptForBackfill, type ParsedMessage } from "./transcript-par
 import * as s from "../styles.js";
 import { homedir } from "os";
 import { join, basename } from "path";
+import { pathToFileURL } from "url";
 import { existsSync, readFileSync, writeFileSync, mkdirSync, readdirSync, statSync } from "fs";
 
 interface Args {
@@ -296,8 +297,9 @@ async function run(): Promise<void> {
 }
 
 // Only auto-run when invoked directly; the guard lets other modules import
-// findTranscripts/groupIntoSessions without triggering an upload.
-if (import.meta.main) {
+// findTranscripts/groupIntoSessions without triggering an upload. URL
+// comparison instead of import.meta.main, which node lacks.
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
   run().catch((err) => {
     console.log(s.error(`Backfill failed: ${err instanceof Error ? err.message : String(err)}`));
     process.exit(1);

--- a/plugins/honcho/src/skills/setup-runner.ts
+++ b/plugins/honcho/src/skills/setup-runner.ts
@@ -18,7 +18,8 @@ import {
 } from "../config.js";
 import * as s from "../styles.js";
 import { copyFileSync, chmodSync, existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
-import { join } from "path";
+import { dirname, join } from "path";
+import { fileURLToPath } from "url";
 
 // Installs the memory statusLine: ships the renderer to a stable path and
 // registers it in the user's global Claude Code settings. Plugins can't
@@ -28,7 +29,7 @@ import { join } from "path";
 function installStatusline(): void {
   console.log(s.section("Installing memory statusLine"));
 
-  const src = join(import.meta.dir, "..", "..", "scripts", "honcho-statusline.sh");
+  const src = join(dirname(fileURLToPath(import.meta.url)), "..", "..", "scripts", "honcho-statusline.sh");
   const dest = join(getConfigDir(), "honcho-statusline.sh");
   try {
     if (!existsSync(getConfigDir())) mkdirSync(getConfigDir(), { recursive: true });


### PR DESCRIPTION
Some features in this:
- Removing `node_modules`
- Swap bun for node for the runtime
- Add CI per-PR that runs `claude plugin validate`
- Adding a build step that compiles a plugin to dist/
- Release workflow that publishes package to npm and pushes a version commit

Docs:
- https://code.claude.com/docs/en/plugins-reference
- https://code.claude.com/docs/en/plugin-marketplaces



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added automated release packaging for the plugin, including versioned npm and GitHub releases.
  - Added validation and smoke testing for bundled plugin entry points before release.

- **Bug Fixes**
  - Improved compatibility with Node-based execution environments.
  - Updated hook input handling and logging for more reliable runtime behavior.
  - Improved plugin version detection across installed and bundled layouts.

- **Chores**
  - Added continuous integration checks for builds, validation, and smoke tests.
  - Excluded generated staging files from version control.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->