### PR TITLE
fix(mcp): keep session overrides on naming-config changes (sticky default)

### DIFF
--- a/plugins/honcho/src/mcp/server.ts
+++ b/plugins/honcho/src/mcp/server.ts
@@ -341,7 +341,7 @@ function handleSetConfig(args: Record<string, unknown>) {
       saveRootField("peerName", cfg.peerName);
       clearPeerCache();
       clearUserContextOnly();
-      if (Object.keys(cfg.sessions ?? {}).length > 0) {
+      if (String(value) !== String(previousValue) && Object.keys(cfg.sessions ?? {}).length > 0) {
         warnings.push(`${Object.keys(cfg.sessions ?? {}).length} session override(s) kept under their existing names; only newly created sessions use the new naming. Use sessions.set/sessions.remove to adjust individual mappings.`);
       }
       cacheInvalidation = { cleared: ["peer IDs", "user context"], reason: "Peer name changed" };
@@ -395,24 +395,27 @@ function handleSetConfig(args: Record<string, unknown>) {
       cacheInvalidation = { cleared: ["all IDs", "all context"], reason: "Endpoint URL changed" };
       break;
 
-    case "sessionStrategy":
-      previousValue = cfg.sessionStrategy ?? "per-directory";
+    case "sessionStrategy": {
+      const prevStrategy = cfg.sessionStrategy ?? "per-directory";
+      previousValue = prevStrategy;
       cfg.sessionStrategy = String(value) as SessionStrategy;
       // Session overrides are kept: they only apply under per-directory,
       // so they go dormant on other strategies rather than becoming stale.
-      if (String(value) !== "per-directory" && Object.keys(cfg.sessions ?? {}).length > 0) {
+      if (String(value) !== prevStrategy && String(value) !== "per-directory" && Object.keys(cfg.sessions ?? {}).length > 0) {
         warnings.push(`${Object.keys(cfg.sessions ?? {}).length} session override(s) kept but inactive: overrides only apply under the per-directory strategy.`);
       }
       break;
+    }
 
-    case "sessionPeerPrefix":
-      previousValue = cfg.sessionPeerPrefix !== false;
+    case "sessionPeerPrefix": {
+      const prevPrefix = cfg.sessionPeerPrefix !== false;
+      previousValue = prevPrefix;
       cfg.sessionPeerPrefix = coerceBoolean(value);
-      if (Object.keys(cfg.sessions ?? {}).length > 0) {
+      if (cfg.sessionPeerPrefix !== prevPrefix && Object.keys(cfg.sessions ?? {}).length > 0) {
         warnings.push(`${Object.keys(cfg.sessions ?? {}).length} session override(s) kept under their existing names; only newly created sessions use the new naming. Use sessions.set/sessions.remove to adjust individual mappings.`);
       }
       break;
-
+    }
 
     case "globalOverride":
       previousValue = cfg.globalOverride ?? false;

--- a/plugins/honcho/src/mcp/server.ts
+++ b/plugins/honcho/src/mcp/server.ts
@@ -341,9 +341,10 @@ function handleSetConfig(args: Record<string, unknown>) {
       saveRootField("peerName", cfg.peerName);
       clearPeerCache();
       clearUserContextOnly();
-      // Clear persisted session names — they embed the peer name
-      cfg.sessions = {};
-      cacheInvalidation = { cleared: ["peer IDs", "user context", "session overrides"], reason: "Peer name changed" };
+      if (Object.keys(cfg.sessions ?? {}).length > 0) {
+        warnings.push(`${Object.keys(cfg.sessions ?? {}).length} session override(s) kept under their existing names; only newly created sessions use the new naming. Use sessions.set/sessions.remove to adjust individual mappings.`);
+      }
+      cacheInvalidation = { cleared: ["peer IDs", "user context"], reason: "Peer name changed" };
       break;
 
     case "aiPeer":
@@ -397,15 +398,19 @@ function handleSetConfig(args: Record<string, unknown>) {
     case "sessionStrategy":
       previousValue = cfg.sessionStrategy ?? "per-directory";
       cfg.sessionStrategy = String(value) as SessionStrategy;
-      // Clear persisted session names — they were derived under the old strategy
-      cfg.sessions = {};
+      // Session overrides are kept: they only apply under per-directory,
+      // so they go dormant on other strategies rather than becoming stale.
+      if (String(value) !== "per-directory" && Object.keys(cfg.sessions ?? {}).length > 0) {
+        warnings.push(`${Object.keys(cfg.sessions ?? {}).length} session override(s) kept but inactive: overrides only apply under the per-directory strategy.`);
+      }
       break;
 
     case "sessionPeerPrefix":
       previousValue = cfg.sessionPeerPrefix !== false;
       cfg.sessionPeerPrefix = coerceBoolean(value);
-      // Clear persisted session names — they embed the old prefix
-      cfg.sessions = {};
+      if (Object.keys(cfg.sessions ?? {}).length > 0) {
+        warnings.push(`${Object.keys(cfg.sessions ?? {}).length} session override(s) kept under their existing names; only newly created sessions use the new naming. Use sessions.set/sessions.remove to adjust individual mappings.`);
+      }
       break;
 
 

--- a/plugins/honcho/src/mcp/server.ts
+++ b/plugins/honcho/src/mcp/server.ts
@@ -399,8 +399,7 @@ function handleSetConfig(args: Record<string, unknown>) {
       const prevStrategy = cfg.sessionStrategy ?? "per-directory";
       previousValue = prevStrategy;
       cfg.sessionStrategy = String(value) as SessionStrategy;
-      // Session overrides are kept: they only apply under per-directory,
-      // so they go dormant on other strategies rather than becoming stale.
+      // Session overrides are kept: they only apply under per-directory (useless for chat-instance, and git-branch needs a different solution)
       if (String(value) !== prevStrategy && String(value) !== "per-directory" && Object.keys(cfg.sessions ?? {}).length > 0) {
         warnings.push(`${Object.keys(cfg.sessions ?? {}).length} session override(s) kept but inactive: overrides only apply under the per-directory strategy.`);
       }


### PR DESCRIPTION
## Summary

Implements the sticky-default: `set_config` no longer wipes the `sessions` map on `peerName` / `sessionStrategy` / `sessionPeerPrefix` changes.

The wipe's premise was wrong: the `sessions` map holds **explicit user overrides** ("this directory maps to this exact name"), not a cache of derived names. A naming-convention change doesn't invalidate them. Changing them silently orphans every mapping while server-side history sat under names nothing pointed to.

New behavior per field:
- **peerName / sessionPeerPrefix**: map untouched; response warns "N session override(s) kept under their existing names; only newly created sessions use the new naming" and points at `sessions.set`/`sessions.remove`.
- **sessionStrategy**: map untouched; overrides only apply under `per-directory`, so they go dormant on other strategies rather than stale. Warns they're kept-but-inactive when switching away.

I suspect the best solution going forward is for Honcho to support server-side session renames. But until this solution is better then the current overwriting strategy. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Session naming overrides are preserved when naming settings change.
  * Existing sessions retain their current names; updated naming settings apply to new sessions where applicable.
  * Added clearer warnings when changes are inactive or do not affect existing sessions.
  * Improved notifications about refreshed peer and user-context information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->