### PR TITLE
feat: add injection options for assistantContext and sessionContext

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,14 +6,14 @@
   },
   "metadata": {
     "description": "Honcho plugins for Claude Code - memory, development tools, and more",
-    "version": "0.2.8"
+    "version": "0.2.9"
   },
   "plugins": [
     {
       "name": "honcho",
       "source": "./plugins/honcho",
       "description": "Persistent memory for Claude Code sessions using Honcho",
-      "version": "0.2.8",
+      "version": "0.2.9",
       "keywords": ["memory", "context", "persistence"],
       "strict": false
     },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to claude-honcho will be documented in this file.
 
 ## [Unreleased]
 
+## [0.2.9] - 2026-07-28
+
+### Changed
+
+- Per-turn injection's `context` component split into three independently selectable components: `userContext` (the former `context`), `assistantContext` (the same fetch for the AI peer), and `sessionContext` (the mapped Honcho session's rolling summary via `session.context()`). Stored configs using `context` keep working — it resolves to `userContext`.
+
 ## [0.2.8] - 2026-07-27
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ All notable changes to claude-honcho will be documented in this file.
 
 ### Changed
 
-- Per-turn injection's `context` component split into three independently selectable components: `userContext` (the former `context`), `assistantContext` (the same fetch for the AI peer), and `sessionContext` (the mapped Honcho session's rolling summary via `session.context()`). Stored configs using `context` keep working — it resolves to `userContext`.
+- Per-turn injection's `context` component split into three independently selectable components: `userContext` (the former `context`), `assistantContext` (the same fetch for the AI peer), and `sessionContext` (recent raw messages from the mapped Honcho session via `session.context()`, budget via `injection.sessionContextTokens`). Stored configs using `context` keep working — it resolves to `userContext`.
 
 ## [0.2.8] - 2026-07-27
 

--- a/plugins/honcho/.claude-plugin/plugin.json
+++ b/plugins/honcho/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "honcho",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "description": "Persistent memory for Claude Code sessions using Honcho by Plastic Labs",
   "author": {
     "name": "Plastic Labs",

--- a/plugins/honcho/package.json
+++ b/plugins/honcho/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-honcho",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "description": "Persistent memory for Claude Code sessions using Honcho by Plastic Labs",
   "type": "module",
   "keywords": [

--- a/plugins/honcho/skills/config/SKILL.md
+++ b/plugins/honcho/skills/config/SKILL.md
@@ -42,7 +42,7 @@ AskUserQuestion:
       description: "What Honcho injects at session start and per turn (currently: start [{resolved.injection.sessionStart}], turn [{resolved.injection.perTurn}])"
 ```
 
-For the "Memory injection" description, use the *effective* values: if `injection.sessionStart` is unset it is `["directives", "summary", "peerCard"]`, and if `injection.perTurn` is unset it is `["context"]` (conclusions on).
+For the "Memory injection" description, use the *effective* values: if `injection.sessionStart` is unset it is `["directives", "summary", "peerCard"]`, and if `injection.perTurn` is unset it is `["userContext"]` (user conclusions on). A stored perTurn value of `"context"` is the legacy name for `"userContext"` — treat them as the same.
 
 If the user selects "Other", present advanced options:
 
@@ -169,15 +169,19 @@ AskUserQuestion:
       header: "Per turn"
       multiSelect: true
       options:
-        - label: "Relevant conclusions"
-          description: "Fresh, prompt-scoped memory pulled every turn"
+        - label: "User conclusions"
+          description: "Fresh, prompt-scoped memory about you pulled every turn"
+        - label: "Assistant conclusions"
+          description: "Same fetch, but for the AI peer — what Honcho knows about the assistant"
+        - label: "Session summary"
+          description: "The mapped Honcho session's rolling summary, refetched each turn"
         - label: "Dialectic recall"
           description: "A reasoned answer over your history each turn — richer but slower (off by default)"
 ```
 
 Map the selections to component names, then call `set_config` once per surface:
 - Session start → `injection.sessionStart`, mapping "Memory directives"→`directives`, "Session summary"→`summary`, "Peer card"→`peerCard`, "Representation"→`peerRepresentation`.
-- Per turn → `injection.perTurn`, mapping "Relevant conclusions"→`context`, "Dialectic recall"→`dialectic`.
+- Per turn → `injection.perTurn`, mapping "User conclusions"→`userContext`, "Assistant conclusions"→`assistantContext`, "Session summary"→`sessionContext`, "Dialectic recall"→`dialectic`.
 
 Pass the value as a JSON array (e.g. `["directives","summary","peerCard"]`). An empty selection for a surface means "inject nothing" there — pass `[]`.
 

--- a/plugins/honcho/skills/config/SKILL.md
+++ b/plugins/honcho/skills/config/SKILL.md
@@ -173,15 +173,15 @@ AskUserQuestion:
           description: "Fresh, prompt-scoped memory about you pulled every turn"
         - label: "Assistant conclusions"
           description: "Same fetch, but for the AI peer — what Honcho knows about the assistant"
-        - label: "Session summary"
-          description: "The mapped Honcho session's rolling summary, refetched each turn"
+        - label: "Session messages"
+          description: "Recent raw messages from the mapped Honcho session — useful when other instances share the session"
         - label: "Dialectic recall"
           description: "A reasoned answer over your history each turn — richer but slower (off by default)"
 ```
 
 Map the selections to component names, then call `set_config` once per surface:
 - Session start → `injection.sessionStart`, mapping "Memory directives"→`directives`, "Session summary"→`summary`, "Peer card"→`peerCard`, "Representation"→`peerRepresentation`.
-- Per turn → `injection.perTurn`, mapping "User conclusions"→`userContext`, "Assistant conclusions"→`assistantContext`, "Session summary"→`sessionContext`, "Dialectic recall"→`dialectic`.
+- Per turn → `injection.perTurn`, mapping "User conclusions"→`userContext`, "Assistant conclusions"→`assistantContext`, "Session messages"→`sessionContext`, "Dialectic recall"→`dialectic`.
 
 Pass the value as a JSON array (e.g. `["directives","summary","peerCard"]`). An empty selection for a surface means "inject nothing" there — pass `[]`.
 

--- a/plugins/honcho/src/config.ts
+++ b/plugins/honcho/src/config.ts
@@ -809,7 +809,10 @@ export function getLocalContextConfig(): LocalContextConfig {
 export function getInjectionConfig(config?: HonchoCLAUDEConfig | null): Required<InjectionConfig> {
   const injection = (config === undefined ? loadConfig() : config)?.injection;
   const resolved = { ...DEFAULT_INJECTION, ...(injection ?? {}) };
-  resolved.perTurn = normalizePerTurn(resolved.perTurn);
+  // Guard hand-edited configs: a non-array perTurn falls back to the default.
+  resolved.perTurn = Array.isArray(resolved.perTurn)
+    ? normalizePerTurn(resolved.perTurn)
+    : DEFAULT_INJECTION.perTurn;
   return resolved;
 }
 

--- a/plugins/honcho/src/config.ts
+++ b/plugins/honcho/src/config.ts
@@ -57,9 +57,9 @@ export type SessionStartComponent = (typeof SESSION_START_COMPONENTS)[number];
  *   searchMaxDistance/maxConclusions knobs below.
  * - "assistantContext": the same peer.context() fetch, but for the AI peer —
  *   what Honcho has derived about the assistant itself.
- * - "sessionContext": the SDK session.context() summary for the currently
- *   mapped Honcho session, which can span other Claude instances sharing the
- *   session name.
+ * - "sessionContext": recent raw messages from the currently mapped Honcho
+ *   session via session.context() (summary off, no search), which can span
+ *   other Claude instances sharing the session name.
  * - "dialectic": a reasoned peer.chat() answer over the representation, seeded
  *   from `dialecticTemplate` (the prompt substituted into %{user_query}) at the
  *   `dialecticReasoning` tier. Off by default — chat() is far slower than
@@ -98,6 +98,8 @@ export interface InjectionConfig {
   /** What drives the per-turn semantic search: the raw "prompt" (default)
    *  or extracted "topics". */
   searchQuerySource?: "topics" | "prompt";
+  /** Token budget for the per-turn "sessionContext" message fetch (default: 1500). */
+  sessionContextTokens?: number;
   /** Query template for the per-turn "dialectic" component. The user's prompt
    *  is substituted into every `%{user_query}` (default: surface anything from
    *  the user's history relevant to the prompt). */
@@ -119,6 +121,7 @@ export const DEFAULT_INJECTION: Required<InjectionConfig> = {
   maxConclusions: 15,
   searchMaxDistance: 0.6,
   searchQuerySource: "prompt",
+  sessionContextTokens: 1500,
   dialecticTemplate:
     "Return a compact, factual list of anything from the user's history — preferences, prior decisions, relevant past work — that would help with the following. Write in the third person as background notes; do not address the user, ask questions, or offer next steps. If nothing relevant exists, say so in one line. Relevant to: %{user_query}",
   dialecticReasoning: "medium",

--- a/plugins/honcho/src/config.ts
+++ b/plugins/honcho/src/config.ts
@@ -52,9 +52,14 @@ export type SessionStartComponent = (typeof SESSION_START_COMPONENTS)[number];
 
 /**
  * Components the UserPromptSubmit hook may emit per non-trivial prompt.
- * - "context": a fresh, prompt-scoped context() blob (representation + peerCard),
- *   whose semantic retrieval is shaped by the searchTopK/searchMaxDistance/
- *   maxConclusions knobs below.
+ * - "userContext": a fresh, prompt-scoped peer.context() blob for the user
+ *   peer, whose semantic retrieval is shaped by the searchTopK/
+ *   searchMaxDistance/maxConclusions knobs below.
+ * - "assistantContext": the same peer.context() fetch, but for the AI peer —
+ *   what Honcho has derived about the assistant itself.
+ * - "sessionContext": the SDK session.context() summary for the currently
+ *   mapped Honcho session, which can span other Claude instances sharing the
+ *   session name.
  * - "dialectic": a reasoned peer.chat() answer over the representation, seeded
  *   from `dialecticTemplate` (the prompt substituted into %{user_query}) at the
  *   `dialecticReasoning` tier. Off by default — chat() is far slower than
@@ -65,8 +70,13 @@ export type SessionStartComponent = (typeof SESSION_START_COMPONENTS)[number];
  * was scoped out: `level` is not filterable through the API, so it needs a
  * honcho-backend + SDK change before it can ship. See the plan.
  */
-export const PER_TURN_COMPONENTS = ["context", "dialectic"] as const;
+export const PER_TURN_COMPONENTS = ["userContext", "assistantContext", "sessionContext", "dialectic"] as const;
 export type PerTurnComponent = (typeof PER_TURN_COMPONENTS)[number];
+
+/** Pre-split configs stored `"context"` for what is now "userContext". */
+export function normalizePerTurn(components: string[]): PerTurnComponent[] {
+  return components.map((c) => (c === "context" ? "userContext" : c)) as PerTurnComponent[];
+}
 
 /**
  * The `injection` config block: turns the two hardcoded injection surfaces
@@ -76,7 +86,7 @@ export type PerTurnComponent = (typeof PER_TURN_COMPONENTS)[number];
 export interface InjectionConfig {
   /** Components emitted once at session open (default: ["directives", "summary", "peerCard"]). */
   sessionStart?: SessionStartComponent[];
-  /** Components emitted per non-trivial prompt (default: ["context"]). */
+  /** Components emitted per non-trivial prompt (default: ["userContext"]). */
   perTurn?: PerTurnComponent[];
   /** Top-K conclusions pulled by context()'s semantic search (default: 10). */
   searchTopK?: number;
@@ -99,12 +109,12 @@ export interface InjectionConfig {
 }
 
 /** Resolved injection defaults: memory-usage directives + session summary +
- *  peer card at session start, a fresh context() per turn. Retrieval knobs
+ *  peer card at session start, a fresh user-peer context() per turn. Retrieval knobs
  *  are tuned for a lean per-turn block — topK 10 for recall, a 0.6 cosine
  *  distance, searching on the raw prompt. */
 export const DEFAULT_INJECTION: Required<InjectionConfig> = {
   sessionStart: ["directives", "summary", "peerCard"],
-  perTurn: ["context"],
+  perTurn: ["userContext"],
   searchTopK: 10,
   maxConclusions: 15,
   searchMaxDistance: 0.6,
@@ -795,7 +805,9 @@ export function getLocalContextConfig(): LocalContextConfig {
  */
 export function getInjectionConfig(config?: HonchoCLAUDEConfig | null): Required<InjectionConfig> {
   const injection = (config === undefined ? loadConfig() : config)?.injection;
-  return { ...DEFAULT_INJECTION, ...(injection ?? {}) };
+  const resolved = { ...DEFAULT_INJECTION, ...(injection ?? {}) };
+  resolved.perTurn = normalizePerTurn(resolved.perTurn);
+  return resolved;
 }
 
 export function isLoggingEnabled(): boolean {

--- a/plugins/honcho/src/hooks/user-prompt.ts
+++ b/plugins/honcho/src/hooks/user-prompt.ts
@@ -8,7 +8,7 @@ import {
   getInstanceIdForCwd,
 } from "../cache.js";
 import { logHook, logApiCall, setLogContext } from "../log.js";
-import { visInjectionMessage, visDialecticMessage, visSessionSummaryMessage, visSkipMessage, addSystemMessage, verboseApiResult, verboseList } from "../visual.js";
+import { visInjectionMessage, visDialecticMessage, visSessionContextMessage, visSkipMessage, addSystemMessage, verboseApiResult, verboseList } from "../visual.js";
 import type { ReasoningLevel } from "../config.js";
 import { honchoSessionUrl } from "../styles.js";
 import { setMemoryState, setSessionLink } from "../state.js";
@@ -231,7 +231,7 @@ export async function handleUserPrompt(): Promise<void> {
   const [userCtxResult, assistantCtxResult, sessionCtx, dialectic] = await Promise.all([
     wantUserContext ? raceTimeout(fetchUserContext(config, prompt, injection), FETCH_TIMEOUT_MS) : Promise.resolve(null),
     wantAssistantContext ? raceTimeout(fetchAssistantContext(config, prompt, injection), FETCH_TIMEOUT_MS) : Promise.resolve(null),
-    wantSessionContext ? raceTimeout(fetchSessionContext(config, sessionName), FETCH_TIMEOUT_MS) : Promise.resolve(null),
+    wantSessionContext ? raceTimeout(fetchSessionContext(config, sessionName, injection), FETCH_TIMEOUT_MS) : Promise.resolve(null),
     wantDialectic ? raceTimeout(fetchDialectic(config, prompt, injection), DIALECTIC_TIMEOUT_MS) : Promise.resolve(null),
   ]);
 
@@ -278,8 +278,8 @@ function emitPerTurn(
   }
 
   if (sessionCtx) {
-    parts.push(`Honcho session summary: ${sessionCtx.summary}`);
-    visLines.push(visSessionSummaryMessage("user-prompt", sessionCtx.tokenCount));
+    parts.push(`Recent Honcho session messages:\n${sessionCtx.lines.join("\n")}`);
+    visLines.push(visSessionContextMessage("user-prompt", sessionCtx.lines.length, sessionCtx.tokenCount));
   }
 
   if (dialectic) {
@@ -424,28 +424,36 @@ async function fetchAssistantContext(config: any, prompt: string, injection: Inj
 }
 
 interface SessionContextResult {
-  summary: string;
+  /** "peer: content" lines, oldest first. */
+  lines: string[];
   tokenCount: number;
 }
 
 /**
- * Per-turn "sessionContext" component: the SDK session.context() summary for
- * the currently mapped Honcho session. Only the summary is injected — the
- * session's messages largely mirror what Claude already has in its own window,
- * but the summary rolls up turns from other Claude instances sharing the
- * session name (per-directory strategy). Returns null when no summary exists.
+ * Per-turn "sessionContext" component: recent raw messages from the currently
+ * mapped Honcho session, within a token budget. Summary is off — it's the same
+ * stored row the sessionStart "summary" component injects — and no peer target
+ * or search query is passed, keeping this a plain message-window fetch rather
+ * than another semantic retrieval. The value is turns from other instances
+ * sharing the session name (per-directory strategy). Returns null when the
+ * session has no messages.
  */
-async function fetchSessionContext(config: any, sessionName: string): Promise<SessionContextResult | null> {
+async function fetchSessionContext(config: any, sessionName: string, injection: InjectionConfig): Promise<SessionContextResult | null> {
   const honcho = new Honcho(getHonchoClientOptions(config));
   const startTime = Date.now();
   try {
     const session = await honcho.session(sessionName);
-    const context = await session.context({ summary: true });
+    const context = await session.context({
+      summary: false,
+      tokens: injection.sessionContextTokens ?? 1500,
+    });
     logApiCall("session.context", "GET", sessionName, Date.now() - startTime, true);
-    const summary = context?.summary?.content?.trim();
-    if (!summary) return null;
-    verboseApiResult("session.context() -> summary", summary);
-    return { summary, tokenCount: context.summary?.tokenCount ?? 0 };
+    const messages = context?.messages ?? [];
+    if (!messages.length) return null;
+    const lines = messages.map((m: any) => `${m.peerId}: ${m.content}`);
+    const tokenCount = messages.reduce((sum: number, m: any) => sum + (m.tokenCount ?? 0), 0);
+    verboseApiResult("session.context() -> messages", lines.join("\n"));
+    return { lines, tokenCount };
   } catch (e) {
     logHook("user-prompt", `Session context fetch failed: ${e}`);
     return null;

--- a/plugins/honcho/src/hooks/user-prompt.ts
+++ b/plugins/honcho/src/hooks/user-prompt.ts
@@ -8,7 +8,7 @@ import {
   getInstanceIdForCwd,
 } from "../cache.js";
 import { logHook, logApiCall, setLogContext } from "../log.js";
-import { visInjectionMessage, visDialecticMessage, visSkipMessage, addSystemMessage, verboseApiResult, verboseList } from "../visual.js";
+import { visInjectionMessage, visDialecticMessage, visSessionSummaryMessage, visSkipMessage, addSystemMessage, verboseApiResult, verboseList } from "../visual.js";
 import type { ReasoningLevel } from "../config.js";
 import { honchoSessionUrl } from "../styles.js";
 import { setMemoryState, setSessionLink } from "../state.js";
@@ -211,10 +211,12 @@ export async function handleUserPrompt(): Promise<void> {
   }
 
   const injection = getInjectionConfig(config);
-  const wantContext = injection.perTurn.includes("context");
+  const wantUserContext = injection.perTurn.includes("userContext");
+  const wantAssistantContext = injection.perTurn.includes("assistantContext");
+  const wantSessionContext = injection.perTurn.includes("sessionContext");
   const wantDialectic = injection.perTurn.includes("dialectic");
 
-  if (!wantContext && !wantDialectic) {
+  if (!wantUserContext && !wantAssistantContext && !wantSessionContext && !wantDialectic) {
     logHook("user-prompt", "No per-turn injection components selected");
     visSkipMessage("user-prompt", sessionLink ? `${sessionLink} · injection off` : "injection off");
     process.exit(0);
@@ -222,44 +224,62 @@ export async function handleUserPrompt(): Promise<void> {
 
   setMemoryState("recalling", undefined, hookInput.session_id);
 
-  // Both components run concurrently on independent budgets: context on the tight
-  // 4s race, dialectic on its own ~25s budget. Neither blocks the other, and the
-  // hook completes as soon as the slowest selected component resolves or times out.
-  const [ctxResult, dialectic] = await Promise.all([
-    wantContext ? raceTimeout(fetchFreshContext(config, prompt, injection), FETCH_TIMEOUT_MS) : Promise.resolve(null),
+  // All components run concurrently on independent budgets: the context fetches
+  // each on the tight 4s race, dialectic on its own budget. None blocks another,
+  // and the hook completes as soon as the slowest selected component resolves or
+  // times out.
+  const [userCtxResult, assistantCtxResult, sessionCtx, dialectic] = await Promise.all([
+    wantUserContext ? raceTimeout(fetchUserContext(config, prompt, injection), FETCH_TIMEOUT_MS) : Promise.resolve(null),
+    wantAssistantContext ? raceTimeout(fetchAssistantContext(config, prompt, injection), FETCH_TIMEOUT_MS) : Promise.resolve(null),
+    wantSessionContext ? raceTimeout(fetchSessionContext(config, sessionName), FETCH_TIMEOUT_MS) : Promise.resolve(null),
     wantDialectic ? raceTimeout(fetchDialectic(config, prompt, injection), DIALECTIC_TIMEOUT_MS) : Promise.resolve(null),
   ]);
 
-  const ctx: { context: any; matched?: string[]; queryLabel?: string } | null =
-    ctxResult?.context
-      ? { context: ctxResult.context, matched: ctxResult.matched, queryLabel: ctxResult.queryLabel }
+  const userCtx: { context: any; matched?: string[]; queryLabel?: string } | null =
+    userCtxResult?.context
+      ? { context: userCtxResult.context, matched: userCtxResult.matched, queryLabel: userCtxResult.queryLabel }
       : null;
 
-  emitPerTurn(config.peerName, ctx, dialectic, sessionLink);
+  emitPerTurn(config, userCtx, assistantCtxResult?.context ?? null, sessionCtx, dialectic, sessionLink);
   process.exit(0);
 }
 
 /**
- * Emit the per-turn injection: the selected components ("context" and/or
- * "dialectic") composed into one additionalContext payload plus a per-component
- * systemMessage summary. Exits silently when nothing resolved to content —
- * mirroring the old no-cache fall-through.
+ * Emit the per-turn injection: the selected components composed into one
+ * additionalContext payload plus a per-component systemMessage summary.
+ * Exits silently when nothing resolved to content — mirroring the old
+ * no-cache fall-through.
  */
 function emitPerTurn(
-  peerName: string,
-  ctx: { context: any; matched?: string[]; queryLabel?: string } | null,
+  config: any,
+  userCtx: { context: any; matched?: string[]; queryLabel?: string } | null,
+  assistantCtx: any | null,
+  sessionCtx: SessionContextResult | null,
   dialectic: DialecticResult | null,
   sessionLink?: string,
 ): void {
   const parts: string[] = [];
   const visLines: string[] = [];
 
-  if (ctx) {
-    const conclusions = extractConclusions(ctx.context);
+  if (userCtx) {
+    const conclusions = extractConclusions(userCtx.context);
     if (conclusions.length > 0) {
       parts.push(`Relevant conclusions: ${conclusions.join("; ")}`);
-      visLines.push(visInjectionMessage("user-prompt", { conclusions, matched: ctx.matched, queryLabel: ctx.queryLabel }));
+      visLines.push(visInjectionMessage("user-prompt", { conclusions, matched: userCtx.matched, queryLabel: userCtx.queryLabel }));
     }
+  }
+
+  if (assistantCtx) {
+    const conclusions = extractConclusions(assistantCtx);
+    if (conclusions.length > 0) {
+      parts.push(`Conclusions about the assistant (${config.aiPeer}): ${conclusions.join("; ")}`);
+      visLines.push(visInjectionMessage("user-prompt", { conclusions, queryLabel: `assistant ${config.aiPeer}` }));
+    }
+  }
+
+  if (sessionCtx) {
+    parts.push(`Honcho session summary: ${sessionCtx.summary}`);
+    visLines.push(visSessionSummaryMessage("user-prompt", sessionCtx.tokenCount));
   }
 
   if (dialectic) {
@@ -270,7 +290,7 @@ function emitPerTurn(
   if (parts.length === 0) return;
 
   const visMsg = visLines.join("\n");
-  outputContext(peerName, parts, sessionLink ? `${sessionLink}\n${visMsg}` : visMsg);
+  outputContext(config.peerName, parts, sessionLink ? `${sessionLink}\n${visMsg}` : visMsg);
 }
 
 interface DialecticResult {
@@ -314,7 +334,11 @@ async function fetchDialectic(config: any, prompt: string, injection: InjectionC
   }
 }
 
-async function fetchFreshContext(config: any, prompt: string, injection: InjectionConfig): Promise<{ context: any; matched: string[]; queryLabel?: string }> {
+/**
+ * Per-turn "userContext" component: a prompt-scoped peer.context() fetch for
+ * the user peer, observation-mode aware.
+ */
+async function fetchUserContext(config: any, prompt: string, injection: InjectionConfig): Promise<{ context: any; matched: string[]; queryLabel?: string }> {
   const honcho = new Honcho(getHonchoClientOptions(config));
   const observationMode = getObservationMode(config);
 
@@ -364,6 +388,68 @@ async function fetchFreshContext(config: any, prompt: string, injection: Injecti
   }
 
   return { context: contextResult, matched, queryLabel: usePrompt ? "prompt" : undefined };
+}
+
+/**
+ * Per-turn "assistantContext" component: the same prompt-scoped peer.context()
+ * fetch, but for the AI peer's own representation — what Honcho has derived
+ * about the assistant. Always the peer's global (self) view, regardless of
+ * observation mode: there is no directional "assistant observed by user"
+ * collection to fall back to.
+ */
+async function fetchAssistantContext(config: any, prompt: string, injection: InjectionConfig): Promise<{ context: any } | null> {
+  const honcho = new Honcho(getHonchoClientOptions(config));
+  const aiPeer = await honcho.peer(config.aiPeer);
+
+  const usePrompt = injection.searchQuerySource === "prompt";
+  const { topics } = usePrompt ? { topics: [] } : extractTopics(prompt);
+  const searchQuery = usePrompt || topics.length === 0 ? prompt : topics.join(" ");
+
+  const startTime = Date.now();
+  try {
+    const context = await aiPeer.context({
+      searchQuery,
+      searchTopK: injection.searchTopK,
+      searchMaxDistance: injection.searchMaxDistance,
+      maxConclusions: injection.maxConclusions,
+      includeMostFrequent: false,
+    });
+    logApiCall("aiPeer.context (assistant)", "GET", `search: ${searchQuery.slice(0, 60)}`, Date.now() - startTime, true);
+    verboseApiResult("aiPeer.context() -> representation (assistant)", (context as any)?.representation);
+    return { context };
+  } catch (e) {
+    logHook("user-prompt", `Assistant context fetch failed: ${e}`);
+    return null;
+  }
+}
+
+interface SessionContextResult {
+  summary: string;
+  tokenCount: number;
+}
+
+/**
+ * Per-turn "sessionContext" component: the SDK session.context() summary for
+ * the currently mapped Honcho session. Only the summary is injected — the
+ * session's messages largely mirror what Claude already has in its own window,
+ * but the summary rolls up turns from other Claude instances sharing the
+ * session name (per-directory strategy). Returns null when no summary exists.
+ */
+async function fetchSessionContext(config: any, sessionName: string): Promise<SessionContextResult | null> {
+  const honcho = new Honcho(getHonchoClientOptions(config));
+  const startTime = Date.now();
+  try {
+    const session = await honcho.session(sessionName);
+    const context = await session.context({ summary: true });
+    logApiCall("session.context", "GET", sessionName, Date.now() - startTime, true);
+    const summary = context?.summary?.content?.trim();
+    if (!summary) return null;
+    verboseApiResult("session.context() -> summary", summary);
+    return { summary, tokenCount: context.summary?.tokenCount ?? 0 };
+  } catch (e) {
+    logHook("user-prompt", `Session context fetch failed: ${e}`);
+    return null;
+  }
 }
 
 // Per-turn context injects representation-derived conclusions ONLY. The full

--- a/plugins/honcho/src/hooks/user-prompt.ts
+++ b/plugins/honcho/src/hooks/user-prompt.ts
@@ -279,7 +279,7 @@ function emitPerTurn(
 
   if (sessionCtx) {
     parts.push(`Recent Honcho session messages:\n${sessionCtx.lines.join("\n")}`);
-    visLines.push(visSessionContextMessage("user-prompt", sessionCtx.lines.length, sessionCtx.tokenCount));
+    visLines.push(visSessionContextMessage("user-prompt", sessionCtx.lines, sessionCtx.tokenCount));
   }
 
   if (dialectic) {

--- a/plugins/honcho/src/mcp/server.ts
+++ b/plugins/honcho/src/mcp/server.ts
@@ -534,6 +534,12 @@ function handleSetConfig(args: Record<string, unknown>) {
       cfg.injection.searchMaxDistance = Number(value);
       break;
 
+    case "injection.sessionContextTokens":
+      previousValue = cfg.injection?.sessionContextTokens;
+      if (!cfg.injection) cfg.injection = {};
+      cfg.injection.sessionContextTokens = Number(value);
+      break;
+
     case "rememberTool":
       previousValue = cfg.rememberTool;
       cfg.rememberTool = Boolean(value);
@@ -912,6 +918,7 @@ export async function runMcpServer(): Promise<void> {
                   "injection.maxConclusions",
                   "injection.searchMaxDistance",
                   "injection.searchQuerySource",
+                  "injection.sessionContextTokens",
                   "injection.dialecticTemplate",
                   "injection.dialecticReasoning",
                   "rememberTool",

--- a/plugins/honcho/src/mcp/server.ts
+++ b/plugins/honcho/src/mcp/server.ts
@@ -28,6 +28,7 @@ import {
   type PerTurnComponent,
   SESSION_START_COMPONENTS,
   PER_TURN_COMPONENTS,
+  normalizePerTurn,
   REASONING_LEVELS,
   getObservationMode,
 } from "../config.js";
@@ -505,7 +506,9 @@ function handleSetConfig(args: Record<string, unknown>) {
     }
 
     case "injection.perTurn": {
-      const arr = validateComponentArray(value, PER_TURN_COMPONENTS, field);
+      // Accept the pre-split "context" name and store its replacement.
+      const raw = coerceStringArray(value);
+      const arr = validateComponentArray(raw ? normalizePerTurn(raw) : value, PER_TURN_COMPONENTS, field);
       if (!Array.isArray(arr)) return arr;
       previousValue = cfg.injection?.perTurn;
       if (!cfg.injection) cfg.injection = {};

--- a/plugins/honcho/src/mcp/server.ts
+++ b/plugins/honcho/src/mcp/server.ts
@@ -534,11 +534,19 @@ function handleSetConfig(args: Record<string, unknown>) {
       cfg.injection.searchMaxDistance = Number(value);
       break;
 
-    case "injection.sessionContextTokens":
+    case "injection.sessionContextTokens": {
+      const tokens = Number(value);
+      if (!Number.isFinite(tokens) || tokens <= 0) {
+        return {
+          content: [{ type: "text", text: JSON.stringify({ success: false, error: "injection.sessionContextTokens must be a positive number" }, null, 2) }],
+          isError: true,
+        };
+      }
       previousValue = cfg.injection?.sessionContextTokens;
       if (!cfg.injection) cfg.injection = {};
-      cfg.injection.sessionContextTokens = Number(value);
+      cfg.injection.sessionContextTokens = tokens;
       break;
+    }
 
     case "rememberTool":
       previousValue = cfg.rememberTool;

--- a/plugins/honcho/src/visual.ts
+++ b/plugins/honcho/src/visual.ts
@@ -87,12 +87,22 @@ export function visDialecticMessage(hookName: string, reasoning: string, elapsed
 
 /**
  * Build the per-turn systemMessage for the "sessionContext" component: a
- * status line with the message and token counts. The messages themselves go
- * to additionalContext only.
+ * status line with the message and token counts, then every injected message
+ * as a bullet. Each message is collapsed to a single truncated line — the
+ * full text goes to additionalContext; this listing is for visibility into
+ * what was injected. The count has no display cutoff: it's bounded upstream
+ * by the sessionContextTokens budget passed to session.context().
  */
-export function visSessionContextMessage(hookName: string, messageCount: number, tokenCount: number): string {
-  const noun = messageCount === 1 ? "message" : "messages";
-  return formatLine("in", hookName, `injected ${messageCount} session ${noun} (~${tokenCount} tokens)`);
+export function visSessionContextMessage(hookName: string, lines: string[], tokenCount: number): string {
+  const noun = lines.length === 1 ? "message" : "messages";
+  const head = formatLine("in", hookName, `injected ${lines.length} session ${noun} (~${tokenCount} tokens)`);
+  const body = lines
+    .map((l) => {
+      const flat = l.replace(/\s+/g, " ").trim();
+      return `  ${sym.bullet} ${flat.length > 150 ? `${flat.slice(0, 149)}…` : flat}`;
+    })
+    .join("\n");
+  return body ? `${head}\n${body}` : head;
 }
 
 /**

--- a/plugins/honcho/src/visual.ts
+++ b/plugins/honcho/src/visual.ts
@@ -86,6 +86,15 @@ export function visDialecticMessage(hookName: string, reasoning: string, elapsed
 }
 
 /**
+ * Build the per-turn systemMessage for the "sessionContext" component: a
+ * status line with the summary's token count. The summary itself goes to
+ * additionalContext only — it's long-lived session prose, not per-turn news.
+ */
+export function visSessionSummaryMessage(hookName: string, tokenCount: number): string {
+  return formatLine("in", hookName, `injected session summary (${tokenCount} tokens)`);
+}
+
+/**
  * Build the systemMessage for the SessionStart composition: a single status
  * line naming which components were injected (e.g. "injected summary + peer
  * card (12 items)"). Session start is a once-per-session surface, so unlike the

--- a/plugins/honcho/src/visual.ts
+++ b/plugins/honcho/src/visual.ts
@@ -87,11 +87,12 @@ export function visDialecticMessage(hookName: string, reasoning: string, elapsed
 
 /**
  * Build the per-turn systemMessage for the "sessionContext" component: a
- * status line with the summary's token count. The summary itself goes to
- * additionalContext only — it's long-lived session prose, not per-turn news.
+ * status line with the message and token counts. The messages themselves go
+ * to additionalContext only.
  */
-export function visSessionSummaryMessage(hookName: string, tokenCount: number): string {
-  return formatLine("in", hookName, `injected session summary (${tokenCount} tokens)`);
+export function visSessionContextMessage(hookName: string, messageCount: number, tokenCount: number): string {
+  const noun = messageCount === 1 ? "message" : "messages";
+  return formatLine("in", hookName, `injected ${messageCount} session ${noun} (~${tokenCount} tokens)`);
 }
 
 /**


### PR DESCRIPTION
Splits into 3 context options for per-turn injection:
- **`userContext`**: same as `context` before
- **`assistantContext`**: similar to above, but on claude's peer instead of the user's.
- **`sessionContext`**: injects results of `session.context({ summary: false, tokens: 1500 })`

Default per-turn selection stays `["userContext"]`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Per-turn memory injection can now independently include user conclusions, assistant conclusions, session messages, and dialectic recall.
  * Added configurable token budgeting for injected session messages.
  * Configuration guidance now reflects the expanded memory injection options.

* **Bug Fixes**
  * Existing configurations using the legacy `context` setting continue to work as user-context injection.

* **Documentation**
  * Added changelog details for the 0.2.9 release.

* **Release**
  * Updated the Honcho plugin version to 0.2.9.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->