### PR TITLE
feat: hide injected context by default

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,14 +6,14 @@
   },
   "metadata": {
     "description": "Honcho plugins for Claude Code - memory, development tools, and more",
-    "version": "0.2.9"
+    "version": "0.2.10"
   },
   "plugins": [
     {
       "name": "honcho",
       "source": "./plugins/honcho",
       "description": "Persistent memory for Claude Code sessions using Honcho",
-      "version": "0.2.9",
+      "version": "0.2.10",
       "keywords": ["memory", "context", "persistence"],
       "strict": false
     },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to claude-honcho will be documented in this file.
 
 ## [Unreleased]
 
+## [0.2.10] - 2026-07-29
+
+### Changed
+
+- Per-turn injection components report a one-line summary instead of printing their contents. `injection.showContents` lists the components that should still print their full payload (default: none). Display only — what reaches the model is unchanged.
+
 ## [0.2.9] - 2026-07-28
 
 ### Changed

--- a/plugins/honcho/.claude-plugin/plugin.json
+++ b/plugins/honcho/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "honcho",
-  "version": "0.2.9",
+  "version": "0.2.10",
   "description": "Persistent memory for Claude Code sessions using Honcho by Plastic Labs",
   "author": {
     "name": "Plastic Labs",

--- a/plugins/honcho/package.json
+++ b/plugins/honcho/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-honcho",
-  "version": "0.2.9",
+  "version": "0.2.10",
   "description": "Persistent memory for Claude Code sessions using Honcho by Plastic Labs",
   "type": "module",
   "keywords": [

--- a/plugins/honcho/skills/config/SKILL.md
+++ b/plugins/honcho/skills/config/SKILL.md
@@ -42,7 +42,7 @@ AskUserQuestion:
       description: "What Honcho injects at session start and per turn (currently: start [{resolved.injection.sessionStart}], turn [{resolved.injection.perTurn}])"
 ```
 
-For the "Memory injection" description, use the *effective* values: if `injection.sessionStart` is unset it is `["directives", "summary", "peerCard"]`, and if `injection.perTurn` is unset it is `["userContext"]` (user conclusions on). A stored perTurn value of `"context"` is the legacy name for `"userContext"` — treat them as the same.
+For the "Memory injection" description, use the *effective* values: if `injection.sessionStart` is unset it is `["directives", "summary", "peerCard"]`, and if `injection.perTurn` is unset it is `["userContext"]` (user conclusions on). A stored perTurn value of `"context"` is the legacy name for `"userContext"` — treat them as the same. `injection.showContents` defaults to `[]`.
 
 If the user selects "Other", present advanced options:
 
@@ -148,7 +148,7 @@ If confirmed, call `set_config` again WITH `confirm: true`.
 
 ### Memory injection
 
-Ask BOTH questions in a SINGLE `AskUserQuestion` call — two multi-select questions — so the user configures both surfaces at once. This is the only injection prompt; do not add follow-ups.
+Ask ALL questions in a SINGLE `AskUserQuestion` call — multi-select each — so the user configures every surface at once. This is the only injection prompt; do not add follow-ups.
 
 ```yaml
 AskUserQuestion:
@@ -177,13 +177,28 @@ AskUserQuestion:
           description: "Recent raw messages from the mapped Honcho session — useful when other instances share the session"
         - label: "Dialectic recall"
           description: "A reasoned answer over your history each turn — richer but slower (off by default)"
+    - question: "Which of those should print what they injected to the terminal?"
+      header: "Show in UI"
+      multiSelect: true
+      options:                     # same four labels as "Per turn"
+        - label: "User conclusions"
+          description: "List each injected conclusion instead of just the count"
+        - label: "Assistant conclusions"
+          description: "List each injected conclusion instead of just the count"
+        - label: "Session messages"
+          description: "List each injected message, one truncated line each"
+        - label: "Dialectic recall"
+          description: "Print the full reasoned answer — prose, can be long"
 ```
 
-Map the selections to component names, then call `set_config` once per surface:
+Map the selections to component names, then call `set_config` once per field:
 - Session start → `injection.sessionStart`, mapping "Memory directives"→`directives`, "Session summary"→`summary`, "Peer card"→`peerCard`, "Representation"→`peerRepresentation`.
 - Per turn → `injection.perTurn`, mapping "User conclusions"→`userContext`, "Assistant conclusions"→`assistantContext`, "Session messages"→`sessionContext`, "Dialectic recall"→`dialectic`.
+- Show in UI → `injection.showContents`, same mapping as per turn.
 
 Pass the value as a JSON array (e.g. `["directives","summary","peerCard"]`). An empty selection for a surface means "inject nothing" there — pass `[]`.
+
+`showContents` only affects the terminal display; every enabled component injects into the model's context regardless. Default is `[]` — each component reports a one-line summary (count, tokens, timing) and nothing else. Only offer components the user selected for per turn; skip this question entirely when they selected none.
 
 Retrieval tuning is intentionally NOT asked here. `injection.searchTopK` (default 10), `injection.maxConclusions` (15), `injection.searchMaxDistance` (0.6, cosine — lower is stricter), and `injection.searchQuerySource` ("prompt" | "topics", default "prompt") are all configurable via `set_config`, but keep the defaults; only mention they're tunable if the user brings it up, and never prompt for them.
 

--- a/plugins/honcho/skills/config/SKILL.md
+++ b/plugins/honcho/skills/config/SKILL.md
@@ -39,10 +39,10 @@ AskUserQuestion:
     - label: "Workspace"
       description: "Data space and session scope (currently: {resolved.workspace})"
     - label: "Memory injection"
-      description: "What Honcho injects at session start and per turn (currently: start [{resolved.injection.sessionStart}], turn [{resolved.injection.perTurn}])"
+      description: "What Honcho injects at session start and per turn (currently: start [{resolved.injection.sessionStart}], turn [{resolved.injection.perTurn}], shown in UI [{resolved.injection.showContents}])"
 ```
 
-For the "Memory injection" description, use the *effective* values: if `injection.sessionStart` is unset it is `["directives", "summary", "peerCard"]`, and if `injection.perTurn` is unset it is `["userContext"]` (user conclusions on). A stored perTurn value of `"context"` is the legacy name for `"userContext"` — treat them as the same. `injection.showContents` defaults to `[]`.
+For the "Memory injection" description, use the *effective* values: if `injection.sessionStart` is unset it is `["directives", "summary", "peerCard"]`, and if `injection.perTurn` is unset it is `["userContext"]` (user conclusions on). A stored perTurn value of `"context"` is the legacy name for `"userContext"` — treat them as the same. `injection.showContents` is `[]` when unset — render that as `none`.
 
 If the user selects "Other", present advanced options:
 
@@ -148,7 +148,7 @@ If confirmed, call `set_config` again WITH `confirm: true`.
 
 ### Memory injection
 
-Ask ALL questions in a SINGLE `AskUserQuestion` call — multi-select each — so the user configures every surface at once. This is the only injection prompt; do not add follow-ups.
+Ask all three questions in a SINGLE `AskUserQuestion` call — multi-select each — so the user configures every surface at once. Always include all three, each offering all of its options: the "Show in UI" answers arrive in the same response as "Per turn", so there is no way to narrow them to what the user just enabled. A "Show in UI" pick for a component that is off is harmless — it's stored and takes effect if that component is enabled later. This is the only injection prompt; do not add follow-ups.
 
 ```yaml
 AskUserQuestion:
@@ -196,9 +196,9 @@ Map the selections to component names, then call `set_config` once per field:
 - Per turn → `injection.perTurn`, mapping "User conclusions"→`userContext`, "Assistant conclusions"→`assistantContext`, "Session messages"→`sessionContext`, "Dialectic recall"→`dialectic`.
 - Show in UI → `injection.showContents`, same mapping as per turn.
 
-Pass the value as a JSON array (e.g. `["directives","summary","peerCard"]`). An empty selection for a surface means "inject nothing" there — pass `[]`.
+Pass the value as a JSON array (e.g. `["directives","summary","peerCard"]`). An empty selection means `[]`: for `injection.sessionStart` and `injection.perTurn` that surface then injects nothing, and for `injection.showContents` (the default) every enabled per-turn component still injects — it just reports a one-line summary (count, tokens, timing) instead of printing its payload.
 
-`showContents` only affects the terminal display; every enabled component injects into the model's context regardless. Default is `[]` — each component reports a one-line summary (count, tokens, timing) and nothing else. Only offer components the user selected for per turn; skip this question entirely when they selected none.
+`showContents` is display-only. It never changes what reaches the model.
 
 Retrieval tuning is intentionally NOT asked here. `injection.searchTopK` (default 10), `injection.maxConclusions` (15), `injection.searchMaxDistance` (0.6, cosine — lower is stricter), and `injection.searchQuerySource` ("prompt" | "topics", default "prompt") are all configurable via `set_config`, but keep the defaults; only mention they're tunable if the user brings it up, and never prompt for them.
 

--- a/plugins/honcho/src/config.ts
+++ b/plugins/honcho/src/config.ts
@@ -398,6 +398,23 @@ export function configExists(): boolean {
 }
 
 /**
+ * The plugin's own version, read from plugin.json — the same source the
+ * version-check script uses. Returns "unknown" when the manifest can't be
+ * located, so callers never advertise a stale hardcoded number.
+ */
+export function getPluginVersion(): string {
+  const root = process.env.CLAUDE_PLUGIN_ROOT;
+  if (!root) return "unknown";
+  try {
+    const raw = readFileSync(join(root, ".claude-plugin", "plugin.json"), "utf-8");
+    const version = (JSON.parse(raw) as { version?: unknown }).version;
+    return typeof version === "string" && version ? version : "unknown";
+  } catch {
+    return "unknown";
+  }
+}
+
+/**
  * Load config from file, with environment variable fallbacks.
  * Host-specific fields are resolved from the hosts block in the config file.
  */

--- a/plugins/honcho/src/config.ts
+++ b/plugins/honcho/src/config.ts
@@ -88,6 +88,10 @@ export interface InjectionConfig {
   sessionStart?: SessionStartComponent[];
   /** Components emitted per non-trivial prompt (default: ["userContext"]). */
   perTurn?: PerTurnComponent[];
+  /** Per-turn components whose full injected payload is printed to the terminal.
+   *  Components not listed still inject; they just report a one-line summary
+   *  instead of their contents (default: [] — summaries only). */
+  showContents?: PerTurnComponent[];
   /** Top-K conclusions pulled by context()'s semantic search (default: 10). */
   searchTopK?: number;
   /** Max conclusions injected per context() call (default: 15). */
@@ -113,10 +117,11 @@ export interface InjectionConfig {
 /** Resolved injection defaults: memory-usage directives + session summary +
  *  peer card at session start, a fresh user-peer context() per turn. Retrieval knobs
  *  are tuned for a lean per-turn block — topK 10 for recall, a 0.6 cosine
- *  distance, searching on the raw prompt. */
+ *  distance, searching on the raw prompt. No component prints its contents. */
 export const DEFAULT_INJECTION: Required<InjectionConfig> = {
   sessionStart: ["directives", "summary", "peerCard"],
   perTurn: ["userContext"],
+  showContents: [],
   searchTopK: 10,
   maxConclusions: 15,
   searchMaxDistance: 0.6,
@@ -809,10 +814,13 @@ export function getLocalContextConfig(): LocalContextConfig {
 export function getInjectionConfig(config?: HonchoCLAUDEConfig | null): Required<InjectionConfig> {
   const injection = (config === undefined ? loadConfig() : config)?.injection;
   const resolved = { ...DEFAULT_INJECTION, ...(injection ?? {}) };
-  // Guard hand-edited configs: a non-array perTurn falls back to the default.
+  // Guard hand-edited configs: a non-array component list falls back to the default.
   resolved.perTurn = Array.isArray(resolved.perTurn)
     ? normalizePerTurn(resolved.perTurn)
     : DEFAULT_INJECTION.perTurn;
+  resolved.showContents = Array.isArray(resolved.showContents)
+    ? normalizePerTurn(resolved.showContents)
+    : DEFAULT_INJECTION.showContents;
   return resolved;
 }
 

--- a/plugins/honcho/src/hooks/user-prompt.ts
+++ b/plugins/honcho/src/hooks/user-prompt.ts
@@ -1,7 +1,7 @@
 import { Honcho } from "@honcho-ai/sdk";
 import { readFileSync, existsSync } from "node:fs";
 import { join } from "node:path";
-import { loadConfig, getSessionName, getHonchoClientOptions, isPluginEnabled, getCachedStdin, getObservationMode, getInjectionConfig, type InjectionConfig } from "../config.js";
+import { loadConfig, getSessionName, getHonchoClientOptions, isPluginEnabled, getCachedStdin, getObservationMode, getInjectionConfig, type InjectionConfig, type PerTurnComponent } from "../config.js";
 import {
   getMessageCount,
   incrementMessageCount,
@@ -240,18 +240,21 @@ export async function handleUserPrompt(): Promise<void> {
       ? { context: userCtxResult.context, matched: userCtxResult.matched, queryLabel: userCtxResult.queryLabel }
       : null;
 
-  emitPerTurn(config, userCtx, assistantCtxResult?.context ?? null, sessionCtx, dialectic, sessionLink);
+  emitPerTurn(config, injection, userCtx, assistantCtxResult?.context ?? null, sessionCtx, dialectic, sessionLink);
   process.exit(0);
 }
 
 /**
  * Emit the per-turn injection: the selected components composed into one
- * additionalContext payload plus a per-component systemMessage summary.
- * Exits silently when nothing resolved to content — mirroring the old
- * no-cache fall-through.
+ * additionalContext payload plus a per-component systemMessage summary. Every
+ * component reports a one-line summary; only those listed in
+ * `injection.showContents` also print their payload to the terminal. Exits
+ * silently when nothing resolved to content — mirroring the old no-cache
+ * fall-through.
  */
 function emitPerTurn(
   config: any,
+  injection: InjectionConfig,
   userCtx: { context: any; matched?: string[]; queryLabel?: string } | null,
   assistantCtx: any | null,
   sessionCtx: SessionContextResult | null,
@@ -260,12 +263,13 @@ function emitPerTurn(
 ): void {
   const parts: string[] = [];
   const visLines: string[] = [];
+  const show = (c: PerTurnComponent) => injection.showContents?.includes(c) ?? false;
 
   if (userCtx) {
     const conclusions = extractConclusions(userCtx.context);
     if (conclusions.length > 0) {
       parts.push(`Relevant conclusions: ${conclusions.join("; ")}`);
-      visLines.push(visInjectionMessage("user-prompt", { conclusions, matched: userCtx.matched, queryLabel: userCtx.queryLabel }));
+      visLines.push(visInjectionMessage("user-prompt", { conclusions, matched: userCtx.matched, queryLabel: userCtx.queryLabel, showContents: show("userContext") }));
     }
   }
 
@@ -273,18 +277,18 @@ function emitPerTurn(
     const conclusions = extractConclusions(assistantCtx);
     if (conclusions.length > 0) {
       parts.push(`Conclusions about the assistant (${config.aiPeer}): ${conclusions.join("; ")}`);
-      visLines.push(visInjectionMessage("user-prompt", { conclusions, queryLabel: `assistant ${config.aiPeer}` }));
+      visLines.push(visInjectionMessage("user-prompt", { conclusions, queryLabel: `assistant ${config.aiPeer}`, showContents: show("assistantContext") }));
     }
   }
 
   if (sessionCtx) {
     parts.push(`Recent Honcho session messages:\n${sessionCtx.lines.join("\n")}`);
-    visLines.push(visSessionContextMessage("user-prompt", sessionCtx.lines, sessionCtx.tokenCount));
+    visLines.push(visSessionContextMessage("user-prompt", sessionCtx.lines, sessionCtx.tokenCount, show("sessionContext")));
   }
 
   if (dialectic) {
     parts.push(`Dialectic recall: ${dialectic.answer}`);
-    visLines.push(visDialecticMessage("user-prompt", dialectic.reasoning, dialectic.elapsedMs, dialectic.answer));
+    visLines.push(visDialecticMessage("user-prompt", dialectic.reasoning, dialectic.elapsedMs, dialectic.answer, show("dialectic")));
   }
 
   if (parts.length === 0) return;

--- a/plugins/honcho/src/mcp/server.ts
+++ b/plugins/honcho/src/mcp/server.ts
@@ -31,6 +31,7 @@ import {
   normalizePerTurn,
   REASONING_LEVELS,
   getObservationMode,
+  getPluginVersion,
 } from "../config.js";
 import { honchoSessionUrl } from "../styles.js";
 import {
@@ -748,7 +749,7 @@ export async function runMcpServer(): Promise<void> {
   const server = new Server(
     {
       name: "honcho",
-      version: "0.2.6",
+      version: getPluginVersion(),
     },
     {
       capabilities: {

--- a/plugins/honcho/src/mcp/server.ts
+++ b/plugins/honcho/src/mcp/server.ts
@@ -516,6 +516,16 @@ function handleSetConfig(args: Record<string, unknown>) {
       break;
     }
 
+    case "injection.showContents": {
+      const raw = coerceStringArray(value);
+      const arr = validateComponentArray(raw ? normalizePerTurn(raw) : value, PER_TURN_COMPONENTS, field);
+      if (!Array.isArray(arr)) return arr;
+      previousValue = cfg.injection?.showContents;
+      if (!cfg.injection) cfg.injection = {};
+      cfg.injection.showContents = arr as PerTurnComponent[];
+      break;
+    }
+
     case "injection.searchTopK":
       previousValue = cfg.injection?.searchTopK;
       if (!cfg.injection) cfg.injection = {};
@@ -922,6 +932,7 @@ export async function runMcpServer(): Promise<void> {
                   "localContext.maxEntries",
                   "injection.sessionStart",
                   "injection.perTurn",
+                  "injection.showContents",
                   "injection.searchTopK",
                   "injection.maxConclusions",
                   "injection.searchMaxDistance",
@@ -935,7 +946,7 @@ export async function runMcpServer(): Promise<void> {
                 ],
               },
               value: {
-                description: "New value. For sessions.set: {path, name}. For sessions.remove: {path}. For injection.sessionStart / injection.perTurn: a string array of component names (e.g. [\"summary\",\"peerCard\"]).",
+                description: "New value. For sessions.set: {path, name}. For sessions.remove: {path}. For injection.sessionStart / injection.perTurn / injection.showContents: a string array of component names (e.g. [\"summary\",\"peerCard\"]).",
               },
               confirm: {
                 type: "boolean",

--- a/plugins/honcho/src/visual.ts
+++ b/plugins/honcho/src/visual.ts
@@ -51,16 +51,19 @@ export function visMessage(direction: HookDirection, hookName: string, message: 
 
 /**
  * Build the injection systemMessage for the user-prompt hook: a one-line status
- * summary followed by the injected conclusions as bullets. The stable profile
- * block is intentionally omitted here — it lives in the injection log, not in
- * every turn's transcript. `matched` is only set for high-signal topics, so a
- * low-signal fuzzy fallback query is never surfaced as a bogus match.
+ * summary, and with `showContents` the injected conclusions as bullets. The
+ * stable profile block is intentionally omitted here — it lives in the injection
+ * log, not in every turn's transcript. `matched` is only set for high-signal
+ * topics, so a low-signal fuzzy fallback query is never surfaced as a bogus
+ * match.
  */
 export function visInjectionMessage(hookName: string, opts: {
   conclusions: string[];
   matched?: string[];
   /** Overrides the matched suffix, e.g. "prompt" → "(query: prompt)". */
   queryLabel?: string;
+  /** Print the conclusions, not just the count. */
+  showContents?: boolean;
 }): string {
   const count = opts.conclusions.length;
   const noun = count === 1 ? "conclusion" : "conclusions";
@@ -70,32 +73,36 @@ export function visInjectionMessage(hookName: string, opts: {
       ? `injected ${count} ${noun} (matched: ${opts.matched.join(", ")})`
       : `injected ${count} ${noun}`;
   const summary = formatLine("in", hookName, head);
+  if (!opts.showContents) return summary;
   const body = opts.conclusions.map(c => `  ${sym.bullet} ${c}`).join("\n");
   return body ? `${summary}\n${body}` : summary;
 }
 
 /**
  * Build the per-turn systemMessage for the "dialectic" component: a status line
- * (tier · elapsed) followed by the full reasoned answer, so the user sees
- * exactly what was injected. The answer is prose and can be long — that's the
- * intended trade-off; it also lands in additionalContext for the model.
+ * (tier · elapsed), and with `showContents` the full reasoned answer, so the
+ * user sees exactly what was injected. The answer is prose and can be long —
+ * that's the trade-off for showing it; it lands in additionalContext for the
+ * model either way.
  */
-export function visDialecticMessage(hookName: string, reasoning: string, elapsedMs: number, answer: string): string {
+export function visDialecticMessage(hookName: string, reasoning: string, elapsedMs: number, answer: string, showContents = false): string {
   const head = formatLine("in", hookName, `injected dialectic (${reasoning} · ${(elapsedMs / 1000).toFixed(1)}s)`);
-  return answer.trim() ? `${head}\n${answer.trim()}` : head;
+  return showContents && answer.trim() ? `${head}\n${answer.trim()}` : head;
 }
 
 /**
  * Build the per-turn systemMessage for the "sessionContext" component: a
- * status line with the message and token counts, then every injected message
- * as a bullet. Each message is collapsed to a single truncated line — the
- * full text goes to additionalContext; this listing is for visibility into
- * what was injected. The count has no display cutoff: it's bounded upstream
- * by the sessionContextTokens budget passed to session.context().
+ * status line with the message and token counts, and with `showContents` every
+ * injected message as a bullet. Each message is collapsed to a single truncated
+ * line — the full text goes to additionalContext; this listing is for
+ * visibility into what was injected. The count has no display cutoff: it's
+ * bounded upstream by the sessionContextTokens budget passed to
+ * session.context().
  */
-export function visSessionContextMessage(hookName: string, lines: string[], tokenCount: number): string {
+export function visSessionContextMessage(hookName: string, lines: string[], tokenCount: number, showContents = false): string {
   const noun = lines.length === 1 ? "message" : "messages";
   const head = formatLine("in", hookName, `injected ${lines.length} session ${noun} (~${tokenCount} tokens)`);
+  if (!showContents) return head;
   const body = lines
     .map((l) => {
       const flat = l.replace(/\s+/g, " ").trim();


### PR DESCRIPTION

Adds a new `injection.showContents` config field (default: `[]`), that controls what injection contents are shown to the user in the hooks system message.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable control over which per-turn memory injection components display full contents in the terminal.
  * Components not selected now display concise one-line summaries while continuing to provide full context to the model.
  * Added configuration support for selecting displayed components.

* **Documentation**
  * Updated setup guidance and changelog with the new display behavior and configuration options.

* **Chores**
  * Bumped the Honcho package and plugin version to 0.2.10.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->