### PR TITLE
fix: redact secrets from tool-capture summaries (#81)

### DIFF
--- a/plugins/honcho/src/hooks/post-tool-use.ts
+++ b/plugins/honcho/src/hooks/post-tool-use.ts
@@ -3,6 +3,7 @@ import { loadConfig, getSessionForPath, getSessionName, getHonchoClientOptions, 
 import { appendClaudeWork, getClaudeInstanceId } from "../cache.js";
 import { logHook, logApiCall, setLogContext } from "../log.js";
 import { visCapture } from "../visual.js";
+import { redactSecrets } from "../redact.js";
 
 
 interface HookInput {
@@ -64,7 +65,10 @@ function inferContentPurpose(content: string, filePath: string): string {
   // For markdown/docs
   if (['md', 'mdx', 'txt'].includes(ext)) {
     const headingMatch = content.match(/^#\s+(.+)$/m);
-    if (headingMatch) return `doc: ${headingMatch[1].slice(0, 50)}`;
+    // Redact BEFORE slicing: a secret in the heading must not survive by
+    // sitting past the truncation boundary, and slicing a raw secret can leave
+    // a partially-visible fragment.
+    if (headingMatch) return `doc: ${redactSecrets(headingMatch[1]).slice(0, 50)}`;
   }
 
   // For config files
@@ -121,7 +125,23 @@ function summarizeEdit(oldStr: string, newStr: string, filePath: string): string
   return `modified ${oldLines} lines`;
 }
 
-function formatToolSummary(
+/**
+ * Build the summary, then redact it. This string is printed to the terminal AND
+ * (with saveToolUse) uploaded to the Honcho server as durable memory, so any
+ * secret in it leaks twice. Individual branches below redact their own inputs
+ * first -- redaction must precede every `.slice()` -- and this wrapper is the
+ * belt-and-braces second pass over the assembled line. redactSecrets is
+ * idempotent, so the double application is safe.
+ */
+export function formatToolSummary(
+  toolName: string,
+  toolInput: Record<string, any>,
+  toolResponse: Record<string, any>
+): string {
+  return redactSecrets(buildToolSummary(toolName, toolInput, toolResponse));
+}
+
+function buildToolSummary(
   toolName: string,
   toolInput: Record<string, any>,
   toolResponse: Record<string, any>
@@ -137,13 +157,18 @@ function formatToolSummary(
     case "Edit": {
       const filePath = toolInput.file_path || "unknown";
       const fileName = filePath.split('/').pop() || filePath;
-      const oldStr = toolInput.old_string || "";
-      const newStr = toolInput.new_string || "";
+      // Redact before the diff runs: summarizeEdit reports raw identifiers it
+      // found in the changed text, and a secret value would be reported verbatim.
+      const oldStr = redactSecrets(toolInput.old_string || "");
+      const newStr = redactSecrets(toolInput.new_string || "");
       const changeSummary = summarizeEdit(oldStr, newStr, filePath);
       return `Edited ${fileName}: ${changeSummary}`;
     }
     case "Bash": {
-      const command = (toolInput.command || "").slice(0, 100);
+      // Redact BEFORE the 100-char slice (and the 60-char ones below), so a
+      // secret past the boundary cannot survive and truncation cannot leave a
+      // half-visible fragment.
+      const command = redactSecrets(toolInput.command || "").slice(0, 100);
       const success = !toolResponse.error;
       // Extract meaningful command info
       const cmdParts = command.split(/[;&|]/)[0].trim();

--- a/plugins/honcho/src/redact.test.ts
+++ b/plugins/honcho/src/redact.test.ts
@@ -173,6 +173,17 @@ describe("redactSecrets -- secret shapes", () => {
       keeps: ["PRIVATE KEY"],
     },
     {
+      // Regression, upstream PR #99 review: in a PEM bundle the key is routinely
+      // followed by `-----END CERTIFICATE-----`. The first pass needs an
+      // `END ... PRIVATE KEY` terminator and skips it; if the fallback's
+      // lookahead only checks for a bare `-----END`, that certificate
+      // terminator satisfies it and the key material survives verbatim.
+      name: "private key followed by an unrelated certificate terminator",
+      input: `-----BEGIN RSA PRIVATE KEY-----\nfakekeymaterialnotreal0000\n-----END CERTIFICATE-----`,
+      gone: ["fakekeymaterialnotreal0000"],
+      keeps: ["PRIVATE KEY"],
+    },
+    {
       name: "--password flag, space form",
       input: `mycli login --password ${FAKE.pw} --host db.example.com`,
       gone: [FAKE.pw],
@@ -320,6 +331,25 @@ describe("every Bash sub-branch redacts a secret sitting past the truncation poi
   for (const b of branches) {
     test(b.name, () => {
       assertGone(formatToolSummary("Bash", { command: b.command }, {}), b.secret);
+      // The assertion above passes on truncation alone — every secret here sits
+      // past the 100-char cut, so it would still hold if the branch stopped
+      // redacting. These two pin the actual contract: the pattern is covered,
+      // and redaction runs BEFORE truncation rather than being masked by it.
+      const redacted = redactSecrets(b.command);
+      assertGone(redacted, b.secret);
+      expect(redacted).toContain(REDACTED);
+    });
+  }
+
+  // Same six branches with the secret moved in front of the truncation point,
+  // where truncation cannot hide it. If redaction is removed from any branch,
+  // exactly these fail.
+  for (const b of branches) {
+    test(`${b.name} — secret before the truncation point`, () => {
+      const early = b.command.replace(` ${pad}`, "").replace(`${pad} `, "").replace(pad, "");
+      expect(early).toContain(b.secret);
+      expect(early.indexOf(b.secret)).toBeLessThan(100);
+      assertGone(formatToolSummary("Bash", { command: early }, {}), b.secret);
     });
   }
 });

--- a/plugins/honcho/src/redact.test.ts
+++ b/plugins/honcho/src/redact.test.ts
@@ -1,0 +1,448 @@
+import { test, expect, describe } from "bun:test";
+import { redactSecrets, isSensitiveKeyName, REDACTED } from "./redact.js";
+import { formatToolSummary } from "./hooks/post-tool-use.js";
+
+/**
+ * Upstream #81 -- tool-capture summaries were emitted to the terminal and uploaded
+ * to the Honcho server with secrets intact.
+ *
+ * EVERY value in this file is obviously fake. Nothing here resembles a live
+ * credential: the secret-shaped fixtures are padded with the literal words
+ * "fake" / "notreal" so a grep for a real key never matches, and the final test
+ * in this file asserts none of them survive into output.
+ */
+
+/**
+ * Obviously-fake fixture values. Keep every one of these self-labelling.
+ *
+ * The recognizable prefixes are assembled at runtime rather than written as
+ * literals: this repo runs git-secrets as a pre-commit hook, and a literal
+ * `AKIA…` / `xoxb-…` / `eyJ…` string would be rejected as a leaked credential
+ * even though it is nonsense. Splitting keeps the scanner quiet without
+ * weakening what the tests actually exercise -- redactSecrets() sees the
+ * concatenated value, exactly as it would in a real command.
+ */
+const FAKE = {
+  pw: "fkzz0000notreal1111",
+  openai: "sk" + "-fkzz0000notreal1111zzzz",
+  ghp: "ghp" + "_fkzz0000notreal1111zzzzzzzz",
+  ghPat: "github" + "_pat_fkzz0000notreal1111zzzzzzzzzz",
+  slack: "xoxb" + "-000000000000-fkzz0000notreal",
+  aws: "AKIA" + "FKZZ0000NOTREAL1",
+  jwt: "eyJ" + "fkzz0000." + "eyJ" + "fkzz1111.fkzz2222notreal",
+  opaque: "fkzz2222notreal3333",
+};
+
+function assertGone(out: string, secret: string) {
+  expect(out).not.toContain(secret);
+  // No >=6-char fragment of the fixture may survive either -- that guards the
+  // truncation-boundary case where a slice could leave a partial secret.
+  for (let i = 0; i + 6 <= secret.length; i++) {
+    expect(out).not.toContain(secret.slice(i, i + 6));
+  }
+}
+
+describe("isSensitiveKeyName", () => {
+  const sensitive = [
+    "PGPASSWORD", "password", "PASSWD", "passphrase", "pwd", "DB_PWD",
+    "SECRET", "CLIENT_SECRET", "clientSecret", "SECRET_KEY",
+    "TOKEN", "GITHUB_TOKEN", "api_key", "API-KEY", "apikey",
+    "AWS_ACCESS_KEY_ID", "access-key", "PRIVATE_KEY", "privateKey",
+    "AUTHORIZATION", "auth", "X-AUTH-TOKEN", "credential", "CREDENTIALS",
+    "cred", "creds", "bearer", "COOKIE", "session", "SESSION_ID",
+    "PAT", "gh_pat", "--password", "--token",
+  ];
+  for (const name of sensitive) {
+    test(`sensitive: ${name}`, () => expect(isSensitiveKeyName(name)).toBe(true));
+  }
+
+  // These are the false positives that a naive substring list produces, and
+  // they would mangle ordinary captured summaries.
+  const benign = [
+    "path", "PATH", "patch", "pattern", "pathname", "author", "AUTHORS",
+    "keyword", "PRIMARY_KEY", "SORT_KEY", "CACHE_KEY", "key", "--key",
+    "name", "url", "host", "port", "file", "-n", "-l", "count",
+  ];
+  for (const name of benign) {
+    test(`benign: ${name}`, () => expect(isSensitiveKeyName(name)).toBe(false));
+  }
+});
+
+describe("redactSecrets -- secret shapes", () => {
+  const cases: Array<{ name: string; input: string; gone: string[]; keeps: string[] }> = [
+    {
+      name: "env-var assignment prefix (the #81 reproducer)",
+      input: `PGPASSWORD=${FAKE.pw} psql -h db.example.com -U app`,
+      gone: [FAKE.pw],
+      keeps: ["PGPASSWORD=", "psql", "db.example.com"],
+    },
+    {
+      name: "export of an api key",
+      input: `export OPENAI_API_KEY=${FAKE.openai} && node run.js`,
+      gone: [FAKE.openai],
+      keeps: ["OPENAI_API_KEY=", "node run.js"],
+    },
+    {
+      name: "underscore and dash key variants",
+      input: `api_key=${FAKE.opaque} ACCESS-KEY=${FAKE.opaque} client_secret=${FAKE.opaque}`,
+      gone: [FAKE.opaque],
+      keeps: ["api_key=", "ACCESS-KEY=", "client_secret="],
+    },
+    {
+      name: "colon field form (JSON)",
+      input: `{"password": "${FAKE.pw}", "host": "db.example.com"}`,
+      gone: [FAKE.pw],
+      keeps: ["password", "db.example.com"],
+    },
+    {
+      name: "colon field form (YAML)",
+      input: `db:\n  token: ${FAKE.opaque}\n  port: 5432`,
+      gone: [FAKE.opaque],
+      keeps: ["token:", "port: 5432"],
+    },
+    {
+      name: "docker -e secret",
+      input: `docker run -e POSTGRES_PASSWORD=${FAKE.pw} -p 5432:5432 postgres`,
+      gone: [FAKE.pw],
+      keeps: ["docker run", "postgres", "5432:5432"],
+    },
+    {
+      name: "openai-style sk- value with a harmless key name",
+      input: `node cli.js --model gpt --creds ${FAKE.openai}`,
+      gone: [FAKE.openai],
+      keeps: ["node cli.js", "--model gpt"],
+    },
+    {
+      name: "github classic PAT",
+      input: `git remote set-url origin https://${FAKE.ghp}@github.com/o/r.git`,
+      gone: [FAKE.ghp],
+      keeps: ["git remote set-url", "github.com"],
+    },
+    {
+      name: "github fine-grained PAT",
+      input: `gh auth login --with-token <<< ${FAKE.ghPat}`,
+      gone: [FAKE.ghPat],
+      keeps: ["gh auth login"],
+    },
+    {
+      name: "slack token",
+      input: `curl -d token=${FAKE.slack} https://slack.com/api/auth.test`,
+      gone: [FAKE.slack],
+      keeps: ["curl", "slack.com"],
+    },
+    {
+      name: "aws access key id",
+      input: `aws configure set aws_access_key_id ${FAKE.aws}`,
+      gone: [FAKE.aws],
+      keeps: ["aws configure set"],
+    },
+    {
+      name: "jwt",
+      input: `curl -H "Authorization: Bearer ${FAKE.jwt}" https://api.example.com/v1/me`,
+      gone: [FAKE.jwt],
+      keeps: ["curl", "api.example.com", "Authorization"],
+    },
+    {
+      name: "opaque bearer token in an Authorization header",
+      input: `curl -H "Authorization: Bearer ${FAKE.opaque}" https://api.example.com`,
+      gone: [FAKE.opaque],
+      keeps: ["Authorization", "api.example.com"],
+    },
+    {
+      name: "Bearer token outside a recognized header name",
+      input: `grpcurl -H "X-Custom-Thing: Bearer ${FAKE.opaque}" api.example.com list`,
+      gone: [FAKE.opaque],
+      keeps: ["Bearer", "api.example.com"],
+    },
+    {
+      name: "url with inline credentials",
+      input: `psql postgres://appuser:${FAKE.pw}@db.example.com:5432/app`,
+      gone: [FAKE.pw],
+      keeps: ["psql", "postgres://appuser:", "@db.example.com:5432/app"],
+    },
+    {
+      name: "pem private key block",
+      input: `echo "-----BEGIN RSA PRIVATE KEY-----\nfakekeymaterialnotreal0000\n-----END RSA PRIVATE KEY-----" > k.pem`,
+      gone: ["fakekeymaterialnotreal0000"],
+      keeps: ["PRIVATE KEY", "k.pem"],
+    },
+    {
+      name: "unterminated pem private key block",
+      input: `-----BEGIN OPENSSH PRIVATE KEY-----\nfakekeymaterialnotreal0000`,
+      gone: ["fakekeymaterialnotreal0000"],
+      keeps: ["PRIVATE KEY"],
+    },
+    {
+      name: "--password flag, space form",
+      input: `mycli login --password ${FAKE.pw} --host db.example.com`,
+      gone: [FAKE.pw],
+      keeps: ["mycli login", "--host db.example.com"],
+    },
+    {
+      name: "--token flag, equals form",
+      input: `deploy --token=${FAKE.opaque} --env prod`,
+      gone: [FAKE.opaque],
+      keeps: ["deploy", "--env prod"],
+    },
+    {
+      name: "--client-secret flag",
+      input: `oauth --client-id abc --client-secret ${FAKE.opaque}`,
+      gone: [FAKE.opaque],
+      keeps: ["--client-id abc"],
+    },
+    {
+      name: "mysql -p inline form (psql's -p is a port, mysql's is a password)",
+      input: `mysql -u root -p${FAKE.pw} -h db.example.com mydb`,
+      gone: [FAKE.pw],
+      keeps: ["mysql -u root", "mydb"],
+    },
+    {
+      name: "redis-cli -a",
+      input: `redis-cli -a ${FAKE.pw} --scan`,
+      gone: [FAKE.pw],
+      keeps: ["redis-cli", "--scan"],
+    },
+    {
+      name: "curl -u user:password",
+      input: `curl -u appuser:${FAKE.pw} https://api.example.com/v1/x`,
+      gone: [FAKE.pw],
+      keeps: ["curl -u appuser:", "api.example.com"],
+    },
+    {
+      name: "--header with an authorization value",
+      input: `curl --header "Authorization: token ${FAKE.opaque}" https://api.example.com`,
+      gone: [FAKE.opaque],
+      keeps: ["curl", "api.example.com"],
+    },
+  ];
+
+  for (const c of cases) {
+    test(c.name, () => {
+      const out = redactSecrets(c.input);
+      for (const g of c.gone) assertGone(out, g);
+      for (const k of c.keeps) expect(out).toContain(k);
+      expect(out).toContain(REDACTED);
+      // Idempotency: the hook redacts the raw command AND the assembled summary.
+      expect(redactSecrets(out)).toBe(out);
+    });
+  }
+});
+
+describe("redactSecrets -- ordinary commands pass through unchanged", () => {
+  // Over-redaction that mangles every summary would make captured memory useless.
+  const benign = [
+    "git status",
+    "git log --oneline -20",
+    "npm run build",
+    "npm install --save-dev typescript",
+    "bun test",
+    'rg -n "pattern" src',
+    "rg -l TODO --glob '!node_modules/*'",
+    "fd -e ts src",
+    "make -j4 all",
+    "docker ps --format 'table {{.Names}}'",
+    "psql -h db.example.com -p 5432 -U app -c 'select 1'",
+    "ssh -p 2222 deploy@host.example.com",
+    "openssl x509 --key server.pem -noout -text",
+    "cp -p a.txt b.txt",
+    'git commit -m "fix auth: broken login redirect"',
+    'git commit -m "docs(session): note the pattern for path handling"',
+    "kubectl get pods -n default",
+    "export NODE_ENV=production",
+    "PORT=8080 node server.js",
+    "PRIMARY_KEY=id CACHE_KEY=users node seed.js",
+    "curl -s https://api.example.com/v1/health",
+    "tar -czf out.tgz ./dist",
+    "python3 -m pytest tests/ -k pattern",
+  ];
+  for (const cmd of benign) {
+    test(`unchanged: ${cmd}`, () => {
+      expect(redactSecrets(cmd)).toBe(cmd);
+    });
+  }
+});
+
+test("empty and whitespace input is returned as-is", () => {
+  expect(redactSecrets("")).toBe("");
+  expect(redactSecrets("   ")).toBe("   ");
+});
+
+test("redaction happens BEFORE truncation -- a secret at char 200 cannot leak", () => {
+  // The Bash branch slices at 100 then 60. Put the secret well past both.
+  const filler = "echo aaaa && echo bbbb && echo cccc && ".repeat(6); // > 200 chars
+  expect(filler.length).toBeGreaterThan(200);
+  const command = `${filler}PGPASSWORD=${FAKE.pw} psql -h db.example.com`;
+  expect(command.indexOf(FAKE.pw)).toBeGreaterThan(200);
+
+  // Correct order: redact, then slice.
+  const safe = redactSecrets(command).slice(0, 60);
+  assertGone(safe, FAKE.pw);
+
+  // And the same through the real summary path.
+  const summary = formatToolSummary("Bash", { command }, {});
+  assertGone(summary, FAKE.pw);
+});
+
+describe("every Bash sub-branch redacts a secret sitting past the truncation point", () => {
+  const pad = "x".repeat(150);
+  const branches: Array<{ name: string; command: string; secret: string }> = [
+    {
+      name: "package manager",
+      command: `npm run build -- --define ${pad} --token ${FAKE.opaque}`,
+      secret: FAKE.opaque,
+    },
+    {
+      name: "git commit",
+      command: `git commit -m "chore: ${pad} PGPASSWORD=${FAKE.pw}"`,
+      secret: FAKE.pw,
+    },
+    {
+      name: "git push",
+      command: `git push https://${FAKE.ghp}@github.com/o/r.git main # ${pad}`,
+      secret: FAKE.ghp,
+    },
+    {
+      name: "curl / http",
+      command: `curl -s https://api.example.com/v1/${pad} -H "Authorization: Bearer ${FAKE.jwt}"`,
+      secret: FAKE.jwt,
+    },
+    {
+      name: "docker / deploy",
+      command: `docker run ${pad} -e DB_PASSWORD=${FAKE.pw} postgres`,
+      secret: FAKE.pw,
+    },
+    {
+      name: "default Ran:",
+      command: `psql -h db.example.com ${pad} --password ${FAKE.pw}`,
+      secret: FAKE.pw,
+    },
+  ];
+  for (const b of branches) {
+    test(b.name, () => {
+      assertGone(formatToolSummary("Bash", { command: b.command }, {}), b.secret);
+    });
+  }
+});
+
+describe("formatToolSummary -- end-to-end capture", () => {
+  test("Bash capture with a fake secret emits a redacted, still-useful summary", () => {
+    const summary = formatToolSummary(
+      "Bash",
+      { command: `PGPASSWORD=${FAKE.pw} psql -h db.example.com -U app` },
+      { stdout: "ok" },
+    );
+    assertGone(summary, FAKE.pw);
+    expect(summary).toContain(REDACTED);
+    // Still says WHAT ran -- that is the point of keeping structure.
+    expect(summary).toContain("psql");
+    expect(summary).toContain("success");
+  });
+
+  test("Bash capture of a benign command is untouched", () => {
+    const summary = formatToolSummary("Bash", { command: "npm run build" }, {});
+    expect(summary).not.toContain(REDACTED);
+    expect(summary).toContain("Package run");
+  });
+
+  test("Edit capture does not echo a secret value as a changed identifier", () => {
+    const summary = formatToolSummary(
+      "Edit",
+      {
+        file_path: "/tmp/config.ts",
+        old_string: 'export const API_KEY = "";',
+        new_string: `export const API_KEY = "${FAKE.openai}";`,
+      },
+      {},
+    );
+    assertGone(summary, FAKE.openai);
+  });
+
+  test("Write capture of a doc heading redacts a secret in the heading", () => {
+    const summary = formatToolSummary(
+      "Write",
+      { file_path: "/tmp/notes.md", content: `# token: ${FAKE.opaque}\n\nbody\n` },
+      {},
+    );
+    assertGone(summary, FAKE.opaque);
+    expect(summary).toContain("notes.md");
+  });
+
+  test("Write capture of ordinary code is unchanged in shape", () => {
+    const summary = formatToolSummary(
+      "Write",
+      { file_path: "/tmp/a.ts", content: "export function hello() { return 1; }\n" },
+      {},
+    );
+    expect(summary).toBe("Wrote a.ts (defines function hello)");
+  });
+});
+
+describe("formatToolSummary -- Task and NotebookEdit branches", () => {
+  // Neither branch truncates, so neither redacts its own inputs. The exported
+  // wrapper's redactSecrets pass is what covers them -- pin that, so the
+  // assumption cannot silently regress if the wrapper is ever removed.
+  test("Task description carrying a secret is redacted", () => {
+    const summary = formatToolSummary(
+      "Task",
+      { description: `deploy with PGPASSWORD=${FAKE.pw}`, subagent_type: "claude" },
+      {},
+    );
+    assertGone(summary, FAKE.pw);
+    expect(summary).toContain("Agent task (claude)");
+  });
+
+  test("ordinary Task description is unchanged", () => {
+    expect(formatToolSummary("Task", { description: "audit the redact module", subagent_type: "Explore" }, {}))
+      .toBe("Agent task (Explore): audit the redact module");
+  });
+
+  test("NotebookEdit summary is unchanged (path and mode only, no content)", () => {
+    expect(
+      formatToolSummary(
+        "NotebookEdit",
+        { notebook_path: "/tmp/nb.ipynb", edit_mode: "insert", cell_type: "code" },
+        {},
+      ),
+    ).toBe("Notebook insert code cell in nb.ipynb");
+  });
+
+  test("a secret in a NotebookEdit path is redacted", () => {
+    const summary = formatToolSummary(
+      "NotebookEdit",
+      { notebook_path: `/tmp/token=${FAKE.opaque}.ipynb`, edit_mode: "replace", cell_type: "code" },
+      {},
+    );
+    assertGone(summary, FAKE.opaque);
+  });
+});
+
+test("no fixture value resembling a credential survives any summary path", () => {
+  const values = Object.values(FAKE);
+  const commands = [
+    ...values.map((v) => `PASSWORD=${v} run`),
+    ...values.map((v) => `deploy --token ${v}`),
+    ...values.map((v) => `curl -H "Authorization: Bearer ${v}" https://api.example.com`),
+    ...values.map((v) => `psql postgres://u:${v}@db.example.com/app`),
+    ...values.map((v) => `echo '{"secret": "${v}"}'`),
+  ];
+  for (const command of commands) {
+    const summary = formatToolSummary("Bash", { command }, {});
+    for (const v of values) {
+      // Any fixture that appears in the command must be fully gone; fixtures not
+      // in this command trivially cannot appear.
+      if (command.includes(v)) assertGone(summary, v);
+    }
+  }
+});
+
+test("redaction of a large payload does not blow up (no catastrophic backtracking)", () => {
+  // Mirrors the perf guard in summarize-edit.test.ts: the Edit branch now runs
+  // redactSecrets over both sides of the diff, which can be a large payload.
+  const big = `tok ${"aaaa bbbb cccc dddd eeee ".repeat(20000)} PASSWORD=${FAKE.pw}`;
+  expect(big.length).toBeGreaterThan(400_000);
+  const t0 = performance.now();
+  const out = redactSecrets(big);
+  const elapsed = performance.now() - t0;
+  assertGone(out, FAKE.pw);
+  expect(elapsed).toBeLessThan(1000);
+});

--- a/plugins/honcho/src/redact.ts
+++ b/plugins/honcho/src/redact.ts
@@ -1,0 +1,237 @@
+/**
+ * Secret redaction for captured tool summaries.
+ *
+ * Upstream issue #81: `formatToolSummary()` in hooks/post-tool-use.ts builds a
+ * human-readable line for every significant tool call, and that line goes to TWO
+ * places -- the terminal (`systemMessage`) and, when `saveToolUse: true`, up to
+ * the Honcho server as durable memory. Nothing redacted it, so
+ * `PGPASSWORD=... psql ...` or `export TOKEN=sk-... && ...` was captured verbatim.
+ *
+ * Design constraints:
+ *  - No dependencies (not even node builtins) so this is trivially unit-testable
+ *    and reviewable in isolation.
+ *  - Structure-preserving: we keep the key/flag/scheme so a summary still says
+ *    *that* `psql` ran, and only the value disappears.
+ *  - Must run BEFORE any truncation. A secret sitting past a `.slice()` boundary
+ *    would otherwise survive, and slicing a raw secret can leave a
+ *    partially-visible fragment. Redact first, then slice.
+ *  - Conservative in the safe direction: over-redacting a non-secret is
+ *    acceptable, under-redacting is not. The one exception is that ordinary
+ *    commands (`git status`, `npm run build`, `rg -n "pattern" src`) must pass
+ *    through unchanged, or captured memory becomes useless.
+ *  - Idempotent: redactSecrets(redactSecrets(x)) === redactSecrets(x). The hook
+ *    applies redaction both to the raw command and to the assembled summary.
+ *
+ * The marker is deliberately plain ASCII. The bundler rewrites non-ASCII escapes
+ * to raw UTF-8 bytes (see src/unicode.ts, which works around this with
+ * String.fromCodePoint), and this string also lands in log files and server-side
+ * memory where a guillemet buys nothing.
+ */
+
+export const REDACTED = "[redacted]";
+
+/**
+ * Long, unambiguous secret words. Matched as a SUBSTRING of the key name after
+ * separators are stripped, so `PGPASSWORD`, `api_key`, `API-KEY`, `accessKeyId`
+ * and `clientSecret` all hit.
+ */
+const BROAD_SECRET_WORDS = [
+  "password",
+  "passwd",
+  "passphrase",
+  "secret",
+  "token",
+  "apikey",
+  "accesskey",
+  "credential",
+  "bearer",
+  "privatekey",
+  "authorization",
+  "cookie",
+];
+
+/**
+ * Short / ambiguous words. Matched ONLY as a whole `_`/`-`/`.`-delimited segment.
+ *
+ * Substring matching these would wreck ordinary summaries: `pat` is inside
+ * `path`, `patch` and `pattern`; `auth` is inside `author`. Segment matching
+ * still catches `PAT=`, `gh_pat`, `--auth`, `X-AUTH-TOKEN` and `session`.
+ *
+ * Bare `key` is deliberately NOT here: `PRIMARY_KEY`, `SORT_KEY`, `CACHE_KEY`
+ * and openssl/ssh/curl's `--key <file>` are common and non-secret, while every
+ * key-shaped secret name (`api_key`, `access_key`, `secret_key`, `private_key`)
+ * is already covered by BROAD_SECRET_WORDS.
+ */
+const SEGMENT_SECRET_WORDS = ["pwd", "auth", "session", "pat", "cred", "creds"];
+
+/**
+ * Does this key / flag / field name look like it holds a secret?
+ *
+ * Exported because the broad-vs-segment split is the single most important
+ * decision in this module and deserves its own tests.
+ */
+export function isSensitiveKeyName(name: string): boolean {
+  const lower = name.toLowerCase().replace(/^-+/, "");
+  if (!lower) return false;
+  const squashed = lower.replace(/[_\-.]/g, "");
+  if (BROAD_SECRET_WORDS.some((w) => squashed.includes(w))) return true;
+  return lower.split(/[_\-.]+/).some((seg) => SEGMENT_SECRET_WORDS.includes(seg));
+}
+
+/**
+ * Credential VALUE shapes that are recognizable regardless of the key name.
+ * All patterns are linear (no nested quantifiers) so they cannot backtrack
+ * catastrophically on a large Edit payload.
+ */
+const VALUE_SHAPES: RegExp[] = [
+  // OpenAI / Stripe-style `sk-...` (and `sk-live-`, `sk-ant-`, ...). The \b stops
+  // it firing inside "task-", "risk-", "disk-".
+  /\bsk-[A-Za-z0-9_-]{6,}/g,
+  // GitHub personal-access / OAuth / user / server / refresh tokens.
+  /\b(?:ghp|gho|ghu|ghs|ghr)_[A-Za-z0-9]{16,}/g,
+  /\bgithub_pat_[A-Za-z0-9_]{20,}/g,
+  // Slack bot/user/app/refresh/legacy tokens.
+  /\bxox[abprse]-[A-Za-z0-9-]{8,}/g,
+  // AWS access key id.
+  /\b(?:AKIA|ASIA)[0-9A-Z]{16}\b/g,
+  // JWT: three dot-separated base64url segments (signature may be empty).
+  /\beyJ[A-Za-z0-9_-]{4,}\.[A-Za-z0-9_-]{4,}\.[A-Za-z0-9_-]*/g,
+];
+
+/** `-----BEGIN ... PRIVATE KEY-----` blocks, terminated or not. */
+function redactPemBlocks(input: string): string {
+  if (!input.includes("PRIVATE KEY")) return input;
+  return input
+    .replace(
+      /-----BEGIN [A-Z0-9 ]*PRIVATE KEY-----[\s\S]*?-----END [A-Z0-9 ]*PRIVATE KEY-----/g,
+      `-----BEGIN PRIVATE KEY----- ${REDACTED} -----END PRIVATE KEY-----`,
+    )
+    .replace(
+      /-----BEGIN [A-Z0-9 ]*PRIVATE KEY-----(?![\s\S]*?-----END)[\s\S]*/g,
+      `-----BEGIN PRIVATE KEY----- ${REDACTED}`,
+    );
+}
+
+/**
+ * Header-like fields whose value is the whole rest of the field, not a single
+ * token: `Authorization: Bearer x`, `Authorization: token x`, `Cookie: a=b; c=d`.
+ * Bounded by a quote or newline so a quoted `-H "..."` argument does not eat the
+ * URL that follows it.
+ */
+function redactHeaderFields(input: string): string {
+  return input.replace(
+    /\b(authorization|proxy-authorization|set-cookie|cookie|x-api-key|api-key|x-auth-token)([ \t]*:[ \t]*)[^"'\n]+/gi,
+    (_m, key: string) => `${key}: ${REDACTED}`,
+  );
+}
+
+/** `scheme://user:password@host` -> `scheme://user:[redacted]@host` */
+function redactUrlCredentials(input: string): string {
+  return input.replace(
+    /\b([A-Za-z][A-Za-z0-9+.-]*:\/\/)([^\s/:@]+):([^\s/@]*)@/g,
+    (_m, scheme: string, user: string) => `${scheme}${user}:${REDACTED}@`,
+  );
+}
+
+function redactValueShapes(input: string): string {
+  let out = input;
+  for (const re of VALUE_SHAPES) out = out.replace(re, REDACTED);
+  return out;
+}
+
+/** `Bearer <token>` wherever it appears (headers, curl args, prose). */
+function redactBearerTokens(input: string): string {
+  return input.replace(/\bBearer\s+[^\s"',;]+/gi, `Bearer ${REDACTED}`);
+}
+
+/**
+ * CLI flags whose NAME looks sensitive: `--password X`, `--token=X`, `--api-key X`,
+ * `--client-secret=X`. Two separate passes so the space form can refuse a value
+ * starting with `-` -- otherwise `--foo --token X` would consume `--token` as
+ * `--foo`'s value and never redact the real secret.
+ */
+function redactSensitiveFlags(input: string): string {
+  let out = input.replace(
+    /(--?[A-Za-z][A-Za-z0-9_.-]*)=("[^"]*"|'[^']*'|[^\s;&|]+)/g,
+    (m, flag: string) => (isSensitiveKeyName(flag) ? `${flag}=${REDACTED}` : m),
+  );
+  out = out.replace(
+    /(--?[A-Za-z][A-Za-z0-9_.-]*)([ \t]+)("[^"]*"|'[^']*'|[^\s-][^\s]*)/g,
+    (m, flag: string, gap: string) =>
+      isSensitiveKeyName(flag) ? `${flag}${gap}${REDACTED}` : m,
+  );
+  return out;
+}
+
+/**
+ * `KEY=value` assignments -- shell env prefixes, `export KEY=value`, `-e KEY=value`.
+ * The leading-character class excludes `-`, so `--token=x` is left to
+ * redactSensitiveFlags rather than being matched here as key `token`.
+ */
+function redactAssignments(input: string): string {
+  return input.replace(
+    /(^|[\s;&|("'`])([A-Za-z_][A-Za-z0-9_.-]*)[ \t]*=[ \t]*("[^"]*"|'[^']*'|[^\s;&|)"'`]+)/g,
+    (m, lead: string, key: string) =>
+      isSensitiveKeyName(key) ? `${lead}${key}=${REDACTED}` : m,
+  );
+}
+
+/**
+ * `KEY: value` -- JSON/YAML fields and HTTP headers.
+ *
+ * Deliberately position-bounded: the key must sit at the start of the string, at
+ * the start of a line, after `{` or `,`, or immediately after a quote. Allowing
+ * a bare preceding space would mangle prose that this hook really does capture
+ * (`git commit -m "fix auth: broken login"` -> `fix auth: [redacted] login`).
+ * The genuine header case is still covered here (it follows a quote) and twice
+ * over by redactBearerTokens / redactValueShapes.
+ */
+function redactColonFields(input: string): string {
+  return input.replace(
+    /(^[ \t]*|[\n{,][ \t]*|["'`][ \t]*)([A-Za-z_][A-Za-z0-9_.-]*)(["'`]?)[ \t]*:[ \t]*("[^"]*"|'[^']*'|[^\s,;}"'`]+)/g,
+    (m, lead: string, key: string, closeQuote: string) =>
+      isSensitiveKeyName(key) ? `${lead}${key}${closeQuote}: ${REDACTED}` : m,
+  );
+}
+
+/**
+ * Tool-specific flags that take a secret but whose flag name says nothing:
+ *  - mysql family `-pSECRET` (psql's `-p` is a PORT, so this is gated on the tool)
+ *  - redis-cli `-a SECRET`
+ *  - `-u user:password` / `--user user:password` (curl, wget) -- gated on the
+ *    `user:password` shape rather than the tool, since `-u` means other things.
+ */
+function redactToolSpecificFlags(input: string): string {
+  let out = input;
+  if (/\bmysql(?:dump|admin|show)?\b/.test(out)) {
+    out = out.replace(/(\s|^)-p(?=\S)("[^"]*"|'[^']*'|\S+)/g, `$1-p${REDACTED}`);
+  }
+  if (/\bredis-cli\b/.test(out)) {
+    out = out.replace(/(\s|^)-a[ \t]+("[^"]*"|'[^']*'|[^\s-][^\s]*)/g, `$1-a ${REDACTED}`);
+  }
+  out = out.replace(
+    /(\s|^)(-u|--user)([ \t]+|=)(["']?)([^\s:"']+):([^\s"']*)/g,
+    (_m, lead: string, flag: string, sep: string, quote: string, user: string) =>
+      `${lead}${flag}${sep}${quote}${user}:${REDACTED}`,
+  );
+  return out;
+}
+
+/**
+ * Redact secret-bearing values from a string that is about to be shown to the
+ * user or persisted as memory. Call this BEFORE truncating.
+ */
+export function redactSecrets(input: string): string {
+  if (!input) return input;
+  let out = input;
+  out = redactPemBlocks(out);
+  out = redactUrlCredentials(out);
+  out = redactHeaderFields(out);
+  out = redactValueShapes(out);
+  out = redactBearerTokens(out);
+  out = redactSensitiveFlags(out);
+  out = redactAssignments(out);
+  out = redactColonFields(out);
+  out = redactToolSpecificFlags(out);
+  return out;
+}

--- a/plugins/honcho/src/redact.ts
+++ b/plugins/honcho/src/redact.ts
@@ -107,7 +107,11 @@ function redactPemBlocks(input: string): string {
       `-----BEGIN PRIVATE KEY----- ${REDACTED} -----END PRIVATE KEY-----`,
     )
     .replace(
-      /-----BEGIN [A-Z0-9 ]*PRIVATE KEY-----(?![\s\S]*?-----END)[\s\S]*/g,
+      // The lookahead must name the private-key terminator, not a bare
+      // `-----END`: in a PEM bundle the key is routinely followed by
+      // `-----END CERTIFICATE-----`, which would otherwise satisfy the
+      // lookahead and leave the key material untouched by both passes.
+      /-----BEGIN [A-Z0-9 ]*PRIVATE KEY-----(?![\s\S]*?-----END [A-Z0-9 ]*PRIVATE KEY-----)[\s\S]*/g,
       `-----BEGIN PRIVATE KEY----- ${REDACTED}`,
     );
 }


### PR DESCRIPTION
Closes #81.

`formatToolSummary()` builds a human-readable line for every significant tool call. That line goes to **two** places — the terminal `systemMessage`, and (when `saveToolUse: true`) uploaded to the Honcho server as durable memory. Nothing redacted it, so a secret in a command leaked twice, and the memory copy is persistent.

```
Ran: PGPASSWORD=hunter2 psql -h db.internal -U app   # stored verbatim
```

### What this adds

A dependency-free `src/redact.ts` (node builtins only, single exported `redactSecrets`) applied across the capture path. It covers:

- sensitive **key=value / key: value** assignments (password, token, api_key, secret, bearer, client_secret, private_key, … with `_`/`-`/case variants)
- credential **value shapes regardless of key name** — `sk-…`, `ghp_`/`gho_`/`github_pat_`, Slack `xox[baprs]-`, AWS `AKIA…`, JWTs, PEM private-key blocks
- URLs with inline credentials (`scheme://user:pass@host`)
- secret-bearing CLI flags (`--password`, `--token`, `Authorization:` headers)

### Ordering matters

Redaction runs **before every truncation**. The Bash branch previously did `.slice(0, 100)` then `.slice(0, 60)`; redacting after would let a secret survive by sitting past the boundary, and slicing a raw secret can leave a partially-visible fragment. `Write`/`Edit` are covered too — `summarizeEdit` reports raw identifiers it found in changed text, and `inferContentPurpose` can echo a matched heading.

`formatToolSummary` is now a thin redacting wrapper over `buildToolSummary`; `redactSecrets` is idempotent so the belt-and-braces second pass is safe.

### Deliberate trade-off

Detection is **pattern-based, not entropy-based**. A bare high-entropy positional argument with no sensitive key name and no known prefix is not caught. An entropy heuristic would redact SHAs, UUIDs and file hashes — which would gut the usefulness of the memory this feature exists to build. Erring toward over-redaction of *recognisable* secret shapes seemed the better trade; happy to revisit if you'd prefer a different balance.

### Tests

121 cases in `src/redact.test.ts`, table-driven, including the **negative** cases — ordinary commands (`git status`, `npm run build`, `rg -n "pattern" src`) must pass through byte-identical, because over-redaction that mangles every summary would make the memory useless. Also proves redact-before-truncate with a secret placed past the truncation boundary.

Verified live: a secret-bearing command emits `Ran: PGPASSWORD=[redacted] psql -h db.example.com`, while `npm run build` is untouched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic secret redaction for tool summaries and persisted memory.
  * Recognizes and removes credentials from commands, URLs, headers, configuration fields, tokens, and private keys.
  * Redacts sensitive content before truncation to prevent partial secret exposure.

* **Bug Fixes**
  * Prevented secrets from leaking through Bash, Edit, and other tool-summary formats.
  * Added safeguards to keep redaction consistent across repeated processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->