### PR TITLE
fix(mcp): set_config boolean fields cannot be turned off — string "false" coerces to true

### DIFF
--- a/plugins/honcho/src/config.ts
+++ b/plugins/honcho/src/config.ts
@@ -241,6 +241,15 @@ export function getDefaultAiPeer(host?: HonchoHost): string {
   return DEFAULT_AI_PEER[host ?? getDetectedHost()];
 }
 
+// MCP tool arguments may arrive as strings; Boolean("false") is true.
+export function coerceBoolean(value: unknown): boolean {
+  if (typeof value === "string") {
+    const v = value.trim().toLowerCase();
+    return v !== "false" && v !== "0" && v !== "";
+  }
+  return Boolean(value);
+}
+
 // Stdin cache: entry points read stdin once via initHook(),
 // handlers consume from cache via getCachedStdin().
 let _stdinText: string | null = null;

--- a/plugins/honcho/src/mcp/server.ts
+++ b/plugins/honcho/src/mcp/server.ts
@@ -10,6 +10,7 @@ import {
   loadConfig,
   saveConfig,
   saveRootField,
+  coerceBoolean,
   getHonchoClientOptions,
   getSessionName,
   getConfigPath,
@@ -402,7 +403,7 @@ function handleSetConfig(args: Record<string, unknown>) {
 
     case "sessionPeerPrefix":
       previousValue = cfg.sessionPeerPrefix !== false;
-      cfg.sessionPeerPrefix = Boolean(value);
+      cfg.sessionPeerPrefix = coerceBoolean(value);
       // Clear persisted session names — they embed the old prefix
       cfg.sessions = {};
       break;
@@ -410,24 +411,24 @@ function handleSetConfig(args: Record<string, unknown>) {
 
     case "globalOverride":
       previousValue = cfg.globalOverride ?? false;
-      cfg.globalOverride = Boolean(value);
+      cfg.globalOverride = coerceBoolean(value);
       // globalOverride is a root-level flag — write to root (user-directed)
       saveRootField("globalOverride", cfg.globalOverride);
       break;
 
     case "enabled":
       previousValue = cfg.enabled;
-      cfg.enabled = Boolean(value);
+      cfg.enabled = coerceBoolean(value);
       break;
 
     case "logging":
       previousValue = cfg.logging;
-      cfg.logging = Boolean(value);
+      cfg.logging = coerceBoolean(value);
       break;
 
     case "saveMessages":
       previousValue = cfg.saveMessages;
-      cfg.saveMessages = Boolean(value);
+      cfg.saveMessages = coerceBoolean(value);
       break;
 
     case "messageUpload.maxUserTokens":
@@ -445,7 +446,7 @@ function handleSetConfig(args: Record<string, unknown>) {
     case "messageUpload.summarizeAssistant":
       previousValue = cfg.messageUpload?.summarizeAssistant;
       if (!cfg.messageUpload) cfg.messageUpload = {};
-      cfg.messageUpload.summarizeAssistant = Boolean(value);
+      cfg.messageUpload.summarizeAssistant = coerceBoolean(value);
       break;
 
     case "contextRefresh.messageThreshold":
@@ -463,7 +464,7 @@ function handleSetConfig(args: Record<string, unknown>) {
     case "contextRefresh.skipDialectic":
       previousValue = cfg.contextRefresh?.skipDialectic;
       if (!cfg.contextRefresh) cfg.contextRefresh = {};
-      cfg.contextRefresh.skipDialectic = Boolean(value);
+      cfg.contextRefresh.skipDialectic = coerceBoolean(value);
       break;
 
     case "reasoningLevel":
@@ -561,7 +562,7 @@ function handleSetConfig(args: Record<string, unknown>) {
 
     case "rememberTool":
       previousValue = cfg.rememberTool;
-      cfg.rememberTool = Boolean(value);
+      cfg.rememberTool = coerceBoolean(value);
       break;
 
     case "injection.searchQuerySource":

--- a/plugins/honcho/tests/config-helpers.test.ts
+++ b/plugins/honcho/tests/config-helpers.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test } from "bun:test";
+import { coerceBoolean } from "../src/config";
+
+describe("coerceBoolean", () => {
+  test("passes real booleans through", () => {
+    expect(coerceBoolean(true)).toBe(true);
+    expect(coerceBoolean(false)).toBe(false);
+  });
+
+  test('string "false" is false (MCP args arrive as strings)', () => {
+    expect(coerceBoolean("false")).toBe(false);
+    expect(coerceBoolean("FALSE")).toBe(false);
+    expect(coerceBoolean(" false ")).toBe(false);
+    expect(coerceBoolean("0")).toBe(false);
+    expect(coerceBoolean("")).toBe(false);
+  });
+
+  test('string "true" and other truthy strings are true', () => {
+    expect(coerceBoolean("true")).toBe(true);
+    expect(coerceBoolean("1")).toBe(true);
+  });
+
+  test("non-string non-boolean values coerce naturally", () => {
+    expect(coerceBoolean(1)).toBe(true);
+    expect(coerceBoolean(0)).toBe(false);
+    expect(coerceBoolean(undefined)).toBe(false);
+    expect(coerceBoolean(null)).toBe(false);
+  });
+});


### PR DESCRIPTION
Fixes the live half of DEV-2236.

## Problem

MCP tool args arrive as strings, and `Boolean("false") === true` — so all 8 boolean fields in `set_config` (`enabled`, `saveMessages`, `logging`, `sessionPeerPrefix`, …) can be turned on but never off, while reporting success. Worst case: "turn off message uploads" leaves uploads running.

## Fix

`coerceBoolean()` ("false"/"0"/"" → false, case/whitespace-insensitive) applied at all 8 sites, unit tested (`bun test` 4/4, `tsc` clean).

## Not in this PR

`sessionPeerPrefix` / `peerName` / `sessionStrategy` still clear the sessions map when changed — that data-loss design question stays open in DEV-2236.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of boolean configuration updates when values are provided as text.
  * Values such as `"false"`, `"0"`, and blank strings are now correctly treated as disabled, while other non-empty strings remain enabled.

* **Tests**
  * Added coverage for text, boolean, numeric, null, and undefined configuration values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->