### PR TITLE
fix: Stop hook re-uploads messages on every wakeup firing

### DIFF
--- a/plugins/honcho/src/hooks/stop.ts
+++ b/plugins/honcho/src/hooks/stop.ts
@@ -18,11 +18,19 @@ interface TranscriptEntry {
   role?: string;
   timestamp?: string;
   isMeta?: boolean;
+  promptSource?: string;
+  origin?: { kind?: string };
   message?: {
     role?: string;
     content: string | Array<{ type: string; text?: string; name?: string; input?: any }>;
   };
   content?: string | Array<{ type: string; text?: string }>;
+}
+
+/** System-injected wakeup (task notification etc.). Not a real prompt, but the Stop
+ *  hook already fired for everything before it, so it ends the previous segment. */
+function isWakeupBoundary(entry: TranscriptEntry): boolean {
+  return entry.promptSource === "system" || entry.origin?.kind === "task-notification";
 }
 
 /** True for a real user-typed prompt. Excludes tool_results, isMeta entries, and `<...>` command caveats. */
@@ -48,8 +56,10 @@ function assistantText(entry: TranscriptEntry): string {
   return "";
 }
 
-/** Assistant text blocks since the last real user prompt (the just-completed turn). */
-function getCurrentTurnAssistantMessages(transcriptPath: string): Array<{ text: string; timestamp?: string }> {
+/** Assistant text blocks of the just-completed segment: everything since the last
+ *  real user prompt OR wakeup boundary. Wakeup firings would otherwise re-collect
+ *  the whole accumulated turn, duplicating blocks already uploaded. */
+export function getCurrentTurnAssistantMessages(transcriptPath: string): Array<{ text: string; timestamp?: string }> {
   if (!transcriptPath || !existsSync(transcriptPath)) return [];
 
   let lines: string[];
@@ -59,12 +69,12 @@ function getCurrentTurnAssistantMessages(transcriptPath: string): Array<{ text: 
     return [];
   }
 
-  // Walk back to the last real user prompt — the start of the current turn.
+  // Walk back to the last real user prompt or wakeup — the start of the current segment.
   let lastPromptIdx = -1;
   for (let i = lines.length - 1; i >= 0; i--) {
     try {
       const entry: TranscriptEntry = JSON.parse(lines[i]);
-      if ((entry.type || entry.role) === "user" && isRealUserPrompt(entry)) {
+      if ((entry.type || entry.role) === "user" && (isRealUserPrompt(entry) || isWakeupBoundary(entry))) {
         lastPromptIdx = i;
         break;
       }

--- a/plugins/honcho/tests/stop-boundary.test.ts
+++ b/plugins/honcho/tests/stop-boundary.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, test } from "bun:test";
+import { mkdtempSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { getCurrentTurnAssistantMessages } from "../src/hooks/stop";
+
+function transcript(lines: object[]): string {
+  const path = join(mkdtempSync(join(tmpdir(), "stop-test-")), "t.jsonl");
+  writeFileSync(path, lines.map((l) => JSON.stringify(l)).join("\n"));
+  return path;
+}
+
+const prompt = { type: "user", message: { content: "do the thing" } };
+const wakeup = {
+  type: "user",
+  promptSource: "system",
+  origin: { kind: "task-notification" },
+  message: { content: "<task-notification>agent done</task-notification>" },
+};
+const toolResult = { type: "user", message: { content: [{ type: "tool_result", content: "file contents" }] } };
+const msgA = { type: "assistant", timestamp: "t1", message: { content: [{ type: "text", text: "narration A" }] } };
+const msgB = { type: "assistant", timestamp: "t2", message: { content: [{ type: "text", text: "narration B" }] } };
+
+describe("getCurrentTurnAssistantMessages segment boundaries", () => {
+  test("first firing collects the whole turn", () => {
+    const path = transcript([prompt, msgA]);
+    expect(getCurrentTurnAssistantMessages(path).map((b) => b.text)).toEqual(["narration A"]);
+  });
+
+  test("wakeup firing collects only blocks after the wakeup", () => {
+    const path = transcript([prompt, msgA, wakeup, msgB]);
+    expect(getCurrentTurnAssistantMessages(path).map((b) => b.text)).toEqual(["narration B"]);
+  });
+
+  test("multiple wakeups: only the latest segment", () => {
+    const path = transcript([prompt, msgA, wakeup, msgB, wakeup, { ...msgA, message: { content: [{ type: "text", text: "final" }] } }]);
+    expect(getCurrentTurnAssistantMessages(path).map((b) => b.text)).toEqual(["final"]);
+  });
+
+  test("origin.kind alone marks a boundary", () => {
+    const bare = { type: "user", origin: { kind: "task-notification" }, message: { content: "<task-notification/>" } };
+    const path = transcript([prompt, msgA, bare, msgB]);
+    expect(getCurrentTurnAssistantMessages(path).map((b) => b.text)).toEqual(["narration B"]);
+  });
+
+  test("tool_result user entries do not end the segment", () => {
+    const path = transcript([prompt, msgA, toolResult, msgB]);
+    expect(getCurrentTurnAssistantMessages(path).map((b) => b.text)).toEqual(["narration A", "narration B"]);
+  });
+
+  test("no prompt and no wakeup collects nothing", () => {
+    const path = transcript([toolResult, msgA]);
+    expect(getCurrentTurnAssistantMessages(path)).toEqual([]);
+  });
+});


### PR DESCRIPTION
In sessions with background agents, every task-notification wakeup fires the Stop hook. Wakeups don't count as real user prompts, so each firing walked back to the same turn boundary and re-uploaded the whole accumulated turn.

## Fix

- Every block uploads exactly once; the final wakeup segment (with the actual answer from the sub agent) is kept.
- Stateless (no marker files, no state.ts changes, nothing to clean up at SessionEnd.)
- Intermediate wakeup segments are still tagged `assistant_intermediate` vs `assistant_response`, so they're filterable

Why not drop wakeup-segment messages entirely? at fire time a stop can't know whether it's an intermediate wakeup or the last one (which contains helpful information from the subagent.)