### PR TITLE
fix: change hooks timeout to s instead of ms

### DIFF
--- a/plugins/honcho/hooks/hooks.json
+++ b/plugins/honcho/hooks/hooks.json
@@ -7,13 +7,12 @@
           {
             "type": "command",
             "command": "bash \"${CLAUDE_PLUGIN_ROOT}/scripts/check-version.sh\"",
-            "timeout": 2000
+            "timeout": 5
           },
           {
             "type": "command",
             "command": "bun run ${CLAUDE_PLUGIN_ROOT}/hooks/session-start.ts",
-            "timeout": 30000,
-            "async": true
+            "timeout": 30
           }
         ]
       }
@@ -24,7 +23,7 @@
           {
             "type": "command",
             "command": "bun run ${CLAUDE_PLUGIN_ROOT}/hooks/session-end.ts",
-            "timeout": 30000
+            "timeout": 5
           }
         ]
       }
@@ -49,7 +48,7 @@
           {
             "type": "command",
             "command": "bun run ${CLAUDE_PLUGIN_ROOT}/hooks/pre-tool-honcho.ts",
-            "timeout": 4000
+            "timeout": 4
           }
         ]
       }
@@ -60,12 +59,12 @@
           {
             "type": "command",
             "command": "bun run ${CLAUDE_PLUGIN_ROOT}/hooks/user-prompt.ts",
-            "timeout": 120
+            "timeout": 125
           },
           {
             "type": "command",
             "command": "bun run ${CLAUDE_PLUGIN_ROOT}/hooks/save-user-message.ts",
-            "timeout": 30000,
+            "timeout": 30,
             "async": true
           }
         ]
@@ -78,7 +77,7 @@
           {
             "type": "command",
             "command": "bun run ${CLAUDE_PLUGIN_ROOT}/hooks/pre-compact.ts",
-            "timeout": 20000
+            "timeout": 20
           }
         ]
       },
@@ -88,7 +87,7 @@
           {
             "type": "command",
             "command": "bun run ${CLAUDE_PLUGIN_ROOT}/hooks/pre-compact.ts",
-            "timeout": 20000
+            "timeout": 20
           }
         ]
       }

--- a/plugins/honcho/src/hooks/session-start.ts
+++ b/plugins/honcho/src/hooks/session-start.ts
@@ -25,6 +25,19 @@ interface HookInput {
   workspace_roots?: string[];
 }
 
+// This hook runs synchronously, so these fetches block startup. Bound them
+// well under the 30s hook ceiling so a slow server degrades to an empty
+// injection instead of a hung session start.
+const CONTEXT_FETCH_TIMEOUT_MS = 10000;
+
+/** Resolve a promise with its value, or null if `ms` elapses or it rejects. */
+function raceTimeout<T>(p: Promise<T>, ms: number): Promise<T | null> {
+  return Promise.race([
+    p.catch(() => null),
+    new Promise<null>((resolve) => setTimeout(() => resolve(null), ms)),
+  ]);
+}
+
 export async function handleSessionStart(): Promise<void> {
   const config = loadConfig();
   if (!config) {
@@ -168,17 +181,20 @@ export async function handleSessionStart(): Promise<void> {
     const contextLabel = observationMode === "unified" ? "userPeer.context()" : "aiPeer.context(target=user)";
     const [userContextResult, summaryResult] = await Promise.allSettled([
       wantContext
-        ? (observationMode === "unified"
-            ? userPeer.context({ maxConclusions: 25, includeMostFrequent: true })
-            : aiPeer.context({ target: config.peerName, maxConclusions: 25, includeMostFrequent: true }))
+        ? raceTimeout(
+            observationMode === "unified"
+              ? userPeer.context({ maxConclusions: 25, includeMostFrequent: true })
+              : aiPeer.context({ target: config.peerName, maxConclusions: 25, includeMostFrequent: true }),
+            CONTEXT_FETCH_TIMEOUT_MS
+          )
         : Promise.resolve(null),
-      wantSummary ? session.summaries() : Promise.resolve(null),
+      wantSummary ? raceTimeout(session.summaries(), CONTEXT_FETCH_TIMEOUT_MS) : Promise.resolve(null),
     ]);
 
     const fetchDuration = Date.now() - fetchStart;
     const asyncResults = [
-      ...(wantContext ? [{ name: contextLabel, success: userContextResult.status === "fulfilled" }] : []),
-      ...(wantSummary ? [{ name: "session.summaries()", success: summaryResult.status === "fulfilled" }] : []),
+      ...(wantContext ? [{ name: contextLabel, success: userContextResult.status === "fulfilled" && userContextResult.value !== null }] : []),
+      ...(wantSummary ? [{ name: "session.summaries()", success: summaryResult.status === "fulfilled" && summaryResult.value !== null }] : []),
     ];
     const successCount = asyncResults.filter(r => r.success).length;
     logAsync("context-fetch", `Fetched ${successCount}/${asyncResults.length} in ${fetchDuration}ms`, asyncResults);


### PR DESCRIPTION
Contains 2 fixes:
- **fix: declare hook timeouts in seconds, not milliseconds**
- **fix: bound session-start context fetches at 10s**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session-start reliability by preventing slow context retrieval from delaying startup.
  * Added safeguards for timed-out or unsuccessful context and summary requests.
  * Updated hook timeout settings to provide more consistent execution across session and prompt events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->