### PR TITLE
feat: resolve linked git worktrees to their main repository's session

### DIFF
--- a/plugins/honcho/src/config.ts
+++ b/plugins/honcho/src/config.ts
@@ -1,6 +1,6 @@
 import { homedir } from "os";
-import { join, basename } from "path";
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
+import { join, basename, dirname, resolve } from "path";
+import { existsSync, mkdirSync, readFileSync, statSync, writeFileSync } from "fs";
 import { captureGitState } from "./git.js";
 import { getInstanceIdForCwd, getClaudeInstanceId } from "./cache.js";
 
@@ -712,10 +712,51 @@ export function getClaudeSettingsDir(): string {
   return join(homedir(), ".claude");
 }
 
+/** If dir is the root of a linked git worktree (`.git` is a pointer file, not a
+ *  directory), return the main repository's root by parsing the `gitdir:` line
+ *  (…/main-repo/.git/worktrees/<name>). Returns null for regular repositories. */
+export function resolveWorktreeMainRoot(dir: string): string | null {
+  try {
+    const gitPath = join(dir, ".git");
+    if (!statSync(gitPath).isFile()) return null;
+    const match = readFileSync(gitPath, "utf-8").match(/^gitdir:\s*(.+?)\s*$/m);
+    if (!match) return null;
+    const gitdir = resolve(dir, match[1]);
+    const marker = join("/", ".git", "worktrees") + "/";
+    const idx = gitdir.lastIndexOf(marker);
+    if (idx === -1) return null;
+    return gitdir.slice(0, idx);
+  } catch {
+    return null;
+  }
+}
+
+/** Main repository root when cwd is inside a linked git worktree, else null.
+ *  Walks up from cwd to the nearest `.git` entry before resolving. */
+export function worktreeMainRootFor(cwd: string): string | null {
+  try {
+    let dir = resolve(cwd);
+    for (let i = 0; i < 12; i++) {
+      if (existsSync(join(dir, ".git"))) return resolveWorktreeMainRoot(dir);
+      const parent = dirname(dir);
+      if (parent === dir) break;
+      dir = parent;
+    }
+  } catch {
+    /* ignore */
+  }
+  return null;
+}
+
 export function getSessionForPath(cwd: string): string | null {
   const config = loadConfig();
   if (!config?.sessions) return null;
-  return config.sessions[cwd] || null;
+  if (config.sessions[cwd]) return config.sessions[cwd];
+  // Linked worktree with no mapping of its own: fall through to the main
+  // repository's mapping so all worktrees of a project share one session.
+  const mainRoot = worktreeMainRootFor(cwd);
+  if (mainRoot && config.sessions[mainRoot]) return config.sessions[mainRoot];
+  return null;
 }
 
 export function deriveSessionName(
@@ -777,7 +818,10 @@ export function getSessionName(cwd: string, instanceId?: string): string {
     resolvedInstanceId = instanceId || getInstanceIdForCwd(cwd) || getClaudeInstanceId() || undefined;
   }
 
-  return deriveSessionName(strategy, cwd, {
+  // Linked worktrees derive from the main repository's path so every worktree
+  // of a project shares one session; the branch (git-branch strategy) is still
+  // captured from the worktree's own checkout above.
+  return deriveSessionName(strategy, worktreeMainRootFor(cwd) ?? cwd, {
     peerName: config?.peerName,
     sessionPeerPrefix: config?.sessionPeerPrefix,
     branch,

--- a/plugins/honcho/src/config.ts
+++ b/plugins/honcho/src/config.ts
@@ -727,9 +727,10 @@ export function getClaudeSettingsDir(): string {
   return join(homedir(), ".claude");
 }
 
-/** If dir is the root of a linked git worktree (`.git` is a pointer file, not a
- *  directory), return the main repository's root by parsing the `gitdir:` line
- *  (…/main-repo/.git/worktrees/<name>). Returns null for regular repositories. */
+/** Main repository root for a linked worktree, parsed from dir's `.git`
+ *  pointer file. Handles standard (`<repo>/.git/worktrees/<n>`) and bare-hub
+ *  (`<hub>.git/worktrees/<n>`) layouts; null for regular repositories and
+ *  anything else (submodules, separate-git-dir). */
 export function resolveWorktreeMainRoot(dir: string): string | null {
   try {
     const gitPath = join(dir, ".git");
@@ -737,21 +738,25 @@ export function resolveWorktreeMainRoot(dir: string): string | null {
     const match = readFileSync(gitPath, "utf-8").match(/^gitdir:\s*(.+?)\s*$/m);
     if (!match) return null;
     const gitdir = resolve(dir, match[1]);
-    const marker = join("/", ".git", "worktrees") + "/";
-    const idx = gitdir.lastIndexOf(marker);
+    const idx = gitdir.lastIndexOf(`${sep}worktrees${sep}`);
     if (idx === -1) return null;
-    return gitdir.slice(0, idx);
+    const gitContainer = gitdir.slice(0, idx);
+    if (basename(gitContainer) === ".git") return dirname(gitContainer);
+    if (gitContainer.endsWith(".git")) return gitContainer;
+    return null;
   } catch {
     return null;
   }
 }
 
-/** Main repository root when cwd is inside a linked git worktree, else null.
- *  Walks up from cwd to the nearest `.git` entry before resolving. */
+// Bound on the .git lookup walk; cwds nested deeper keep per-directory naming.
+const MAX_GIT_WALK_UP = 12;
+
+/** Main repository root when cwd is inside a linked git worktree, else null. */
 export function worktreeMainRootFor(cwd: string): string | null {
   try {
     let dir = resolve(cwd);
-    for (let i = 0; i < 12; i++) {
+    for (let i = 0; i < MAX_GIT_WALK_UP; i++) {
       if (existsSync(join(dir, ".git"))) return resolveWorktreeMainRoot(dir);
       const parent = dirname(dir);
       if (parent === dir) break;
@@ -763,14 +768,13 @@ export function worktreeMainRootFor(cwd: string): string | null {
   return null;
 }
 
-export function getSessionForPath(cwd: string): string | null {
+export function getSessionForPath(cwd: string, mainRoot?: string | null): string | null {
   const config = loadConfig();
   if (!config?.sessions) return null;
   if (config.sessions[cwd]) return config.sessions[cwd];
-  // Linked worktree with no mapping of its own: fall through to the main
-  // repository's mapping so all worktrees of a project share one session.
-  const mainRoot = worktreeMainRootFor(cwd);
-  if (mainRoot && config.sessions[mainRoot]) return config.sessions[mainRoot];
+  // Worktrees without a mapping of their own share the main repo's session.
+  const mr = mainRoot === undefined ? worktreeMainRootFor(cwd) : mainRoot;
+  if (mr && config.sessions[mr]) return config.sessions[mr];
   return null;
 }
 
@@ -812,11 +816,12 @@ export function deriveSessionName(
 export function getSessionName(cwd: string, instanceId?: string): string {
   const config = loadConfig();
   const strategy = config?.sessionStrategy ?? "per-directory";
+  const mainRoot = worktreeMainRootFor(cwd);
 
   // Manual overrides only apply to per-directory strategy.
   // For chat-instance and git-branch, the session name is always derived dynamically.
   if (strategy === "per-directory") {
-    const configuredSession = getSessionForPath(cwd);
+    const configuredSession = getSessionForPath(cwd, mainRoot);
     if (configuredSession) {
       return configuredSession;
     }
@@ -833,10 +838,9 @@ export function getSessionName(cwd: string, instanceId?: string): string {
     resolvedInstanceId = instanceId || getInstanceIdForCwd(cwd) || getClaudeInstanceId() || undefined;
   }
 
-  // Linked worktrees derive from the main repository's path so every worktree
-  // of a project shares one session; the branch (git-branch strategy) is still
-  // captured from the worktree's own checkout above.
-  return deriveSessionName(strategy, worktreeMainRootFor(cwd) ?? cwd, {
+  // Worktrees derive from the main repo's path; branch still comes from the
+  // worktree's own checkout above.
+  return deriveSessionName(strategy, mainRoot ?? cwd, {
     peerName: config?.peerName,
     sessionPeerPrefix: config?.sessionPeerPrefix,
     branch,

--- a/plugins/honcho/tests/config-helpers.test.ts
+++ b/plugins/honcho/tests/config-helpers.test.ts
@@ -27,3 +27,83 @@ describe("coerceBoolean", () => {
     expect(coerceBoolean(null)).toBe(false);
   });
 });
+
+describe("worktree main-root resolution", () => {
+  const { mkdtempSync, mkdirSync, writeFileSync, rmSync } = require("fs");
+  const { join } = require("path");
+  const { tmpdir } = require("os");
+  const { resolveWorktreeMainRoot, worktreeMainRootFor } = require("../src/config");
+
+  const makeTmp = () => mkdtempSync(join(tmpdir(), "honcho-wt-"));
+
+  test("linked worktree resolves to the main repository root", () => {
+    const tmp = makeTmp();
+    try {
+      const main = join(tmp, "main-repo");
+      const wt = join(tmp, "worktrees", "feature-x");
+      mkdirSync(join(main, ".git", "worktrees", "feature-x"), { recursive: true });
+      mkdirSync(wt, { recursive: true });
+      writeFileSync(join(wt, ".git"), `gitdir: ${join(main, ".git", "worktrees", "feature-x")}\n`);
+      expect(resolveWorktreeMainRoot(wt)).toBe(main);
+      expect(worktreeMainRootFor(wt)).toBe(main);
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  test("subdirectory of a worktree walks up to the pointer", () => {
+    const tmp = makeTmp();
+    try {
+      const main = join(tmp, "main-repo");
+      const wt = join(tmp, "wt");
+      mkdirSync(join(wt, "src", "deep"), { recursive: true });
+      writeFileSync(join(wt, ".git"), `gitdir: ${join(main, ".git", "worktrees", "wt")}\n`);
+      expect(worktreeMainRootFor(join(wt, "src", "deep"))).toBe(main);
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  test("regular repository (.git directory) returns null", () => {
+    const tmp = makeTmp();
+    try {
+      mkdirSync(join(tmp, ".git"), { recursive: true });
+      expect(resolveWorktreeMainRoot(tmp)).toBeNull();
+      expect(worktreeMainRootFor(tmp)).toBeNull();
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  test("no .git at all returns null", () => {
+    const tmp = makeTmp();
+    try {
+      expect(resolveWorktreeMainRoot(tmp)).toBeNull();
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  test("gitdir pointer outside a worktrees dir (e.g. submodule) returns null", () => {
+    const tmp = makeTmp();
+    try {
+      writeFileSync(join(tmp, ".git"), `gitdir: ${join(tmp, "elsewhere", "modules", "sub")}\n`);
+      expect(resolveWorktreeMainRoot(tmp)).toBeNull();
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  test("relative gitdir pointer resolves against the worktree dir", () => {
+    const tmp = makeTmp();
+    try {
+      const main = join(tmp, "main-repo");
+      const wt = join(tmp, "wt");
+      mkdirSync(wt, { recursive: true });
+      writeFileSync(join(wt, ".git"), "gitdir: ../main-repo/.git/worktrees/wt\n");
+      expect(resolveWorktreeMainRoot(wt)).toBe(main);
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+});

--- a/plugins/honcho/tests/config-helpers.test.ts
+++ b/plugins/honcho/tests/config-helpers.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, test } from "bun:test";
-import { coerceBoolean } from "../src/config";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import { coerceBoolean, resolveWorktreeMainRoot, worktreeMainRootFor } from "../src/config";
 
 describe("coerceBoolean", () => {
   test("passes real booleans through", () => {
@@ -29,11 +32,6 @@ describe("coerceBoolean", () => {
 });
 
 describe("worktree main-root resolution", () => {
-  const { mkdtempSync, mkdirSync, writeFileSync, rmSync } = require("fs");
-  const { join } = require("path");
-  const { tmpdir } = require("os");
-  const { resolveWorktreeMainRoot, worktreeMainRootFor } = require("../src/config");
-
   const makeTmp = () => mkdtempSync(join(tmpdir(), "honcho-wt-"));
 
   test("linked worktree resolves to the main repository root", () => {
@@ -102,6 +100,31 @@ describe("worktree main-root resolution", () => {
       mkdirSync(wt, { recursive: true });
       writeFileSync(join(wt, ".git"), "gitdir: ../main-repo/.git/worktrees/wt\n");
       expect(resolveWorktreeMainRoot(wt)).toBe(main);
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  test("bare-hub worktree (<hub>.git/worktrees/<n>) resolves to the hub", () => {
+    const tmp = makeTmp();
+    try {
+      const hub = join(tmp, "project.git");
+      const wt = join(tmp, "wt");
+      mkdirSync(wt, { recursive: true });
+      writeFileSync(join(wt, ".git"), `gitdir: ${join(hub, "worktrees", "wt")}\n`);
+      expect(resolveWorktreeMainRoot(wt)).toBe(hub);
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  test("separate-git-dir worktree (no .git in gitdir path) returns null", () => {
+    const tmp = makeTmp();
+    try {
+      const wt = join(tmp, "wt");
+      mkdirSync(wt, { recursive: true });
+      writeFileSync(join(wt, ".git"), `gitdir: ${join(tmp, "detached-gitdir", "worktrees", "wt")}\n`);
+      expect(resolveWorktreeMainRoot(wt)).toBeNull();
     } finally {
       rmSync(tmp, { recursive: true, force: true });
     }

--- a/plugins/honcho/tests/worktree-session.test.ts
+++ b/plugins/honcho/tests/worktree-session.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, test } from "bun:test";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+
+// getSessionForPath/getSessionName read ~/.honcho/config.json via a
+// module-level homedir() const, so the integration path runs in a child
+// process with HOME pointed at a fixture.
+function runInSandbox(home: string, script: string): string {
+  const env = Object.fromEntries(
+    Object.entries(process.env).filter(([k]) => !k.startsWith("HONCHO_"))
+  ) as Record<string, string>;
+  const proc = Bun.spawnSync(["bun", "-e", script], {
+    env: { ...env, HOME: home },
+    cwd: join(import.meta.dir, ".."),
+  });
+  if (proc.exitCode !== 0) throw new Error(proc.stderr.toString());
+  return proc.stdout.toString().trim();
+}
+
+describe("worktree session sharing (integration)", () => {
+  test("worktrees share the main repo's mapping and derived name", () => {
+    const home = mkdtempSync(join(tmpdir(), "honcho-home-"));
+    try {
+      const main = join(home, "proj");
+      const wt1 = join(home, "wt1");
+      const wt2 = join(home, "wt2");
+      mkdirSync(join(main, ".git", "worktrees"), { recursive: true });
+      for (const wt of [wt1, wt2]) {
+        mkdirSync(wt, { recursive: true });
+        writeFileSync(join(wt, ".git"), `gitdir: ${join(main, ".git", "worktrees", "x")}\n`);
+      }
+      mkdirSync(join(home, ".honcho"), { recursive: true });
+      writeFileSync(
+        join(home, ".honcho", "config.json"),
+        JSON.stringify({ apiKey: "k", peerName: "t", sessions: { [main]: "shared-session" } })
+      );
+
+      const out = runInSandbox(
+        home,
+        `import { getSessionForPath, getSessionName } from "./src/config.ts";
+         console.log(JSON.stringify({
+           fromWorktree: getSessionForPath(${JSON.stringify(wt1)}),
+           name1: getSessionName(${JSON.stringify(wt1)}),
+           name2: getSessionName(${JSON.stringify(wt2)}),
+           mainName: getSessionName(${JSON.stringify(main)}),
+         }));`
+      );
+      const r = JSON.parse(out);
+      // Main-root mapping is visible from the worktree path
+      expect(r.fromWorktree).toBe("shared-session");
+      expect(r.name1).toBe("shared-session");
+      expect(r.name2).toBe("shared-session");
+      expect(r.mainName).toBe("shared-session");
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  test("without a mapping, worktrees derive the main repo's basename", () => {
+    const home = mkdtempSync(join(tmpdir(), "honcho-home-"));
+    try {
+      const main = join(home, "proj");
+      const wt = join(home, "wt-feature");
+      mkdirSync(join(main, ".git", "worktrees"), { recursive: true });
+      mkdirSync(wt, { recursive: true });
+      writeFileSync(join(wt, ".git"), `gitdir: ${join(main, ".git", "worktrees", "x")}\n`);
+      mkdirSync(join(home, ".honcho"), { recursive: true });
+      writeFileSync(
+        join(home, ".honcho", "config.json"),
+        JSON.stringify({ apiKey: "k", peerName: "t" })
+      );
+
+      const out = runInSandbox(
+        home,
+        `import { getSessionName } from "./src/config.ts";
+         console.log(JSON.stringify({
+           wtName: getSessionName(${JSON.stringify(wt)}),
+           mainName: getSessionName(${JSON.stringify(main)}),
+         }));`
+      );
+      const r = JSON.parse(out);
+      expect(r.wtName).toBe("t-proj");
+      expect(r.wtName).toBe(r.mainName);
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Problem

With the default `per-directory` session strategy, every linked git worktree of a project mints its own Honcho session (named after the worktree directory's basename). For workflows that lean on worktrees — one worktree per feature/eval branch — this fragments a project's memory across many sessions: conclusions recorded while working in one worktree never surface in the next, and the sessions map fills with orphaned one-off entries.

Example from a real config after a few weeks of worktree use:

```
/mnt/data/repos/CallVaultManager                        -> shaun-callvaultmanager
.../workspaces/CallVaultManager/turbot                  -> shaun-turbot
.../workspaces/CallVaultManager/Daily-Report-Evaluations -> shaun-daily-report-evaluations
.../workspaces/CallVaultManager/Job-Queue-Retention-... -> shaun-job-queue-retention-archiving
```

All four are the same project.

## Fix

A linked worktree's `.git` is a pointer **file** (`gitdir: …/main-repo/.git/worktrees/<name>`), so the main repository root is machine-readable. This PR resolves it:

- `resolveWorktreeMainRoot(dir)` — parses the pointer file at a worktree root; returns the main repo root, or `null` for regular repositories (`.git` directory), submodule pointers (no `/.git/worktrees/` segment), or anything unreadable.
- `worktreeMainRootFor(cwd)` — walks up from `cwd` to the nearest `.git` entry first, so subdirectories of a worktree resolve too.
- `getSessionForPath` — when the worktree path has no explicit mapping, falls through to the **main repository's** sessions-map entry.
- `getSessionName` — the default derived name uses the main repo's basename for worktrees (the `git-branch` strategy still captures the branch from the worktree's own checkout).

Session-start's existing `setSessionForPath` call then persists the worktree path against the shared session on first use, so the config stays self-maintaining.

## Behavior unchanged for

- Regular repositories and plain directories (`.git` directory or none): `worktreeMainRootFor` returns `null`, naming falls back to `basename(cwd)` exactly as before.
- Paths with an explicit `sessions` entry: exact-match lookup still wins first.
- Submodules: `gitdir:` pointers without a `/.git/worktrees/` segment are ignored.

## Tests

6 new cases in `tests/config-helpers.test.ts` (worktree root, worktree subdirectory, regular repo, no `.git`, submodule pointer, relative `gitdir:` pointer). Full plugin suite: 10 pass / 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session lookup and naming for Git worktrees.
  * Worktrees now fall back to their main repository’s session mapping while retaining their own branch information.
  * Improved handling of nested, linked, and bare-repository worktrees.

* **Tests**
  * Added coverage for worktree resolution, missing or invalid Git metadata, relative references, and isolated configuration scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->