### PR TITLE
chore: version bump

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,14 +6,14 @@
   },
   "metadata": {
     "description": "Honcho plugins for Claude Code - memory, development tools, and more",
-    "version": "0.2.10"
+    "version": "0.2.11"
   },
   "plugins": [
     {
       "name": "honcho",
       "source": "./plugins/honcho",
       "description": "Persistent memory for Claude Code sessions using Honcho",
-      "version": "0.2.10",
+      "version": "0.2.11",
       "keywords": ["memory", "context", "persistence"],
       "strict": false
     },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,17 @@
 
 All notable changes to claude-honcho will be documented in this file.
 
-## [Unreleased]
+## [0.2.11] - 2026-07-31
 
 ### Added
 
 - `/honcho:insights` skill — runs a max-reasoning dialectic pass over accumulated memory and turns it into proposed CLAUDE.md edits, output-style rules, and skill ideas. Falls back to a parallel `honcho_remember` fan-out at `high` if the max query times out. Read-only until the user picks what to apply.
+- Session briefing (session summary + peer card) — injectable at session start, and loadable on demand via the `get_briefing` MCP tool or `/honcho:briefing` skill.
+
+### Fixed
+
+- Hook timeouts specified in seconds instead of milliseconds.
+- `set_config` coerces string booleans.
 
 ## [0.2.10] - 2026-07-29
 

--- a/plugins/honcho/.claude-plugin/plugin.json
+++ b/plugins/honcho/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "honcho",
-  "version": "0.2.10",
+  "version": "0.2.11",
   "description": "Persistent memory for Claude Code sessions using Honcho by Plastic Labs",
   "author": {
     "name": "Plastic Labs",

--- a/plugins/honcho/package.json
+++ b/plugins/honcho/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-honcho",
-  "version": "0.2.10",
+  "version": "0.2.11",
   "description": "Persistent memory for Claude Code sessions using Honcho by Plastic Labs",
   "type": "module",
   "keywords": [


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the `/honcho:insights` skill.
  - Added session briefing functionality.
  - Hook timeout units are now clearly specified in seconds.
  - Configuration now supports string values for boolean settings.

- **Release**
  - Updated the Honcho plugin and package to version 0.2.11.
  - Added release notes dated July 31, 2026.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->