### PR TITLE
feat: redact secrets from tool-capture summaries, drop claude-context.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ All configuration lives in a single global file at `~/.honcho/config.json`. You 
   },
 
   // Miscellaneous
-  "localContext": { "maxEntries": 50 }, // Max entries in claude-context.md
+  "redactPatterns": [],               // Extra regexes redacted from tool summaries (additive to built-in secret patterns)
   "enabled": true,
   "logging": true,
 

--- a/plugins/honcho/src/cache.ts
+++ b/plugins/honcho/src/cache.ts
@@ -1,12 +1,11 @@
 import { homedir } from "os";
 import { join } from "path";
 import { existsSync, readFileSync, writeFileSync, mkdirSync } from "fs";
-import { getContextRefreshConfig, getLocalContextConfig } from "./config.js";
+import { getContextRefreshConfig } from "./config.js";
 
 const CACHE_DIR = join(homedir(), ".honcho");
 const ID_CACHE_FILE = join(CACHE_DIR, "cache.json");
 const CONTEXT_CACHE_FILE = join(CACHE_DIR, "context-cache.json");
-const CLAUDE_CONTEXT_FILE = join(CACHE_DIR, "claude-context.md");
 
 // Ensure cache directory exists
 function ensureCacheDir(): void {
@@ -197,58 +196,6 @@ export function resetMessageCount(): void {
 }
 
 // ============================================
-// CLAUDE Context File - self-summary
-// ============================================
-
-export function getClaudeContextPath(): string {
-  return CLAUDE_CONTEXT_FILE;
-}
-
-export function loadClaudeLocalContext(): string {
-  ensureCacheDir();
-  if (!existsSync(CLAUDE_CONTEXT_FILE)) {
-    return "";
-  }
-  try {
-    return readFileSync(CLAUDE_CONTEXT_FILE, "utf-8");
-  } catch {
-    return "";
-  }
-}
-
-export function saveClaudeLocalContext(content: string): void {
-  ensureCacheDir();
-  writeFileSync(CLAUDE_CONTEXT_FILE, content);
-}
-
-export function appendClaudeWork(workDescription: string): void {
-  ensureCacheDir();
-  const timestamp = new Date().toISOString();
-  const entry = `\n- [${timestamp}] ${workDescription}`;
-
-  let existing = loadClaudeLocalContext();
-  if (!existing) {
-    existing = `# CLAUDE Work Context\n\nAuto-generated log of CLAUDE's recent work.\n\n## Recent Activity\n`;
-  }
-
-  // Keep only last N entries to prevent file from growing too large
-  let maxEntries = getLocalContextConfig().maxEntries;
-  if (!maxEntries) {
-    maxEntries = 10;
-  }
-  const lines = existing.split("\n");
-  const activityStart = lines.findIndex((l) => l.includes("## Recent Activity"));
-  if (activityStart !== -1) {
-    const header = lines.slice(0, activityStart + 1);
-    const activities = lines.slice(activityStart + 1).filter((l) => l.trim());
-    const recentActivities = activities.slice(-(maxEntries - 1)); // Keep last N-1, add 1 new
-    existing = [...header, ...recentActivities].join("\n");
-  }
-
-  saveClaudeLocalContext(existing + entry);
-}
-
-// ============================================
 // Git State Cache - track git state per directory
 // ============================================
 
@@ -436,7 +383,6 @@ export function clearAllCaches(): void {
   if (existsSync(ID_CACHE_FILE)) writeFileSync(ID_CACHE_FILE, "{}");
   if (existsSync(CONTEXT_CACHE_FILE)) writeFileSync(CONTEXT_CACHE_FILE, "{}");
   if (existsSync(GIT_STATE_FILE)) writeFileSync(GIT_STATE_FILE, "{}");
-  // Don't clear claude-context.md - that's valuable history
 }
 
 /** Clear only the ID cache (workspace, peer, session IDs) */

--- a/plugins/honcho/src/config.ts
+++ b/plugins/honcho/src/config.ts
@@ -27,11 +27,6 @@ export interface ContextRefreshConfig {
   skipDialectic?: boolean;
 }
 
-export interface LocalContextConfig {
-  /** Max entries in claude-context.md (default: 50) */
-  maxEntries?: number;
-}
-
 // ============================================
 // Composable injection (DEV-2088 + DEV-2024)
 // ============================================
@@ -197,7 +192,8 @@ export interface HostConfig {
   observationMode?: ObservationMode;
   messageUpload?: MessageUploadConfig;
   contextRefresh?: ContextRefreshConfig;
-  localContext?: LocalContextConfig;
+  /** Extra regex patterns redacted from tool summaries (additive to built-in defaults) */
+  redactPatterns?: string[];
   endpoint?: HonchoEndpointConfig;
   /** Composable injection config (session-start + per-turn component menus). */
   injection?: InjectionConfig;
@@ -307,7 +303,8 @@ interface HonchoFileConfig {
   messageUpload?: MessageUploadConfig;
   contextRefresh?: ContextRefreshConfig;
   endpoint?: HonchoEndpointConfig;
-  localContext?: LocalContextConfig;
+  /** Extra regex patterns redacted from tool summaries (additive to built-in defaults) */
+  redactPatterns?: string[];
   enabled?: boolean;
   logging?: boolean;
   sessionStrategy?: SessionStrategy;
@@ -374,8 +371,8 @@ export interface HonchoCLAUDEConfig {
   contextRefresh?: ContextRefreshConfig;
   /** SaaS vs local instance config */
   endpoint?: HonchoEndpointConfig;
-  /** Local claude-context.md settings */
-  localContext?: LocalContextConfig;
+  /** Extra regex patterns redacted from tool summaries (additive to built-in defaults) */
+  redactPatterns?: string[];
   /** Composable injection config (session-start + per-turn component menus) */
   injection?: InjectionConfig;
   /** Register the on-demand `honcho_remember` MCP tool (default: false).
@@ -516,7 +513,7 @@ function resolveConfig(raw: HonchoFileConfig, host: HonchoHost): HonchoCLAUDECon
     messageUpload: hostBlock?.messageUpload ?? raw.messageUpload,
     contextRefresh: hostBlock?.contextRefresh ?? raw.contextRefresh,
     endpoint: hostBlock?.endpoint ?? raw.endpoint,
-    localContext: hostBlock?.localContext ?? raw.localContext,
+    redactPatterns: hostBlock?.redactPatterns ?? raw.redactPatterns,
     injection: hostBlock?.injection ?? raw.injection,
     rememberTool: hostBlock?.rememberTool ?? raw.rememberTool,
     enabled: hostBlock?.enabled ?? raw.enabled,
@@ -680,7 +677,7 @@ export function saveConfig(config: HonchoCLAUDEConfig): void {
   setHostIfExplicit("observationMode", config.observationMode, existing.observationMode);
   setHostIfExplicit("messageUpload", config.messageUpload, existing.messageUpload);
   setHostIfExplicit("contextRefresh", config.contextRefresh, existing.contextRefresh);
-  setHostIfExplicit("localContext", config.localContext, existing.localContext);
+  setHostIfExplicit("redactPatterns", config.redactPatterns, existing.redactPatterns);
   setHostIfExplicit("endpoint", config.endpoint, existing.endpoint);
   setHostIfExplicit("injection", config.injection, existing.injection);
   setHostIfExplicit("rememberTool", config.rememberTool, existing.rememberTool);
@@ -885,13 +882,6 @@ export function getContextRefreshConfig(): ContextRefreshConfig {
     messageThreshold: config?.contextRefresh?.messageThreshold ?? 30,
     ttlSeconds: config?.contextRefresh?.ttlSeconds ?? 300,
     skipDialectic: config?.contextRefresh?.skipDialectic ?? false,
-  };
-}
-
-export function getLocalContextConfig(): LocalContextConfig {
-  const config = loadConfig();
-  return {
-    maxEntries: config?.localContext?.maxEntries ?? 50,
   };
 }
 

--- a/plugins/honcho/src/hooks/post-tool-use.ts
+++ b/plugins/honcho/src/hooks/post-tool-use.ts
@@ -1,7 +1,8 @@
 import { Honcho } from "@honcho-ai/sdk";
 import { loadConfig, getSessionForPath, getSessionName, getHonchoClientOptions, isPluginEnabled, getCachedStdin, readStdinText } from "../config.js";
-import { appendClaudeWork, getClaudeInstanceId } from "../cache.js";
+import { getClaudeInstanceId } from "../cache.js";
 import { logHook, logApiCall, setLogContext } from "../log.js";
+import { redactSecrets } from "../redact.js";
 import { visCapture } from "../visual.js";
 
 
@@ -218,12 +219,13 @@ export async function handlePostToolUse(): Promise<void> {
     process.exit(0);
   }
 
-  const summary = formatToolSummary(toolName, toolInput, toolResponse);
+  // Redact before fan-out so every sink (UI, log, upload) gets the safe copy.
+  const summary = redactSecrets(
+    formatToolSummary(toolName, toolInput, toolResponse),
+    config.redactPatterns
+  );
   logHook("post-tool-use", summary, { tool: toolName });
   visCapture(summary);
-
-  // INSTANT: Update local claude context file (~2ms)
-  appendClaudeWork(summary);
 
   // Upload to Honcho and wait for completion
   await logToHonchoAsync(config, cwd, summary).catch((e) => logHook("post-tool-use", `Upload failed: ${e}`, { error: String(e) }));

--- a/plugins/honcho/src/hooks/post-tool-use.ts
+++ b/plugins/honcho/src/hooks/post-tool-use.ts
@@ -219,7 +219,6 @@ export async function handlePostToolUse(): Promise<void> {
     process.exit(0);
   }
 
-  // Redact before fan-out so every sink (UI, log, upload) gets the safe copy.
   const summary = redactSecrets(
     formatToolSummary(toolName, toolInput, toolResponse),
     config.redactPatterns

--- a/plugins/honcho/src/mcp/server.ts
+++ b/plugins/honcho/src/mcp/server.ts
@@ -34,6 +34,7 @@ import {
   getObservationMode,
   getPluginVersion,
 } from "../config.js";
+import { validateRedactPattern } from "../redact.js";
 import { honchoSessionUrl } from "../styles.js";
 import {
   getLastActiveCwd,
@@ -118,7 +119,7 @@ function handleGetConfig(cwd: string) {
     reasoningLevel: cfg.reasoningLevel ?? "medium",
     observationMode: cfg.observationMode ?? "unified",
     statusline: cfg.statusline ?? "on",
-    localContext: cfg.localContext ?? {},
+    redactPatterns: cfg.redactPatterns ?? [],
     injection: cfg.injection ?? {},
     rememberTool: cfg.rememberTool === true,
     enabled: cfg.enabled !== false,
@@ -499,11 +500,27 @@ function handleSetConfig(args: Record<string, unknown>) {
       break;
     }
 
-    case "localContext.maxEntries":
-      previousValue = cfg.localContext?.maxEntries;
-      if (!cfg.localContext) cfg.localContext = {};
-      cfg.localContext.maxEntries = Number(value);
+    case "redactPatterns": {
+      const arr = coerceStringArray(value);
+      if (!arr) {
+        return {
+          content: [{ type: "text", text: JSON.stringify({ success: false, error: "redactPatterns must be an array of regex strings" }, null, 2) }],
+          isError: true,
+        };
+      }
+      for (const source of arr) {
+        const err = validateRedactPattern(source);
+        if (err) {
+          return {
+            content: [{ type: "text", text: JSON.stringify({ success: false, error: err }, null, 2) }],
+            isError: true,
+          };
+        }
+      }
+      previousValue = cfg.redactPatterns;
+      cfg.redactPatterns = arr;
       break;
+    }
 
     case "injection.sessionStart": {
       const arr = validateComponentArray(value, SESSION_START_COMPONENTS, field);
@@ -663,7 +680,7 @@ function handleSetConfig(args: Record<string, unknown>) {
     reasoningLevel: cfg.reasoningLevel ?? "medium",
     observationMode: cfg.observationMode ?? "unified",
     statusline: cfg.statusline ?? "on",
-    localContext: cfg.localContext ?? {},
+    redactPatterns: cfg.redactPatterns ?? [],
     injection: cfg.injection ?? {},
     rememberTool: cfg.rememberTool === true,
     enabled: cfg.enabled !== false,
@@ -948,7 +965,7 @@ export async function runMcpServer(): Promise<void> {
                   "contextRefresh.skipDialectic",
                   "reasoningLevel",
                   "observationMode",
-                  "localContext.maxEntries",
+                  "redactPatterns",
                   "injection.sessionStart",
                   "injection.perTurn",
                   "injection.showContents",
@@ -965,7 +982,7 @@ export async function runMcpServer(): Promise<void> {
                 ],
               },
               value: {
-                description: "New value. For sessions.set: {path, name}. For sessions.remove: {path}. For injection.sessionStart / injection.perTurn / injection.showContents: a string array of component names (e.g. [\"summary\",\"peerCard\"]).",
+                description: "New value. For sessions.set: {path, name}. For sessions.remove: {path}. For injection.sessionStart / injection.perTurn / injection.showContents: a string array of component names (e.g. [\"summary\",\"peerCard\"]). For redactPatterns: a string array of regexes redacted from tool summaries in addition to the built-in secret patterns.",
               },
               confirm: {
                 type: "boolean",

--- a/plugins/honcho/src/redact.ts
+++ b/plugins/honcho/src/redact.ts
@@ -1,9 +1,7 @@
 /**
  * Best-effort secret redaction for tool-capture summaries.
- * Applied once where the summary string is created (post-tool-use), so every
- * sink — UI systemMessage, activity log, Honcho upload — gets the safe copy.
- * Regex redaction is harm reduction, not a guarantee: novel secret formats
- * pass through. Users extend the defaults via the `redactPatterns` config.
+ * Regex-based, so novel secret formats pass through; users extend the
+ * defaults via the `redactPatterns` config.
  */
 
 interface RedactRule {
@@ -32,9 +30,9 @@ const DEFAULT_RULES: RedactRule[] = [
     pattern: /([a-z][a-z0-9+.-]*:\/\/[^/\s:@]+:)[^@\s]+@/gi,
     replacement: "$1***@",
   },
-  // Well-known token shapes: AWS, OpenAI/Anthropic-style sk-, GitHub, Slack, GitLab, npm
+  // Well-known token shapes: Honcho, AWS, OpenAI/Anthropic-style sk-, GitHub, Slack, GitLab, npm
   {
-    pattern: /\b(?:AKIA[0-9A-Z]{16}|sk-[A-Za-z0-9_-]{16,}|(?:ghp|gho|ghu|ghs|ghr)_[A-Za-z0-9]{20,}|github_pat_[A-Za-z0-9_]{20,}|xox[baprs]-[A-Za-z0-9-]{10,}|glpat-[A-Za-z0-9_-]{20,}|npm_[A-Za-z0-9]{36})\b/g,
+    pattern: /\b(?:hch[_-]?[A-Za-z0-9_-]{16,}|AKIA[0-9A-Z]{16}|sk-[A-Za-z0-9_-]{16,}|(?:ghp|gho|ghu|ghs|ghr)_[A-Za-z0-9]{20,}|github_pat_[A-Za-z0-9_]{20,}|xox[baprs]-[A-Za-z0-9-]{10,}|glpat-[A-Za-z0-9_-]{20,}|npm_[A-Za-z0-9]{36})\b/g,
     replacement: "***",
   },
 ];

--- a/plugins/honcho/src/redact.ts
+++ b/plugins/honcho/src/redact.ts
@@ -1,0 +1,74 @@
+/**
+ * Best-effort secret redaction for tool-capture summaries.
+ * Applied once where the summary string is created (post-tool-use), so every
+ * sink — UI systemMessage, activity log, Honcho upload — gets the safe copy.
+ * Regex redaction is harm reduction, not a guarantee: novel secret formats
+ * pass through. Users extend the defaults via the `redactPatterns` config.
+ */
+
+interface RedactRule {
+  pattern: RegExp;
+  replacement: string;
+}
+
+const DEFAULT_RULES: RedactRule[] = [
+  // KEY=value assignments with a secret-bearing key (PGPASSWORD=..., AWS_SECRET_ACCESS_KEY=...)
+  {
+    pattern: /\b(\w*(?:PASSWORD|PASSWD|PWD|SECRET|TOKEN|API_?KEY|ACCESS_KEY|CREDENTIALS?)\w*)\s*=\s*("[^"]*"|'[^']*'|[^\s;|&"']+)/gi,
+    replacement: "$1=***",
+  },
+  // --password / --token style CLI flags
+  {
+    pattern: /(--(?:password|passwd|pwd|token|api-?key|secret|auth)[= ])(?:"[^"]*"|'[^']*'|[^\s;|&"']+)/gi,
+    replacement: "$1***",
+  },
+  // Authorization headers
+  {
+    pattern: /(authorization:\s*(?:bearer|basic|token)\s+)[^\s"']+/gi,
+    replacement: "$1***",
+  },
+  // Credentials embedded in URLs (scheme://user:pass@host)
+  {
+    pattern: /([a-z][a-z0-9+.-]*:\/\/[^/\s:@]+:)[^@\s]+@/gi,
+    replacement: "$1***@",
+  },
+  // Well-known token shapes: AWS, OpenAI/Anthropic-style sk-, GitHub, Slack, GitLab, npm
+  {
+    pattern: /\b(?:AKIA[0-9A-Z]{16}|sk-[A-Za-z0-9_-]{16,}|(?:ghp|gho|ghu|ghs|ghr)_[A-Za-z0-9]{20,}|github_pat_[A-Za-z0-9_]{20,}|xox[baprs]-[A-Za-z0-9-]{10,}|glpat-[A-Za-z0-9_-]{20,}|npm_[A-Za-z0-9]{36})\b/g,
+    replacement: "***",
+  },
+];
+
+/**
+ * Validate a user-supplied pattern string. Returns an error message, or null
+ * if it compiles. Used by set_config so bad regexes are rejected at write time.
+ */
+export function validateRedactPattern(source: string): string | null {
+  try {
+    new RegExp(source);
+    return null;
+  } catch (e) {
+    return `Invalid regex ${JSON.stringify(source)}: ${e instanceof Error ? e.message : String(e)}`;
+  }
+}
+
+/**
+ * Redact secrets from `text`. `extraPatterns` (from config `redactPatterns`)
+ * are additive to the built-in defaults; matches are replaced whole with ***.
+ * Patterns that fail to compile are skipped — set_config validates on write,
+ * so this only guards hand-edited config files.
+ */
+export function redactSecrets(text: string, extraPatterns?: string[]): string {
+  let result = text;
+  for (const rule of DEFAULT_RULES) {
+    result = result.replace(rule.pattern, rule.replacement);
+  }
+  for (const source of extraPatterns ?? []) {
+    try {
+      result = result.replace(new RegExp(source, "gi"), "***");
+    } catch {
+      continue;
+    }
+  }
+  return result;
+}

--- a/plugins/honcho/tests/redact.test.ts
+++ b/plugins/honcho/tests/redact.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, test } from "bun:test";
+import { redactSecrets, validateRedactPattern } from "../src/redact";
+
+describe("redactSecrets defaults", () => {
+  test("env-var assignments with secret-bearing keys", () => {
+    expect(redactSecrets('Ran: export PGPASSWORD=SuperSecret123; psql -h 127.0.0.1 (success)'))
+      .toBe('Ran: export PGPASSWORD=***; psql -h 127.0.0.1 (success)');
+    expect(redactSecrets('AWS_SECRET_ACCESS_KEY=abc/def+123'))
+      .toBe('AWS_SECRET_ACCESS_KEY=***');
+    expect(redactSecrets('MYSQL_PWD="hunter two"'))
+      .toBe('MYSQL_PWD=***');
+    expect(redactSecrets('api_key=xyz'))
+      .toBe('api_key=***');
+  });
+
+  test("--password / --token style flags", () => {
+    expect(redactSecrets('mysql --password=hunter2 -u root'))
+      .toBe('mysql --password=*** -u root');
+    expect(redactSecrets('deploy --token abc123'))
+      .toBe('deploy --token ***');
+    expect(redactSecrets('curl --api-key=xyz'))
+      .toBe('curl --api-key=***');
+  });
+
+  test("Authorization headers", () => {
+    expect(redactSecrets('curl -H "Authorization: Bearer eyJhbGciOi"'))
+      .toBe('curl -H "Authorization: Bearer ***"');
+  });
+
+  test("credentials embedded in URLs", () => {
+    expect(redactSecrets('psql postgres://app:s3cret@db.host:5432/prod'))
+      .toBe('psql postgres://app:***@db.host:5432/prod');
+  });
+
+  test("well-known token shapes", () => {
+    expect(redactSecrets('AKIAIOSFODNN7EXAMPLE in output')).toBe('*** in output');
+    expect(redactSecrets('gh auth ghp_abcdefghijklmnopqrstuvwx')).toBe('gh auth ***');
+    expect(redactSecrets('key sk-ant-api03-abcdefghijklmnop')).toBe('key ***');
+    expect(redactSecrets('xoxb-1234567890-abcdefghij')).toBe('***');
+  });
+
+  test("does not mangle ordinary commands", () => {
+    expect(redactSecrets('mkdir -p src/hooks && bun test')).toBe('mkdir -p src/hooks && bun test');
+    expect(redactSecrets('find . -print -prune')).toBe('find . -print -prune');
+    expect(redactSecrets('Edited config.ts: changed: localContext')).toBe('Edited config.ts: changed: localContext');
+    expect(redactSecrets('PATH=/usr/bin ls')).toBe('PATH=/usr/bin ls');
+  });
+});
+
+describe("redactSecrets custom patterns", () => {
+  test("user patterns are additive and replace whole match", () => {
+    expect(redactSecrets('conn acme-internal-abc123 ok', ['acme-internal-\\w+']))
+      .toBe('conn *** ok');
+  });
+
+  test("invalid user patterns are skipped, defaults still apply", () => {
+    expect(redactSecrets('PGPASSWORD=x', ['[unclosed']))
+      .toBe('PGPASSWORD=***');
+  });
+});
+
+describe("validateRedactPattern", () => {
+  test("accepts valid regex", () => {
+    expect(validateRedactPattern('foo\\d+')).toBeNull();
+  });
+
+  test("rejects invalid regex with message", () => {
+    expect(validateRedactPattern('[unclosed')).toContain("Invalid regex");
+  });
+});

--- a/plugins/honcho/tests/redact.test.ts
+++ b/plugins/honcho/tests/redact.test.ts
@@ -33,6 +33,7 @@ describe("redactSecrets defaults", () => {
   });
 
   test("well-known token shapes", () => {
+    expect(redactSecrets('hch_abcdefghijklmnop1234 in output')).toBe('*** in output');
     expect(redactSecrets('AKIAIOSFODNN7EXAMPLE in output')).toBe('*** in output');
     expect(redactSecrets('gh auth ghp_abcdefghijklmnopqrstuvwx')).toBe('gh auth ***');
     expect(redactSecrets('key sk-ant-api03-abcdefghijklmnop')).toBe('key ***');


### PR DESCRIPTION
Fixes plastic-labs/claude-honcho#81.

* **Configurable:** new `redactPatterns` config array, additive to the defaults. `set_config redactPatterns` validates each regex compiles; invalid patterns are skipped so the hook never crashes.
* **Built-in patterns**: secret-bearing `KEY=value` assignments (`PGPASSWORD=…`, `AWS_SECRET_ACCESS_KEY=…`), `--password`/`--token`-style flags, `Authorization: Bearer/Basic/token` headers, credentials in URLs, and well-known token shapes (AKIA, sk-, ghp\_/github_pat\_, xox, glpat-, npm\_). Value = `***` and key names stay readable.
* `~/.honcho/claude-context.md` **removed entirely.** It has been write-only since plastic-labs/claude-honcho#79 (nothing reads it) so just removing all writing to it.

## Notes

* Redaction is best-effort, but unusual secret formats can still get saved, but its configurable 🤷‍♀️
* Existing `claude-context.md` files on disk stop getting added but are not deleted.

## Summary by CodeRabbit

* **New Features**
  * Added automatic redaction of common secrets from captured tool summaries.
  * Added support for custom regular-expression redaction patterns.
  * Added validation and configuration support for redaction patterns.
* **Bug Fixes**
  * Prevented credentials, authorization headers, tokens, and secret assignments from being exposed in summaries.
  * Invalid custom patterns are safely ignored while built-in protections remain active.
* **Documentation**
  * Updated configuration examples to use `redactPatterns`.