### PR TITLE
fix: surface a missing bun runtime instead of failing silently (#82)

### DIFF
--- a/README.md
+++ b/README.md
@@ -447,6 +447,21 @@ The plugin hooks into Claude Code's lifecycle events:
 
 Make sure `saveMessages` is not set to `false` in your config (or `HONCHO_SAVE_MESSAGES` in env).
 
+### `honcho: 'bun' not found` in the transcript
+
+Claude Code runs hooks non-interactively, so they do not inherit the PATH from
+your shell profile — bun can be visible in your terminal and invisible to the
+hooks. The plugin searches PATH plus the usual install locations
+(`~/.bun/bin`, `/opt/homebrew/bin`, `/usr/local/bin`, `/usr/bin`,
+`~/.local/bin`). If your bun lives elsewhere, point the hooks at it directly:
+
+```bash
+export HONCHO_BUN=/absolute/path/to/bun
+```
+
+Then restart Claude Code. (Before this message existed, a missing bun disabled
+memory capture silently.)
+
 ### Using a local Honcho instance
 
 Via config file:

--- a/plugins/honcho/hooks/hooks.json
+++ b/plugins/honcho/hooks/hooks.json
@@ -7,12 +7,12 @@
           {
             "type": "command",
             "command": "bash \"${CLAUDE_PLUGIN_ROOT}/scripts/check-version.sh\"",
-            "timeout": 2000
+            "timeout": 5
           },
           {
             "type": "command",
             "command": "bun run ${CLAUDE_PLUGIN_ROOT}/hooks/session-start.ts",
-            "timeout": 30000,
+            "timeout": 30,
             "async": true
           }
         ]
@@ -24,7 +24,7 @@
           {
             "type": "command",
             "command": "bun run ${CLAUDE_PLUGIN_ROOT}/hooks/session-end.ts",
-            "timeout": 30000
+            "timeout": 5
           }
         ]
       }
@@ -49,7 +49,7 @@
           {
             "type": "command",
             "command": "bun run ${CLAUDE_PLUGIN_ROOT}/hooks/pre-tool-honcho.ts",
-            "timeout": 4000
+            "timeout": 4
           }
         ]
       }
@@ -60,12 +60,12 @@
           {
             "type": "command",
             "command": "bun run ${CLAUDE_PLUGIN_ROOT}/hooks/user-prompt.ts",
-            "timeout": 120
+            "timeout": 125
           },
           {
             "type": "command",
             "command": "bun run ${CLAUDE_PLUGIN_ROOT}/hooks/save-user-message.ts",
-            "timeout": 30000,
+            "timeout": 30,
             "async": true
           }
         ]
@@ -78,7 +78,7 @@
           {
             "type": "command",
             "command": "bun run ${CLAUDE_PLUGIN_ROOT}/hooks/pre-compact.ts",
-            "timeout": 20000
+            "timeout": 20
           }
         ]
       },
@@ -88,7 +88,7 @@
           {
             "type": "command",
             "command": "bun run ${CLAUDE_PLUGIN_ROOT}/hooks/pre-compact.ts",
-            "timeout": 20000
+            "timeout": 20
           }
         ]
       }

--- a/plugins/honcho/hooks/hooks.json
+++ b/plugins/honcho/hooks/hooks.json
@@ -11,7 +11,7 @@
           },
           {
             "type": "command",
-            "command": "bun run ${CLAUDE_PLUGIN_ROOT}/hooks/session-start.ts",
+            "command": "sh \"${CLAUDE_PLUGIN_ROOT}/scripts/run-hook.sh\" \"${CLAUDE_PLUGIN_ROOT}/hooks/session-start.ts\"",
             "timeout": 30,
             "async": true
           }
@@ -23,7 +23,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bun run ${CLAUDE_PLUGIN_ROOT}/hooks/session-end.ts",
+            "command": "sh \"${CLAUDE_PLUGIN_ROOT}/scripts/run-hook.sh\" \"${CLAUDE_PLUGIN_ROOT}/hooks/session-end.ts\"",
             "timeout": 5
           }
         ]
@@ -35,7 +35,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bun run ${CLAUDE_PLUGIN_ROOT}/hooks/post-tool-use.ts",
+            "command": "sh \"${CLAUDE_PLUGIN_ROOT}/scripts/run-hook.sh\" \"${CLAUDE_PLUGIN_ROOT}/hooks/post-tool-use.ts\"",
             "timeout": 10,
             "async": true
           }
@@ -48,7 +48,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bun run ${CLAUDE_PLUGIN_ROOT}/hooks/pre-tool-honcho.ts",
+            "command": "sh \"${CLAUDE_PLUGIN_ROOT}/scripts/run-hook.sh\" \"${CLAUDE_PLUGIN_ROOT}/hooks/pre-tool-honcho.ts\"",
             "timeout": 4
           }
         ]
@@ -59,12 +59,12 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bun run ${CLAUDE_PLUGIN_ROOT}/hooks/user-prompt.ts",
+            "command": "sh \"${CLAUDE_PLUGIN_ROOT}/scripts/run-hook.sh\" \"${CLAUDE_PLUGIN_ROOT}/hooks/user-prompt.ts\"",
             "timeout": 125
           },
           {
             "type": "command",
-            "command": "bun run ${CLAUDE_PLUGIN_ROOT}/hooks/save-user-message.ts",
+            "command": "sh \"${CLAUDE_PLUGIN_ROOT}/scripts/run-hook.sh\" \"${CLAUDE_PLUGIN_ROOT}/hooks/save-user-message.ts\"",
             "timeout": 30,
             "async": true
           }
@@ -77,7 +77,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bun run ${CLAUDE_PLUGIN_ROOT}/hooks/pre-compact.ts",
+            "command": "sh \"${CLAUDE_PLUGIN_ROOT}/scripts/run-hook.sh\" \"${CLAUDE_PLUGIN_ROOT}/hooks/pre-compact.ts\"",
             "timeout": 20
           }
         ]
@@ -87,7 +87,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bun run ${CLAUDE_PLUGIN_ROOT}/hooks/pre-compact.ts",
+            "command": "sh \"${CLAUDE_PLUGIN_ROOT}/scripts/run-hook.sh\" \"${CLAUDE_PLUGIN_ROOT}/hooks/pre-compact.ts\"",
             "timeout": 20
           }
         ]
@@ -98,7 +98,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bun run ${CLAUDE_PLUGIN_ROOT}/hooks/stop.ts",
+            "command": "sh \"${CLAUDE_PLUGIN_ROOT}/scripts/run-hook.sh\" \"${CLAUDE_PLUGIN_ROOT}/hooks/stop.ts\"",
             "timeout": 10,
             "async": true
           }

--- a/plugins/honcho/scripts/run-hook.sh
+++ b/plugins/honcho/scripts/run-hook.sh
@@ -1,0 +1,68 @@
+#!/bin/sh
+# Upstream #82 — resolve `bun` for the hook environment, and FAIL LOUDLY if it
+# is missing.
+#
+# Claude Code runs hooks non-interactively, so they do not necessarily inherit
+# the shell PATH the user installed bun onto (no .zshrc/.bashrc sourcing). When
+# `bun` was invoked directly from hooks.json, a missing bun meant every hook
+# exited non-zero with an empty message and memory capture simply stopped —
+# nothing in the transcript, nothing in the plugin's own log (the log is written
+# by the TypeScript that never got to run).
+#
+# The guard therefore has to live OUTSIDE the TypeScript: a fix written in TS
+# cannot run when the runtime that executes TS is the thing that is missing.
+#
+# POSIX sh only, no dependencies, no stdin reads (the hook payload on stdin must
+# reach the exec'd process untouched), and one `exec` so no extra process
+# lingers on the hot path.
+#
+# Precedent for shelling out from hooks.json: SessionStart already invokes
+# `bash "${CLAUDE_PLUGIN_ROOT}/scripts/check-version.sh"`, so a shell entry point
+# is an established, working shape for this plugin on every supported platform.
+#
+# Overrides (both optional):
+#   HONCHO_BUN            absolute path to the bun binary to use
+#   HONCHO_BUN_CANDIDATES space-separated list replacing the default search list
+set -u
+
+if [ "$#" -lt 1 ]; then
+  echo "honcho: run-hook.sh requires a hook script path" >&2
+  exit 1
+fi
+
+HOOK_SCRIPT="$1"
+shift
+
+DEFAULT_CANDIDATES="${HOME:-}/.bun/bin/bun /opt/homebrew/bin/bun /usr/local/bin/bun /usr/bin/bun ${HOME:-}/.local/bin/bun"
+CANDIDATES="${HONCHO_BUN_CANDIDATES:-$DEFAULT_CANDIDATES}"
+
+BUN_BIN=""
+
+if [ -n "${HONCHO_BUN:-}" ] && [ -x "${HONCHO_BUN}" ]; then
+  BUN_BIN="${HONCHO_BUN}"
+else
+  # `command -v` is a shell builtin: no subprocess, no stdin, no measurable cost.
+  if command -v bun >/dev/null 2>&1; then
+    BUN_BIN="$(command -v bun)"
+  else
+    for candidate in $CANDIDATES; do
+      if [ -x "$candidate" ]; then
+        BUN_BIN="$candidate"
+        break
+      fi
+    done
+  fi
+fi
+
+if [ -z "$BUN_BIN" ]; then
+  # Exit non-zero WITHOUT writing to stdout. Per Claude Code's hook reference, a
+  # non-zero exit other than 2 is a non-blocking error and "the transcript shows
+  # a <hook name> hook error notice followed by the first line of stderr", so
+  # this surfaces without --debug and without needing the JSON channel. Writing
+  # to stdout would be wrong here: on UserPromptSubmit, exit-0 stdout is injected
+  # into the model's context, so a diagnostic there could become fake memory.
+  echo "honcho: 'bun' not found - memory capture is DISABLED for this session. Claude Code runs hooks without your shell PATH; install bun (https://bun.sh) or set HONCHO_BUN=/absolute/path/to/bun. Searched PATH plus: $CANDIDATES" >&2
+  exit 1
+fi
+
+exec "$BUN_BIN" run "$HOOK_SCRIPT" "$@"

--- a/plugins/honcho/src/bun-resolution.test.ts
+++ b/plugins/honcho/src/bun-resolution.test.ts
@@ -1,0 +1,133 @@
+import { test, expect } from "bun:test";
+import { readFileSync, mkdtempSync, writeFileSync, chmodSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+/**
+ * Upstream #82 — a missing `bun` must fail LOUDLY, not silently.
+ *
+ * hooks.json used to invoke `bun run …` directly. Claude Code runs hooks
+ * non-interactively, so bun can be absent from PATH even when the user's
+ * terminal has it; memory capture then stopped with no message anywhere. The
+ * guard cannot live in TypeScript (the missing runtime is what would execute
+ * it), so it lives in scripts/run-hook.sh.
+ *
+ * Visible channel: stderr + a non-zero exit. Per Claude Code's hook reference,
+ * a non-zero exit other than 2 is a non-blocking error whose first stderr line
+ * is shown in the transcript without --debug. stdout is deliberately NOT used:
+ * on UserPromptSubmit, exit-0 stdout is injected into the model's context.
+ */
+
+const WRAPPER = join(import.meta.dir, "..", "scripts", "run-hook.sh");
+const HOOKS_JSON = join(import.meta.dir, "..", "hooks", "hooks.json");
+
+function hookCommands(): string[] {
+  const parsed = JSON.parse(readFileSync(HOOKS_JSON, "utf-8"));
+  const out: string[] = [];
+  for (const matchers of Object.values(parsed.hooks as Record<string, any[]>)) {
+    for (const matcher of matchers) {
+      for (const hook of matcher.hooks as { command: string }[]) out.push(hook.command);
+    }
+  }
+  return out;
+}
+
+/**
+ * Run the wrapper with bun made unreachable: an empty PATH neutralizes
+ * `command -v bun`, and HONCHO_BUN_CANDIDATES points the fallback list at a
+ * path that cannot exist (the real /opt/homebrew/bin/bun exists on many dev
+ * machines, so overriding the list is what makes this test deterministic).
+ */
+async function runWithoutBun(env: Record<string, string> = {}) {
+  const proc = Bun.spawn(["/bin/sh", WRAPPER, "/tmp/does-not-matter.ts"], {
+    env: {
+      PATH: "",
+      HOME: "/nonexistent-home",
+      HONCHO_BUN_CANDIDATES: "/nonexistent/path/to/bun",
+      ...env,
+    },
+    stdout: "pipe",
+    stderr: "pipe",
+    stdin: "ignore",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ]);
+  return { stdout, stderr, exitCode };
+}
+
+test("every TypeScript hook goes through the bun-resolving wrapper", () => {
+  for (const cmd of hookCommands()) {
+    if (cmd.includes("/hooks/")) {
+      expect(cmd).toContain("scripts/run-hook.sh");
+      // No hook may invoke a bare `bun` any more — that is the silent-failure path.
+      expect(cmd).not.toMatch(/(^|[^-\w])bun run/);
+    }
+  }
+});
+
+test("a missing bun produces a visible error, not silence", async () => {
+  const { stdout, stderr, exitCode } = await runWithoutBun();
+
+  // Loud: non-zero exit so the transcript shows "<hook> hook error" + stderr line 1.
+  expect(exitCode).not.toBe(0);
+  // Not exit 2 — that would BLOCK the user's prompt/tool call over a broken install.
+  expect(exitCode).not.toBe(2);
+
+  // Diagnosable: names the missing binary, the consequence, and the two fixes.
+  expect(stderr).toContain("bun");
+  expect(stderr).toContain("not found");
+  expect(stderr.toLowerCase()).toContain("memory capture");
+  expect(stderr).toContain("HONCHO_BUN");
+  // First stderr line carries the whole diagnosis — that's the only line the
+  // transcript notice shows.
+  expect(stderr.trim().split("\n")[0]!).toContain("not found");
+
+  // Nothing on stdout: on UserPromptSubmit stdout becomes model context.
+  expect(stdout).toBe("");
+});
+
+test("HONCHO_BUN overrides resolution when PATH has no bun", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "honcho-bun-"));
+  try {
+    const fakeBun = join(dir, "bun");
+    // A stand-in that proves the wrapper exec'd it with `run <script>`.
+    writeFileSync(fakeBun, '#!/bin/sh\necho "ran:$1:$2"\n');
+    chmodSync(fakeBun, 0o755);
+
+    const proc = Bun.spawn(["/bin/sh", WRAPPER, "/tmp/hook.ts", "--extra"], {
+      env: {
+        PATH: "",
+        HOME: "/nonexistent-home",
+        HONCHO_BUN_CANDIDATES: "/nonexistent/path/to/bun",
+        HONCHO_BUN: fakeBun,
+      },
+      stdout: "pipe",
+      stderr: "pipe",
+      stdin: "ignore",
+    });
+    const [stdout, exitCode] = await Promise.all([
+      new Response(proc.stdout).text(),
+      proc.exited,
+    ]);
+    expect(exitCode).toBe(0);
+    expect(stdout.trim()).toBe("ran:run:/tmp/hook.ts");
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("the wrapper is dependency-free POSIX sh and never reads stdin", () => {
+  const src = readFileSync(WRAPPER, "utf-8");
+  expect(src.startsWith("#!/bin/sh")).toBe(true);
+  // Reading stdin here would consume the hook payload before exec.
+  expect(src).not.toMatch(/\bread\b/);
+  expect(src).not.toContain("cat -");
+  // One exec, so the wrapper adds no lingering process to the hot path.
+  expect(src).toContain("exec ");
+  // bashisms that would break under dash/ash
+  expect(src).not.toContain("[[");
+  expect(src).not.toContain("$(<");
+});

--- a/plugins/honcho/src/hooks-timeout.test.ts
+++ b/plugins/honcho/src/hooks-timeout.test.ts
@@ -40,8 +40,10 @@ function loadHooks(): HookEntry[] {
 function timeoutsByScript(): Record<string, number[]> {
   const map: Record<string, number[]> = {};
   for (const hook of loadHooks()) {
-    const m = hook.command.match(/([\w.-]+\.(?:ts|sh))/);
-    const key = m ? m[1]! : hook.command;
+    // The LAST script name in the command line is the hook itself — anything
+    // earlier is a launcher (e.g. scripts/run-hook.sh, which resolves bun).
+    const all = hook.command.match(/[\w.-]+\.(?:ts|sh)/g);
+    const key = all?.length ? all[all.length - 1]! : hook.command;
     (map[key] ??= []).push(hook.timeout as number);
   }
   return map;

--- a/plugins/honcho/src/hooks-timeout.test.ts
+++ b/plugins/honcho/src/hooks-timeout.test.ts
@@ -1,0 +1,108 @@
+import { test, expect } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+/**
+ * Upstream #59 — hooks.json `timeout` is SECONDS, not milliseconds.
+ *
+ * Claude Code's hook reference is explicit: `timeout` is "Seconds before
+ * canceling" (https://code.claude.com/docs/en/hooks — Common fields). The file
+ * used to mix units: `30000`/`20000`/`4000`/`2000` (plainly intended as ms)
+ * next to `120`/`10` (plainly seconds). Read as seconds, `30000` is ~8.3 hours
+ * — i.e. no timeout at all, which is the bug.
+ *
+ * These assertions pin the corrected SECOND values. They deliberately assert
+ * only the `timeout` fields — never the `command` strings — so this test stays
+ * green independently of the bun-resolution change (#82) that rewrites commands.
+ */
+
+const HOOKS_JSON = join(import.meta.dir, "..", "hooks", "hooks.json");
+
+interface HookEntry {
+  type: string;
+  command: string;
+  timeout?: number;
+  async?: boolean;
+}
+
+function loadHooks(): HookEntry[] {
+  const parsed = JSON.parse(readFileSync(HOOKS_JSON, "utf-8"));
+  const out: HookEntry[] = [];
+  for (const matchers of Object.values(parsed.hooks as Record<string, any[]>)) {
+    for (const matcher of matchers) {
+      for (const hook of matcher.hooks as HookEntry[]) out.push(hook);
+    }
+  }
+  return out;
+}
+
+/** Timeouts keyed by the hook script's basename (or the shell script's). */
+function timeoutsByScript(): Record<string, number[]> {
+  const map: Record<string, number[]> = {};
+  for (const hook of loadHooks()) {
+    const m = hook.command.match(/([\w.-]+\.(?:ts|sh))/);
+    const key = m ? m[1]! : hook.command;
+    (map[key] ??= []).push(hook.timeout as number);
+  }
+  return map;
+}
+
+test("every hook declares a timeout", () => {
+  for (const hook of loadHooks()) {
+    expect(typeof hook.timeout).toBe("number");
+  }
+});
+
+test("no hook timeout is a millisecond value misread as seconds", () => {
+  // The tightest defensible ceiling: the longest-running hook is the
+  // UserPromptSubmit read path, bounded internally by DIALECTIC_TIMEOUT_MS
+  // (120s). Anything above that is a unit error, not a real budget.
+  for (const hook of loadHooks()) {
+    expect(hook.timeout!).toBeGreaterThan(0);
+    expect(hook.timeout!).toBeLessThanOrEqual(125);
+  }
+});
+
+test("each hook's timeout matches its real workload, in seconds", () => {
+  const t = timeoutsByScript();
+
+  // curl --max-time 2 is the only network call; the rest is sed/find + spawn.
+  expect(t["check-version.sh"]).toEqual([5]);
+
+  // Parallel context warm-up; the code documents a 30s budget. async: true, so
+  // this never blocks the user.
+  expect(t["session-start.ts"]).toEqual([30]);
+
+  // Touches NO network (see handleSessionEnd) — purely local file cleanup. Kept
+  // deliberately small: per the hook reference, SessionEnd hooks share a
+  // 1.5s shutdown budget which Claude Code RAISES to match a longer per-hook
+  // timeout (up to 60s), so an inflated value here would stall /exit for
+  // nothing.
+  expect(t["session-end.ts"]).toEqual([5]);
+
+  // One session.addMessages POST bounded internally by UPLOAD_TIMEOUT_MS (5s),
+  // plus interpreter start.
+  expect(t["post-tool-use.ts"]).toEqual([10]);
+
+  // Local-only: parse stdin, write one state file. Blocks the MCP tool call, so
+  // it stays tight — the headroom is for a cold interpreter start, not work.
+  expect(t["pre-tool-honcho.ts"]).toEqual([4]);
+
+  // The read path races a 4s context fetch (FETCH_TIMEOUT_MS) and a 120s
+  // dialectic budget (DIALECTIC_TIMEOUT_MS). MUST be strictly greater than the
+  // internal budget: at 120 vs 120000ms the harness would kill the process at
+  // the exact moment the internal race resolves, so the graceful-degradation
+  // path could never print its JSON.
+  expect(t["user-prompt.ts"]).toEqual([125]);
+  expect(t["user-prompt.ts"]![0]!).toBeGreaterThan(120);
+
+  // Async write half of UserPromptSubmit: one batched POST, off the hot path.
+  expect(t["save-user-message.ts"]).toEqual([30]);
+
+  // Two parallel peer.chat() calls at "low" reasoning plus a context() fetch,
+  // no internal bound. Registered twice (auto + manual triggers).
+  expect(t["pre-compact.ts"]).toEqual([20, 20]);
+
+  // Transcript scan + upload, async.
+  expect(t["stop.ts"]).toEqual([10]);
+});


### PR DESCRIPTION
Closes #82. **Stacked on #100 (`upstream-pr/59-timeout-units`)** because both edit `hooks/hooks.json`; merge that first, or say the word and I'll rebase this onto `main` standalone.

Claude Code runs hooks non-interactively, so they don't necessarily inherit the shell PATH that `bun` was installed onto — no `.zshrc`/`.bashrc` is sourced. With `hooks.json` invoking `bun run …` directly, a missing `bun` meant every hook exited non-zero with an empty message and **memory capture just stopped**. Nothing in the transcript, and nothing in the plugin's own log either — because the log is written by the TypeScript that never got to run.

That last point drives the design: **the guard has to live outside the TypeScript.** A fix written in TS cannot run when the runtime that executes TS is the thing that's missing.

### What this adds

`scripts/run-hook.sh` — POSIX `sh`, no dependencies. It resolves `bun` from `HONCHO_BUN`, then PATH, then the usual install locations (`~/.bun/bin`, `/opt/homebrew/bin`, `/usr/local/bin`), and `exec`s so no extra process lingers on the hot path. It never reads stdin, so the hook payload reaches the exec'd process untouched.

When nothing resolves:

```
honcho: 'bun' not found - memory capture is DISABLED for this session.
Claude Code runs hooks without your shell PATH; install bun (https://bun.sh)
or set HONCHO_BUN=/absolute/path/to/bun. Searched PATH plus: …
```

Exit 1, on stderr, naming the cause, the consequence, and two ways to fix it.

There's precedent for this shape: `SessionStart` already invokes `bash "${CLAUDE_PLUGIN_ROOT}/scripts/check-version.sh"`, so a shell entry point is established and working across supported platforms.

### Verification

- bun absent → exit 1 with the message above (tested with PATH stripped of bun and the candidate list pointed at a nonexistent path)
- bun present → stdin passes through intact; `post-tool-use` emits its normal summary, byte-identical to before
- `src/bun-resolution.test.ts` covers the resolution order and the failure message

Escape hatches (`HONCHO_BUN`, `HONCHO_BUN_CANDIDATES`) are documented in the README.