### PR TITLE
fix: dedup repeated conclusions per session (#39)

### DIFF
--- a/plugins/honcho/src/hooks/user-prompt.ts
+++ b/plugins/honcho/src/hooks/user-prompt.ts
@@ -11,7 +11,7 @@ import { logHook, logApiCall, setLogContext } from "../log.js";
 import { visInjectionMessage, visDialecticMessage, visSessionContextMessage, visSkipMessage, addSystemMessage, verboseApiResult, verboseList } from "../visual.js";
 import type { ReasoningLevel } from "../config.js";
 import { honchoSessionUrl } from "../styles.js";
-import { setMemoryState, setSessionLink } from "../state.js";
+import { setMemoryState, setSessionLink, loadDedupLedger, saveDedupLedger, type DedupLedger } from "../state.js";
 
 interface HookInput {
   prompt?: string;
@@ -106,6 +106,86 @@ function extractTopics(prompt: string): { topics: string[]; precise: boolean } {
   const stopwords = new Set(['the', 'and', 'for', 'that', 'this', 'with', 'from', 'have', 'are', 'was', 'were', 'been', 'being', 'has', 'had', 'does', 'did', 'will', 'would', 'could', 'should', 'can', 'may', 'might', 'must', 'shall', 'need', 'want', 'like', 'just', 'also', 'more', 'some', 'what', 'when', 'where', 'which', 'who', 'how', 'why', 'all', 'each', 'every', 'both', 'few', 'most', 'other', 'into', 'over', 'such', 'only', 'same', 'than', 'very', 'your', 'make', 'take', 'come', 'give', 'look', 'think', 'know']);
   const words = prompt.toLowerCase().match(/\b[a-z]{4,}\b/g) || [];
   return { topics: [...new Set(words.filter(w => !stopwords.has(w)))].slice(0, 10), precise: false };
+}
+
+// ============================================
+// Per-session conclusion dedup (#39)
+// ============================================
+
+/**
+ * How many turns a conclusion stays suppressed after being injected.
+ *
+ * Not "forever": a conclusion that mattered 20 turns ago can legitimately
+ * matter again once the conversation has moved on, and by then it has very
+ * likely dropped out of the live context window (or been summarized away by a
+ * compact), so re-injecting it is real information rather than noise. Not a raw
+ * count cap either — a count would suppress by arrival order regardless of how
+ * long ago the repeat was seen. Eight turns is short enough that genuine
+ * re-relevance recovers quickly, and long enough to kill the every-single-turn
+ * repetition #39 reports.
+ */
+export const DEDUP_WINDOW_TURNS = 8;
+
+/**
+ * The floor: if dedup would leave NOTHING, inject this many of the original
+ * conclusions anyway. Handing the model no memory at all is strictly worse than
+ * repeating yourself, so dedup is only ever allowed to THIN the payload.
+ */
+export const DEDUP_FLOOR = 3;
+
+/**
+ * Short, stable content hash (FNV-1a, 32-bit, hex). Dependency-free and
+ * deterministic across runs, so the ledger survives process restarts.
+ * Whitespace is collapsed and case folded first, so cosmetic re-rendering of
+ * the same conclusion still counts as a repeat.
+ *
+ * `namespace` keeps the user-peer and assistant-peer views separate: the same
+ * sentence about each is two different facts.
+ */
+export function dedupKey(conclusion: string, namespace: string): string {
+  const normalized = conclusion.trim().toLowerCase().replace(/\s+/g, " ");
+  let hash = 0x811c9dc5;
+  for (let i = 0; i < normalized.length; i++) {
+    hash ^= normalized.charCodeAt(i);
+    hash = Math.imul(hash, 0x01000193) >>> 0;
+  }
+  return `${namespace}:${hash.toString(16)}`;
+}
+
+/**
+ * Drop conclusions injected within the last DEDUP_WINDOW_TURNS turns, then
+ * RECORD what survived against the current turn.
+ *
+ * Guarantees:
+ *  - Never returns an empty list for a non-empty input (the DEDUP_FLOOR floor).
+ *  - Only the emitted conclusions get their stamp refreshed, so a suppressed
+ *    one ages out on schedule from its last real injection.
+ *  - Purely a function of (conclusions, ledger, namespace). It never reads any
+ *    display setting, so additionalContext is identical at every verbosity.
+ */
+export function filterRepeats(
+  conclusions: string[],
+  ledger: DedupLedger,
+  namespace: string,
+): { kept: string[]; suppressed: number; floored: boolean } {
+  if (conclusions.length === 0) return { kept: [], suppressed: 0, floored: false };
+
+  const fresh = conclusions.filter((c) => {
+    const lastTurn = ledger.seen[dedupKey(c, namespace)];
+    return lastTurn === undefined || ledger.turn - lastTurn > DEDUP_WINDOW_TURNS;
+  });
+
+  const floored = fresh.length === 0;
+  // The floor: everything was a repeat, but an empty injection would hand the
+  // model no memory at all. Re-send the top-N in retrieval order (already
+  // relevance-ranked by context()) rather than nothing.
+  const kept = floored ? conclusions.slice(0, DEDUP_FLOOR) : fresh;
+
+  for (const c of kept) {
+    ledger.seen[dedupKey(c, namespace)] = ledger.turn;
+  }
+
+  return { kept, suppressed: conclusions.length - kept.length, floored };
 }
 
 function shouldSkipContextRetrieval(prompt: string): boolean {
@@ -240,7 +320,17 @@ export async function handleUserPrompt(): Promise<void> {
       ? { context: userCtxResult.context, matched: userCtxResult.matched, queryLabel: userCtxResult.queryLabel }
       : null;
 
-  emitPerTurn(config, injection, userCtx, assistantCtxResult?.context ?? null, sessionCtx, dialectic, sessionLink);
+  // #39: load this session's dedup ledger, advance its turn counter, let
+  // emitPerTurn thin out conclusions already injected inside the window, then
+  // PERSIST what was actually emitted. The save has to sit between emit and
+  // process.exit — process.exit is immediate, so anything deferred past it
+  // never lands.
+  const ledger = loadDedupLedger(hookInput.session_id);
+  ledger.turn += 1;
+
+  emitPerTurn(config, injection, userCtx, assistantCtxResult?.context ?? null, sessionCtx, dialectic, sessionLink, ledger);
+
+  saveDedupLedger(ledger, hookInput.session_id);
   process.exit(0);
 }
 
@@ -252,7 +342,7 @@ export async function handleUserPrompt(): Promise<void> {
  * silently when nothing resolved to content — mirroring the old no-cache
  * fall-through.
  */
-function emitPerTurn(
+export function emitPerTurn(
   config: any,
   injection: InjectionConfig,
   userCtx: { context: any; matched?: string[]; queryLabel?: string } | null,
@@ -260,13 +350,30 @@ function emitPerTurn(
   sessionCtx: SessionContextResult | null,
   dialectic: DialecticResult | null,
   sessionLink?: string,
+  // #39: the per-session dedup ledger. When omitted, behavior is exactly as
+  // before — every retrieved conclusion is injected. When present, conclusions
+  // injected within the last DEDUP_WINDOW_TURNS turns are thinned out and the
+  // ledger is MUTATED with what was actually emitted; the caller persists it.
+  dedupLedger?: DedupLedger,
 ): void {
   const parts: string[] = [];
   const visLines: string[] = [];
   const show = (c: PerTurnComponent) => injection.showContents?.includes(c) ?? false;
+  // Dedup applies to the conclusion lists only — never to sessionContext (a raw
+  // message window, meaningless partially elided) or dialectic (a freshly
+  // generated answer, not a stored conclusion).
+  const dedup = (conclusions: string[], namespace: string): string[] => {
+    if (!dedupLedger) return conclusions;
+    const { kept, suppressed, floored } = filterRepeats(conclusions, dedupLedger, namespace);
+    logHook(
+      "user-prompt",
+      `dedup[${namespace}] candidates=${conclusions.length} suppressed=${suppressed} emitted=${kept.length}${floored ? " (floor)" : ""}`,
+    );
+    return kept;
+  };
 
   if (userCtx) {
-    const conclusions = extractConclusions(userCtx.context);
+    const conclusions = dedup(extractConclusions(userCtx.context), "u");
     if (conclusions.length > 0) {
       parts.push(`Relevant conclusions: ${conclusions.join("; ")}`);
       visLines.push(visInjectionMessage("user-prompt", { conclusions, matched: userCtx.matched, queryLabel: userCtx.queryLabel, showContents: show("userContext") }));
@@ -274,7 +381,7 @@ function emitPerTurn(
   }
 
   if (assistantCtx) {
-    const conclusions = extractConclusions(assistantCtx);
+    const conclusions = dedup(extractConclusions(assistantCtx), "a");
     if (conclusions.length > 0) {
       parts.push(`Conclusions about the assistant (${config.aiPeer}): ${conclusions.join("; ")}`);
       visLines.push(visInjectionMessage("user-prompt", { conclusions, queryLabel: `assistant ${config.aiPeer}`, showContents: show("assistantContext") }));

--- a/plugins/honcho/src/hooks/user-prompt.ts
+++ b/plugins/honcho/src/hooks/user-prompt.ts
@@ -325,12 +325,20 @@ export async function handleUserPrompt(): Promise<void> {
   // PERSIST what was actually emitted. The save has to sit between emit and
   // process.exit — process.exit is immediate, so anything deferred past it
   // never lands.
-  const ledger = loadDedupLedger(hookInput.session_id);
+  // Key the ledger off `instanceId`, not `hookInput.session_id`: session_id is
+  // optional here (line ~244 already falls back to getInstanceIdForCwd), and
+  // with no id the ledger collapses to one shared global dedup.json. Two
+  // concurrent sessions would then share a turn counter and a `seen` map and
+  // suppress each other's conclusions — losing session isolation exactly when
+  // it matters — and clearSessionFiles early-returns without a sessionId, so
+  // that file would never be cleaned up either.
+  const dedupId = instanceId || undefined;
+  const ledger = loadDedupLedger(dedupId);
   ledger.turn += 1;
 
   emitPerTurn(config, injection, userCtx, assistantCtxResult?.context ?? null, sessionCtx, dialectic, sessionLink, ledger);
 
-  saveDedupLedger(ledger, hookInput.session_id);
+  saveDedupLedger(ledger, dedupId);
   process.exit(0);
 }
 

--- a/plugins/honcho/src/state.ts
+++ b/plugins/honcho/src/state.ts
@@ -87,11 +87,27 @@ export function pruneLedger(ledger: DedupLedger): DedupLedger {
   return { turn: ledger.turn, seen };
 }
 
+/**
+ * A ledger's `seen` map must be a plain object of finite numeric turn stamps.
+ * Arrays and non-numeric values are treated as corruption and discarded.
+ */
+function isValidSeenMap(seen: unknown): seen is Record<string, number> {
+  if (!seen || typeof seen !== "object" || Array.isArray(seen)) return false;
+  return Object.values(seen as Record<string, unknown>).every(
+    (v) => typeof v === "number" && Number.isFinite(v),
+  );
+}
+
 export function loadDedupLedger(sessionId?: string): DedupLedger {
   try {
     const raw = JSON.parse(readFileSync(dedupFile(sessionId), "utf-8"));
     const turn = typeof raw?.turn === "number" && raw.turn >= 0 ? raw.turn : 0;
-    const seen = raw?.seen && typeof raw.seen === "object" ? raw.seen : {};
+    // `typeof x === "object"` alone admits arrays and non-numeric stamps. A
+    // stamp that will not coerce to a number makes `ledger.turn - lastTurn`
+    // NaN, and `NaN > DEDUP_WINDOW_TURNS` is false — so that conclusion reads
+    // as a permanent repeat. Only *kept* entries get restamped, so a poisoned
+    // entry never heals for the life of the session. Cheap to reject up front.
+    const seen = isValidSeenMap(raw?.seen) ? raw.seen : {};
     return { turn, seen };
   } catch {
     // Missing or corrupt: start clean. A lost ledger costs at most one turn of

--- a/plugins/honcho/src/state.ts
+++ b/plugins/honcho/src/state.ts
@@ -7,7 +7,7 @@
 
 import { homedir } from "os";
 import { join } from "path";
-import { writeFileSync, unlinkSync } from "fs";
+import { writeFileSync, readFileSync, unlinkSync } from "fs";
 
 const DIR = join(homedir(), ".honcho");
 
@@ -20,6 +20,15 @@ function stateFile(sessionId?: string): string {
 }
 function sessionFile(sessionId?: string): string {
   return join(DIR, sessionId ? `session-${sessionId}.json` : "session.json");
+}
+// The per-session record of which conclusions UserPromptSubmit has already
+// injected. Deliberately a SIBLING of state-*.json rather than a field inside
+// it: setMemoryState() rewrites state-${sessionId}.json wholesale on every
+// phase change (several times per turn), so a ledger stored there would be
+// clobbered constantly. Same directory, same session_id keying, and
+// clearSessionFiles() cleans it up with the rest.
+function dedupFile(sessionId?: string): string {
+  return join(DIR, sessionId ? `dedup-${sessionId}.json` : "dedup.json");
 }
 
 export type MemoryPhase =
@@ -47,10 +56,62 @@ export function setSessionLink(url: string, name: string | undefined, sessionId?
   }
 }
 
+/**
+ * Which conclusions this session has already injected, and when.
+ *
+ * `turn` counts injecting UserPromptSubmit turns (trivial and harness-injected
+ * prompts exit before reaching this, so they don't advance it). `seen` maps a
+ * short content hash to the turn it was LAST ACTUALLY injected on — a
+ * suppressed repeat deliberately does not refresh its stamp, so a conclusion
+ * becomes eligible again a fixed window after its last real injection rather
+ * than being buried for the rest of the session.
+ *
+ * Only hashes are stored, never conclusion text: the ledger stays tiny and no
+ * memory content is duplicated into a second file on disk.
+ */
+export interface DedupLedger {
+  turn: number;
+  seen: Record<string, number>;
+}
+
+/** Entries older than this many turns are dropped on save, bounding file size. */
+export const DEDUP_LEDGER_RETAIN_TURNS = 50;
+
+/** Drop stamps too old to ever matter again. Pure, so it is directly testable. */
+export function pruneLedger(ledger: DedupLedger): DedupLedger {
+  const cutoff = ledger.turn - DEDUP_LEDGER_RETAIN_TURNS;
+  const seen: Record<string, number> = {};
+  for (const [key, turn] of Object.entries(ledger.seen)) {
+    if (turn > cutoff) seen[key] = turn;
+  }
+  return { turn: ledger.turn, seen };
+}
+
+export function loadDedupLedger(sessionId?: string): DedupLedger {
+  try {
+    const raw = JSON.parse(readFileSync(dedupFile(sessionId), "utf-8"));
+    const turn = typeof raw?.turn === "number" && raw.turn >= 0 ? raw.turn : 0;
+    const seen = raw?.seen && typeof raw.seen === "object" ? raw.seen : {};
+    return { turn, seen };
+  } catch {
+    // Missing or corrupt: start clean. A lost ledger costs at most one turn of
+    // repeats — never any memory content.
+    return { turn: 0, seen: {} };
+  }
+}
+
+export function saveDedupLedger(ledger: DedupLedger, sessionId?: string): void {
+  try {
+    writeFileSync(dedupFile(sessionId), JSON.stringify(pruneLedger(ledger)));
+  } catch {
+    // best-effort — a failed write just means the next turn may repeat itself
+  }
+}
+
 // Clean up this window's files when its session ends, so they don't accumulate.
 export function clearSessionFiles(sessionId?: string): void {
   if (!sessionId) return;
-  for (const f of [stateFile(sessionId), sessionFile(sessionId)]) {
+  for (const f of [stateFile(sessionId), sessionFile(sessionId), dedupFile(sessionId)]) {
     try { unlinkSync(f); } catch { /* already gone */ }
   }
 }

--- a/plugins/honcho/src/state.ts
+++ b/plugins/honcho/src/state.ts
@@ -27,6 +27,11 @@ function sessionFile(sessionId?: string): string {
 // phase change (several times per turn), so a ledger stored there would be
 // clobbered constantly. Same directory, same session_id keying, and
 // clearSessionFiles() cleans it up with the rest.
+/**
+ * Path to a session's dedup ledger.
+ *
+ * @param sessionId - Session key; omitted yields the shared `dedup.json`.
+ */
 function dedupFile(sessionId?: string): string {
   return join(DIR, sessionId ? `dedup-${sessionId}.json` : "dedup.json");
 }
@@ -98,6 +103,16 @@ function isValidSeenMap(seen: unknown): seen is Record<string, number> {
   );
 }
 
+/**
+ * Read this session's dedup ledger from disk.
+ *
+ * Never throws: a missing, unreadable, or corrupt ledger yields a clean
+ * `{ turn: 0, seen: {} }`. Losing a ledger costs at most one turn of repeated
+ * conclusions, so failing open is strictly better than failing the hook.
+ *
+ * @param sessionId - Session key; omitted falls back to the shared file.
+ * @returns A validated ledger, with any corrupt `seen` map discarded.
+ */
 export function loadDedupLedger(sessionId?: string): DedupLedger {
   try {
     const raw = JSON.parse(readFileSync(dedupFile(sessionId), "utf-8"));
@@ -116,6 +131,15 @@ export function loadDedupLedger(sessionId?: string): DedupLedger {
   }
 }
 
+/**
+ * Persist the ledger, pruned to {@link DEDUP_LEDGER_RETAIN_TURNS}.
+ *
+ * Best-effort: a failed write is swallowed, because the only consequence is
+ * that the next turn may re-inject conclusions it already showed.
+ *
+ * @param ledger - Ledger to write; pruned before serialization.
+ * @param sessionId - Session key; omitted falls back to the shared file.
+ */
 export function saveDedupLedger(ledger: DedupLedger, sessionId?: string): void {
   try {
     writeFileSync(dedupFile(sessionId), JSON.stringify(pruneLedger(ledger)));
@@ -124,7 +148,15 @@ export function saveDedupLedger(ledger: DedupLedger, sessionId?: string): void {
   }
 }
 
-// Clean up this window's files when its session ends, so they don't accumulate.
+/**
+ * Delete this window's per-session files when its session ends, so they don't
+ * accumulate: the state, session, and dedup-ledger files.
+ *
+ * A missing file is not an error. Without a `sessionId` there is nothing
+ * session-scoped to remove, so this is a no-op.
+ *
+ * @param sessionId - Session whose files should be removed.
+ */
 export function clearSessionFiles(sessionId?: string): void {
   if (!sessionId) return;
   for (const f of [stateFile(sessionId), sessionFile(sessionId), dedupFile(sessionId)]) {

--- a/plugins/honcho/tests/dedup.test.ts
+++ b/plugins/honcho/tests/dedup.test.ts
@@ -59,8 +59,9 @@ describe("filterRepeats", () => {
     const l = ledger(1);
     filterRepeats(["a"], l, "u");
 
-    // Still inside the window: suppressed (via the floor, since it is the only
-    // candidate — see the floor tests below).
+    // Still inside the window, so "a" is suppressed BY THE WINDOW. "fresh" is a
+    // new candidate and keeps the result non-empty, so the floor is not
+    // involved here — see the floor tests below for that path.
     l.turn = 1 + DEDUP_WINDOW_TURNS;
     expect(filterRepeats(["a", "fresh"], l, "u").kept).toEqual(["fresh"]);
 
@@ -130,6 +131,29 @@ describe("filterRepeats", () => {
       expect(suppressed).toBe(0);
       expect(floored).toBe(false);
     });
+  });
+});
+
+// Why loadDedupLedger validates `seen` values rather than only checking that
+// `seen` is an object. filterRepeats does arithmetic on the stamp, so a value
+// that will not coerce to a number poisons that entry permanently: the
+// comparison is NaN > WINDOW, which is false (a repeat), and only KEPT entries
+// are restamped — so a suppressed entry can never heal itself. No filesystem
+// here; this pins the consequence the loader's guard exists to prevent.
+describe("a non-numeric turn stamp would suppress a conclusion permanently", () => {
+  test("NaN-producing stamp reads as a repeat at any distance", () => {
+    const corrupt = { turn: 1, seen: { [dedupKey("a", "u")]: "abc" } } as unknown as DedupLedger;
+    for (const turn of [2, 50, 100_000]) {
+      corrupt.turn = turn;
+      // "fresh" keeps the result non-empty so the floor cannot mask the effect.
+      expect(filterRepeats(["a", "fresh"], corrupt, "u").kept).toEqual(["fresh"]);
+    }
+  });
+
+  test("a valid numeric stamp does age out, by contrast", () => {
+    const ok = ledger(1, { [dedupKey("a", "u")]: 1 });
+    ok.turn = 1 + DEDUP_WINDOW_TURNS + 1;
+    expect(filterRepeats(["a", "fresh"], ok, "u").kept).toEqual(["a", "fresh"]);
   });
 });
 

--- a/plugins/honcho/tests/dedup.test.ts
+++ b/plugins/honcho/tests/dedup.test.ts
@@ -1,0 +1,249 @@
+import { describe, expect, test, beforeEach, afterEach } from "bun:test";
+import {
+  dedupKey,
+  filterRepeats,
+  emitPerTurn,
+  DEDUP_WINDOW_TURNS,
+  DEDUP_FLOOR,
+} from "../src/hooks/user-prompt";
+import { pruneLedger, DEDUP_LEDGER_RETAIN_TURNS, type DedupLedger } from "../src/state";
+import type { InjectionConfig } from "../src/config";
+
+const ledger = (turn: number, seen: Record<string, number> = {}): DedupLedger => ({ turn, seen });
+
+describe("dedupKey", () => {
+  test("is stable for the same conclusion", () => {
+    expect(dedupKey("Prefers concise answers", "u")).toBe(dedupKey("Prefers concise answers", "u"));
+  });
+
+  test("normalizes whitespace and case, so cosmetic re-rendering still counts as a repeat", () => {
+    expect(dedupKey("  Prefers   CONCISE\nanswers ", "u")).toBe(dedupKey("prefers concise answers", "u"));
+  });
+
+  test("different conclusions get different keys", () => {
+    expect(dedupKey("Prefers concise answers", "u")).not.toBe(dedupKey("Prefers verbose answers", "u"));
+  });
+
+  test("namespaces separate the user peer from the assistant peer", () => {
+    expect(dedupKey("Prefers concise answers", "u")).not.toBe(dedupKey("Prefers concise answers", "a"));
+  });
+});
+
+describe("filterRepeats", () => {
+  test("first sight of a conclusion passes through untouched", () => {
+    const l = ledger(1);
+    const { kept, suppressed, floored } = filterRepeats(["a", "b", "c"], l, "u");
+    expect(kept).toEqual(["a", "b", "c"]);
+    expect(suppressed).toBe(0);
+    expect(floored).toBe(false);
+  });
+
+  test("records what it emitted against the current turn", () => {
+    const l = ledger(4);
+    filterRepeats(["a", "b"], l, "u");
+    expect(l.seen[dedupKey("a", "u")]).toBe(4);
+    expect(l.seen[dedupKey("b", "u")]).toBe(4);
+  });
+
+  test("suppresses only the repeats, keeping genuinely new conclusions", () => {
+    const l = ledger(1);
+    filterRepeats(["a", "b"], l, "u");
+    l.turn = 2;
+    const { kept, suppressed, floored } = filterRepeats(["a", "b", "c"], l, "u");
+    expect(kept).toEqual(["c"]);
+    expect(suppressed).toBe(2);
+    expect(floored).toBe(false);
+  });
+
+  test("a conclusion becomes eligible again once the window has passed", () => {
+    const l = ledger(1);
+    filterRepeats(["a"], l, "u");
+
+    // Still inside the window: suppressed (via the floor, since it is the only
+    // candidate — see the floor tests below).
+    l.turn = 1 + DEDUP_WINDOW_TURNS;
+    expect(filterRepeats(["a", "fresh"], l, "u").kept).toEqual(["fresh"]);
+
+    // One turn past the window, measured from its LAST REAL injection (turn 1).
+    l.turn = 1 + DEDUP_WINDOW_TURNS + 1;
+    expect(filterRepeats(["a", "fresh2"], l, "u").kept).toEqual(["a", "fresh2"]);
+  });
+
+  test("being suppressed does NOT refresh the stamp — it ages out on schedule", () => {
+    const l = ledger(1);
+    filterRepeats(["a"], l, "u"); // real injection on turn 1
+
+    // Suppressed on every turn in between; its stamp must stay at 1.
+    for (let t = 2; t <= 1 + DEDUP_WINDOW_TURNS; t++) {
+      l.turn = t;
+      filterRepeats(["a", `new-${t}`], l, "u");
+      expect(l.seen[dedupKey("a", "u")]).toBe(1);
+    }
+
+    // Therefore it recovers on schedule rather than being buried forever.
+    l.turn = 1 + DEDUP_WINDOW_TURNS + 1;
+    expect(filterRepeats(["a", "z"], l, "u").kept).toContain("a");
+  });
+
+  test("the user and assistant namespaces do not suppress each other", () => {
+    const l = ledger(1);
+    filterRepeats(["shared sentence"], l, "u");
+    l.turn = 2;
+    expect(filterRepeats(["shared sentence"], l, "a").kept).toEqual(["shared sentence"]);
+  });
+
+  describe("the never-empty floor", () => {
+    test("an all-repeat turn still injects DEDUP_FLOOR conclusions, never zero", () => {
+      const l = ledger(1);
+      const all = ["a", "b", "c", "d", "e"];
+      filterRepeats(all, l, "u");
+      l.turn = 2;
+      const { kept, suppressed, floored } = filterRepeats(all, l, "u");
+      expect(kept).toEqual(["a", "b", "c"]); // top-N in retrieval (relevance) order
+      expect(kept.length).toBe(DEDUP_FLOOR);
+      expect(suppressed).toBe(all.length - DEDUP_FLOOR);
+      expect(floored).toBe(true);
+    });
+
+    test("fewer candidates than the floor: all of them are re-emitted", () => {
+      const l = ledger(1);
+      filterRepeats(["only"], l, "u");
+      l.turn = 2;
+      expect(filterRepeats(["only"], l, "u").kept).toEqual(["only"]);
+    });
+
+    test("a non-empty retrieval NEVER yields an empty injection, across many turns", () => {
+      const l = ledger(0);
+      const all = ["a", "b", "c", "d", "e"];
+      for (let t = 1; t <= 40; t++) {
+        l.turn = t;
+        const { kept } = filterRepeats(all, l, "u");
+        expect(kept.length).toBeGreaterThan(0);
+        expect(kept.length).toBeLessThanOrEqual(all.length);
+      }
+    });
+
+    test("an empty retrieval stays empty — the floor invents nothing", () => {
+      const l = ledger(1);
+      const { kept, suppressed, floored } = filterRepeats([], l, "u");
+      expect(kept).toEqual([]);
+      expect(suppressed).toBe(0);
+      expect(floored).toBe(false);
+    });
+  });
+});
+
+describe("pruneLedger", () => {
+  test("drops stamps older than the retention horizon and keeps the rest", () => {
+    const l = ledger(100, { old: 100 - DEDUP_LEDGER_RETAIN_TURNS, recent: 99 });
+    const pruned = pruneLedger(l);
+    expect(pruned.turn).toBe(100);
+    expect(pruned.seen).toEqual({ recent: 99 });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The payload-level guarantee: dedup shapes additionalContext, and does so
+// independently of any display setting.
+// ---------------------------------------------------------------------------
+
+const injection = (showContents: string[]): InjectionConfig =>
+  ({
+    sessionStart: [],
+    perTurn: ["userContext", "assistantContext"],
+    showContents,
+  }) as unknown as InjectionConfig;
+
+const repr = (lines: string[]) => ({ representation: lines.join("\n") });
+
+function captureAdditionalContext(fn: () => void): string {
+  const original = console.log;
+  let captured = "";
+  console.log = (line: string) => {
+    captured = JSON.parse(line).hookSpecificOutput?.additionalContext ?? "";
+  };
+  try {
+    fn();
+  } finally {
+    console.log = original;
+  }
+  return captured;
+}
+
+describe("emitPerTurn dedup applied to additionalContext", () => {
+  const config = { peerName: "tester", aiPeer: "assistant" };
+  const conclusions = ["Prefers concise answers", "Prefers a conversational tone", "Wants structure per-context", "Uses bun"];
+
+  let originalLevel: string | undefined;
+  beforeEach(() => {
+    originalLevel = process.env.HONCHO_LOG_LEVEL;
+  });
+  afterEach(() => {
+    if (originalLevel === undefined) delete process.env.HONCHO_LOG_LEVEL;
+    else process.env.HONCHO_LOG_LEVEL = originalLevel;
+  });
+
+  test("a repeat turn produces a SMALLER but non-empty payload", () => {
+    const l = ledger(0);
+
+    l.turn = 1;
+    const first = captureAdditionalContext(() =>
+      emitPerTurn(config, injection([]), { context: repr(conclusions) }, null, null, null, undefined, l),
+    );
+
+    l.turn = 2;
+    const second = captureAdditionalContext(() =>
+      emitPerTurn(config, injection([]), { context: repr(conclusions) }, null, null, null, undefined, l),
+    );
+
+    expect(first).toContain("Prefers concise answers");
+    expect(second.length).toBeGreaterThan(0);
+    expect(second.length).toBeLessThan(first.length);
+    expect(second).toContain("Relevant conclusions:");
+  });
+
+  test("a fresh session (fresh ledger) gets the full payload again", () => {
+    const shared = ledger(1);
+    const full = captureAdditionalContext(() =>
+      emitPerTurn(config, injection([]), { context: repr(conclusions) }, null, null, null, undefined, shared),
+    );
+
+    shared.turn = 2;
+    captureAdditionalContext(() =>
+      emitPerTurn(config, injection([]), { context: repr(conclusions) }, null, null, null, undefined, shared),
+    );
+
+    // A new session starts from a clean ledger — nothing carries over.
+    const freshSession = ledger(1);
+    const refetched = captureAdditionalContext(() =>
+      emitPerTurn(config, injection([]), { context: repr(conclusions) }, null, null, null, undefined, freshSession),
+    );
+    expect(refetched).toBe(full);
+  });
+
+  test("additionalContext is byte-identical regardless of showContents (ledger POPULATED)", () => {
+    // With an empty ledger this assertion passes trivially — populate it first
+    // so the dedup path itself is what gets compared across display settings.
+    const seed = ledger(1);
+    filterRepeats(conclusions.slice(0, 2), seed, "u");
+
+    const run = (showContents: string[]) => {
+      const l: DedupLedger = { turn: 2, seen: { ...seed.seen } };
+      return captureAdditionalContext(() =>
+        emitPerTurn(config, injection(showContents), { context: repr(conclusions) }, repr(conclusions), null, null, undefined, l),
+      );
+    };
+
+    const hidden = run([]);
+    const shown = run(["userContext", "assistantContext"]);
+    expect(hidden).toBe(shown);
+    expect(hidden.length).toBeGreaterThan(0);
+  });
+
+  test("without a ledger, behavior is unchanged — every conclusion is injected", () => {
+    const withoutLedger = captureAdditionalContext(() =>
+      emitPerTurn(config, injection([]), { context: repr(conclusions) }, null, null, null),
+    );
+    for (const c of conclusions) expect(withoutLedger).toContain(c);
+  });
+});

--- a/plugins/honcho/tests/dedup.test.ts
+++ b/plugins/honcho/tests/dedup.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test, beforeEach, afterEach } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import {
   dedupKey,
   filterRepeats,
@@ -180,11 +180,27 @@ const injection = (showContents: string[]): InjectionConfig =>
 
 const repr = (lines: string[]) => ({ representation: lines.join("\n") });
 
+/**
+ * Capture the additionalContext payload emitted on stdout.
+ *
+ * Only lines that actually carry `hookSpecificOutput.additionalContext` count.
+ * The hook can emit more than one line per turn (a systemMessage-only line, for
+ * one), and an unconditional assignment would let a later non-payload line
+ * clobber the real capture with "". Non-JSON lines are ignored rather than
+ * thrown on, so this stays correct if anything else ever writes to stdout.
+ */
 function captureAdditionalContext(fn: () => void): string {
   const original = console.log;
   let captured = "";
   console.log = (line: string) => {
-    captured = JSON.parse(line).hookSpecificOutput?.additionalContext ?? "";
+    let parsed: any;
+    try {
+      parsed = JSON.parse(line);
+    } catch {
+      return; // not our payload
+    }
+    const ctx = parsed?.hookSpecificOutput?.additionalContext;
+    if (typeof ctx === "string") captured = ctx;
   };
   try {
     fn();
@@ -198,14 +214,6 @@ describe("emitPerTurn dedup applied to additionalContext", () => {
   const config = { peerName: "tester", aiPeer: "assistant" };
   const conclusions = ["Prefers concise answers", "Prefers a conversational tone", "Wants structure per-context", "Uses bun"];
 
-  let originalLevel: string | undefined;
-  beforeEach(() => {
-    originalLevel = process.env.HONCHO_LOG_LEVEL;
-  });
-  afterEach(() => {
-    if (originalLevel === undefined) delete process.env.HONCHO_LOG_LEVEL;
-    else process.env.HONCHO_LOG_LEVEL = originalLevel;
-  });
 
   test("a repeat turn produces a SMALLER but non-empty payload", () => {
     const l = ledger(0);

--- a/plugins/honcho/tests/dedup.test.ts
+++ b/plugins/honcho/tests/dedup.test.ts
@@ -1,4 +1,7 @@
 import { describe, expect, test } from "bun:test";
+import { writeFileSync, existsSync, mkdirSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
 import {
   dedupKey,
   filterRepeats,
@@ -6,7 +9,13 @@ import {
   DEDUP_WINDOW_TURNS,
   DEDUP_FLOOR,
 } from "../src/hooks/user-prompt";
-import { pruneLedger, DEDUP_LEDGER_RETAIN_TURNS, type DedupLedger } from "../src/state";
+import {
+  pruneLedger,
+  loadDedupLedger,
+  clearSessionFiles,
+  DEDUP_LEDGER_RETAIN_TURNS,
+  type DedupLedger,
+} from "../src/state";
 import type { InjectionConfig } from "../src/config";
 
 const ledger = (turn: number, seen: Record<string, number> = {}): DedupLedger => ({ turn, seen });
@@ -154,6 +163,52 @@ describe("a non-numeric turn stamp would suppress a conclusion permanently", () 
     const ok = ledger(1, { [dedupKey("a", "u")]: 1 });
     ok.turn = 1 + DEDUP_WINDOW_TURNS + 1;
     expect(filterRepeats(["a", "fresh"], ok, "u").kept).toEqual(["a", "fresh"]);
+  });
+
+  /**
+   * The tests above hand a malformed ledger straight to filterRepeats, so they
+   * pin the CONSEQUENCE but would stay green if the loader's validation were
+   * deleted. These exercise loadDedupLedger against a PERSISTED bad value, so
+   * removing that guard fails here.
+   *
+   * These touch the real ~/.honcho: state.ts resolves paths through
+   * `homedir()`, and Bun reads that from the passwd entry while ignoring
+   * process.env.HOME, so the directory cannot be redirected from a test. The
+   * fixture id is namespaced so it can never collide with a live Claude Code
+   * session_id (a UUID), and every case removes its own file in a finally.
+   */
+  const FIXTURE = "pr104-loader-validation-fixture";
+
+  function withPersistedLedger(raw: unknown, assert: (loaded: DedupLedger) => void): void {
+    mkdirSync(join(homedir(), ".honcho"), { recursive: true });
+    const path = join(homedir(), ".honcho", `dedup-${FIXTURE}.json`);
+    try {
+      writeFileSync(path, JSON.stringify(raw));
+      assert(loadDedupLedger(FIXTURE));
+    } finally {
+      clearSessionFiles(FIXTURE);
+      expect(existsSync(path)).toBe(false);
+    }
+  }
+
+  test("loadDedupLedger discards a persisted non-numeric stamp", () => {
+    withPersistedLedger({ turn: 5, seen: { "u:x": "abc" } }, (loaded) => {
+      expect(loaded.seen).toEqual({});
+      expect(loaded.turn).toBe(5); // a valid turn survives; only `seen` is rejected
+    });
+  });
+
+  test("loadDedupLedger discards a persisted array seen map", () => {
+    withPersistedLedger({ turn: 3, seen: [1, 2, 3] }, (loaded) => {
+      expect(loaded.seen).toEqual({});
+    });
+  });
+
+  test("loadDedupLedger round-trips a valid numeric seen map", () => {
+    withPersistedLedger({ turn: 4, seen: { "u:x": 2 } }, (loaded) => {
+      expect(loaded.seen).toEqual({ "u:x": 2 });
+      expect(loaded.turn).toBe(4);
+    });
   });
 });
 


### PR DESCRIPTION
Closes #39

## The problem

`UserPromptSubmit` composes `additionalContext` with no memory of what it already sent. `peer.context()` is relevance-ranked and largely stable turn to turn, so the same conclusions arrive verbatim on every prompt. Over a long session the high-frequency preferences (tone, structure, formatting) get pasted in dozens of times — context bloat, and visible repetition in the replies.

## The fix

Per-session dedup: a conclusion already injected recently in this session is not injected again verbatim.

### Where the seen-set lives

A per-session ledger owned by `state.ts`: `~/.honcho/dedup-<session_id>.json`, keyed on the same `session_id` as the existing `state-`/`session-` files and cleaned up by the existing `clearSessionFiles()`.

It is a **sibling** of `state-<session_id>.json` rather than a field inside it on purpose: `setMemoryState()` rewrites that file wholesale on every phase change (several times per turn), so a ledger co-located there would be clobbered constantly.

Only short FNV-1a content hashes are stored, never conclusion text — the ledger stays tiny and no memory content is duplicated to a second file on disk. Load is fail-open: a missing or corrupt ledger starts clean, costing at most one turn of repeats and never any memory content.

### Scope and eviction

Per session, with a **sliding 8-turn window** keyed on the turn a conclusion was *last actually injected*.

Two properties matter here:

- **Being suppressed does not refresh the stamp.** A conclusion ages out on schedule from its last *real* injection, so it becomes eligible again instead of being buried for the rest of the session. This is the failure mode called out in the issue thread — the injected text can be compacted away, and a permanent suppression table would then lose the memory for good.
- **A window, not a count.** A raw count cap would suppress by arrival order regardless of how long ago the repeat was seen. Eight turns is short enough that genuine re-relevance recovers quickly, and long enough to kill the every-single-turn repetition the issue reports. By the time a conclusion recovers it has usually dropped out of the live context window anyway, so re-injecting it is real information rather than noise.

The ledger is pruned to a 50-turn retention horizon on save, bounding file size.

### The never-empty floor (explicit guarantee)

**A non-empty retrieval can never produce an empty injection.** If dedup would remove everything, the top `DEDUP_FLOOR = 3` conclusions are injected anyway, in retrieval (relevance) order. Dedup is only ever allowed to *thin* the payload — handing the model no memory at all is strictly worse than repeating yourself. This is asserted directly in the tests, including across 40 consecutive all-repeat turns.

### What it applies to

The `userContext` and `assistantContext` conclusion lists only, each in its own hash namespace (the same sentence about the user and about the assistant are two different facts). Not `sessionContext` — a raw message window, meaningless partially elided — and not `dialectic`, which is a freshly generated answer rather than a stored conclusion.

### Independent of display settings

`filterRepeats()` is a pure function of `(conclusions, ledger, namespace)`. It reads no display or verbosity setting, so `additionalContext` is byte-identical whatever `injection.showContents` contains. A test asserts exactly that **with the ledger populated** — with an empty ledger the assertion would pass trivially.

### Counters

Each component logs `candidates= / suppressed= / emitted=` (plus a `(floor)` marker), which gives the measurable regression signal asked for in the thread.

## Measured

Driven through the real hook entry point (`bun run hooks/user-prompt.ts` with real stdin JSON) against a stub Honcho returning a fixed 12-conclusion representation on every call — i.e. exactly the issue's scenario. Same prompt, same session, measuring the injected conclusions block inside `hookSpecificOutput.additionalContext`:

| Turn | conclusions injected | conclusions-block chars |
|------|---------------------|-------------------------|
| 1    | 12                  | 600                     |
| 2–9  | 3 (the floor)       | 190                     |
| 10   | 9 (window expired — they come back) | 408     |
| 11   | 3                   | 190                     |

A **fresh session**, same prompt, first turn: **12 conclusions / 600 chars** — full context, unaffected by the other session's ledger.

So a repeat turn is ~68% smaller and never empty, and a conclusion suppressed at turn 2 is eligible again at turn 10 rather than lost for the session.

## Tests

`plugins/honcho/tests/dedup.test.ts` — 19 new tests covering hash stability and normalization, namespace separation, window expiry, the stamp-not-refreshed-on-suppression property, ledger pruning, the never-empty floor (including the 40-turn all-repeat case and the "empty stays empty" case), the shrinking-but-non-empty repeat payload, fresh-session recovery, display-independence with a populated ledger, and unchanged behavior when no ledger is passed.

- `bun test`: **23 pass / 0 fail** (4 before this PR).
- `bunx tsc --noEmit`: clean.

## Deliberately out of scope

A ledger reset at the `/compact` / PreCompact boundary. It is a reasonable follow-up and `hooks/pre-compact.ts` is the obvious home for it, but it is not needed for correctness here: the sliding window already guarantees every conclusion becomes eligible again 8 turns after its last real injection, so compaction can never strand a memory permanently. Keeping this PR to one issue.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Reduced repeated user and assistant conclusions within a session.
  * Preserved a minimum number of conclusions when repeated content is detected.
  * Kept user and assistant conclusion histories separate.
  * Maintained session context and dialectic responses without filtering.
  * Improved resilience when saved session state is missing or corrupted.
  * Automatically refreshed deduplication state as sessions progressed and removed it during session cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->