### PR TITLE
feat: adding session briefing

### DIFF
--- a/plugins/honcho/skills/briefing/SKILL.md
+++ b/plugins/honcho/skills/briefing/SKILL.md
@@ -1,0 +1,20 @@
+---
+description: Load the Honcho session briefing (session summary + peer card) via a visible tool call
+user-invocable: true
+---
+
+# Honcho Briefing
+
+Load the stored session summary and the user's peer card through the `get_briefing` MCP tool.
+
+## Usage
+
+Run `/honcho:briefing` at any point to load (or reload) the briefing. The session-start directives may also ask for this automatically on the first turn when the `briefing` component is configured.
+
+## Implementation
+
+Call the `get_briefing` tool from the honcho MCP server (`mcp__plugin_honcho_honcho__get_briefing`). No arguments.
+
+## Presentation
+
+The payload is already visible in the expandable tool row — do NOT repeat it back. After the call, reply with at most two sentences: confirm the briefing is loaded and name where the session left off (from the summary). If the tool reports no briefing available, say so in one line.

--- a/plugins/honcho/src/config.ts
+++ b/plugins/honcho/src/config.ts
@@ -46,8 +46,12 @@ export interface LocalContextConfig {
  * - "summary": the SDK `session.summaries().long` narrative.
  * - "peerCard" / "peerRepresentation": the two fields of a single context() call,
  *   each injected at full length (no per-field caps — inclusion is the only lever).
+ * - "briefing": a static nudge to call the `get_briefing` MCP tool instead of
+ *   injecting summary/peerCard inline — the tool call renders as an expandable
+ *   row in the UI, making the briefing user-visible. Use in place of
+ *   "summary"/"peerCard", not alongside them (the content would land twice).
  */
-export const SESSION_START_COMPONENTS = ["directives", "summary", "peerCard", "peerRepresentation"] as const;
+export const SESSION_START_COMPONENTS = ["directives", "summary", "peerCard", "peerRepresentation", "briefing"] as const;
 export type SessionStartComponent = (typeof SESSION_START_COMPONENTS)[number];
 
 /**

--- a/plugins/honcho/src/injection.ts
+++ b/plugins/honcho/src/injection.ts
@@ -94,6 +94,13 @@ export function renderSessionStart(
         }
         break;
       }
+      case "briefing": {
+        parts.push(
+          `Session briefing: the session summary and user profile were NOT injected — load them by calling the honcho \`get_briefing\` tool as the first action of your first response, before answering. Skip the call only if the user's first prompt explicitly says not to.`
+        );
+        labels.push("briefing nudge");
+        break;
+      }
       case "peerCard": {
         const card = (data.peerCard ?? []).filter((item) => item?.trim());
         if (card.length) {

--- a/plugins/honcho/src/mcp/server.ts
+++ b/plugins/honcho/src/mcp/server.ts
@@ -872,6 +872,16 @@ export async function runMcpServer(): Promise<void> {
           },
         },
         {
+          name: "get_briefing",
+          description:
+            "Load the session briefing: the stored long summary of this session plus the user's peer card (identity/attribute profile). " +
+            "Call this once at the start of a session when the session-start directives ask for it, or any time you need to catch up on where the session left off.",
+          inputSchema: {
+            type: "object",
+            properties: {},
+          },
+        },
+        {
           name: "get_context",
           description: "Retrieve the full context object (representation + peer card) from Honcho for the current user. Scoped by observation mode.",
           inputSchema: {
@@ -1200,6 +1210,34 @@ export async function runMcpServer(): Promise<void> {
                 text: `Saved conclusion: ${conclusions[0]?.content || content}`,
               },
             ],
+          };
+        }
+
+        case "get_briefing": {
+          // Fetches at sessionStart "summary"/"peerCard" components
+          const [summariesResult, ctxResult] = await Promise.allSettled([
+            session.summaries(),
+            activePeer.context({
+              ...(contextTarget ? { target: contextTarget } : {}),
+              maxConclusions: 25,
+              includeMostFrequent: true,
+            }),
+          ]);
+
+          const summary = summariesResult.status === "fulfilled"
+            ? (summariesResult.value as any)?.longSummary?.content?.trim()
+            : null;
+          const card: string[] = ctxResult.status === "fulfilled"
+            ? ((ctxResult.value as any)?.peerCard ?? []).filter((item: string) => item?.trim())
+            : [];
+
+          const parts: string[] = [];
+          if (summary) parts.push(`## Session summary\n${summary}`);
+          if (card.length) parts.push(`## Peer card (${card.length} items)\n${card.map((item) => `- ${item}`).join("\n")}`);
+          if (parts.length === 0) parts.push("No briefing available yet — no stored session summary or peer card.");
+
+          return {
+            content: [{ type: "text", text: parts.join("\n\n") }],
           };
         }
 


### PR DESCRIPTION
<img width="2260" height="188" alt="image" src="https://github.com/user-attachments/assets/f1c21621-674f-4256-9e7a-9070dfff6e71" />

configure your session-start injection to be **directives** 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Honcho briefing skill accessible through the `/honcho:briefing` command.
  * Added a briefing tool that loads the current session summary and peer card together.
  * Added an optional session-start briefing that prompts the assistant to load context automatically.
  * Briefings gracefully handle unavailable or incomplete session information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->