### PR TITLE
feat(mcp): search conclusions via search tool + add query_conclusions

### DIFF
--- a/plugins/honcho/src/mcp/server.ts
+++ b/plugins/honcho/src/mcp/server.ts
@@ -1090,10 +1090,6 @@ export async function runMcpServer(): Promise<void> {
           const query = args?.query as string;
           const limit = (args?.limit as number) ?? 10;
           const scope = (args?.scope as string) ?? "session";
-
-          // Conclusions are queried alongside messages (issue #95: conclusions
-          // saved via create_conclusion were unreachable through search).
-          // Degrades to messages-only if the conclusion query fails.
           const [messages, conclusions] = await Promise.all([
             scope === "workspace"
               ? honcho.search(query, { limit })

--- a/plugins/honcho/src/mcp/server.ts
+++ b/plugins/honcho/src/mcp/server.ts
@@ -790,7 +790,7 @@ export async function runMcpServer(): Promise<void> {
         ...(rememberEnabled ? [REMEMBER_TOOL] : []),
         {
           name: "search",
-          description: "Search across messages using semantic search. Defaults to the current session; use scope='workspace' to search across all sessions.",
+          description: "Semantic search across messages and saved conclusions. Messages default to the current session; use scope='workspace' to search across all sessions. Conclusions are always searched workspace-wide.",
           inputSchema: {
             type: "object",
             properties: {
@@ -866,8 +866,27 @@ export async function runMcpServer(): Promise<void> {
           },
         },
         {
+          name: "query_conclusions",
+          description: "Semantically search conclusions Honcho has saved about the user. Returns IDs usable with delete_conclusion — much faster than paging list_conclusions when looking for something specific.",
+          inputSchema: {
+            type: "object",
+            properties: {
+              query: {
+                type: "string",
+                description: "Search query",
+              },
+              top_k: {
+                type: "number",
+                description: "Max results (default 10)",
+                default: 10,
+              },
+            },
+            required: ["query"],
+          },
+        },
+        {
           name: "delete_conclusion",
-          description: "Delete a conclusion from Honcho's memory by ID. Use list_conclusions to find the ID first.",
+          description: "Delete a conclusion from Honcho's memory by ID. Use query_conclusions or list_conclusions to find the ID first.",
           inputSchema: {
             type: "object",
             properties: {
@@ -996,7 +1015,7 @@ export async function runMcpServer(): Promise<void> {
 
     // ── Peer-only tools (no session needed) ──
 
-    if (name === "list_conclusions" || name === "delete_conclusion") {
+    if (name === "list_conclusions" || name === "delete_conclusion" || name === "query_conclusions") {
       try {
         const observationMode = getObservationMode(config);
         // unified: (observer=user, observed=user); directional: (observer=aiPeer, observed=user)
@@ -1019,6 +1038,20 @@ export async function runMcpServer(): Promise<void> {
               type: "text",
               text: JSON.stringify({ items, total: result.total, page: result.page, pages: result.pages }, null, 2),
             }],
+          };
+        }
+
+        if (name === "query_conclusions") {
+          const query = args?.query as string;
+          const topK = Math.min((args?.top_k as number) ?? 10, 50);
+          const conclusions = await conclusionScope.query(query, topK);
+          const items = conclusions.map((c) => ({
+            id: c.id,
+            content: c.content,
+            createdAt: c.createdAt,
+          }));
+          return {
+            content: [{ type: "text", text: JSON.stringify(items, null, 2) }],
           };
         }
 
@@ -1058,15 +1091,28 @@ export async function runMcpServer(): Promise<void> {
           const limit = (args?.limit as number) ?? 10;
           const scope = (args?.scope as string) ?? "session";
 
-          const messages = scope === "workspace"
-            ? await honcho.search(query, { limit })
-            : await session.search(query, { limit });
+          // Conclusions are queried alongside messages (issue #95: conclusions
+          // saved via create_conclusion were unreachable through search).
+          // Degrades to messages-only if the conclusion query fails.
+          const [messages, conclusions] = await Promise.all([
+            scope === "workspace"
+              ? honcho.search(query, { limit })
+              : session.search(query, { limit }),
+            activePeer.conclusionsOf(config.peerName).query(query, limit).catch(() => []),
+          ]);
 
-          const results = messages.map((msg: any) => ({
-            content: msg.content,
-            peerId: msg.peer,
-            createdAt: msg.createdAt || msg.created_at,
-          }));
+          const results = {
+            messages: messages.map((msg: any) => ({
+              content: msg.content,
+              peerId: msg.peer,
+              createdAt: msg.createdAt || msg.created_at,
+            })),
+            conclusions: conclusions.map((c) => ({
+              id: c.id,
+              content: c.content,
+              createdAt: c.createdAt,
+            })),
+          };
 
           return {
             content: [


### PR DESCRIPTION
Fixes #95 (DEV-2230). Also covers DEV-2025.

The MCP `search` tool only queried the message store, so conclusions saved via `create_conclusion` were unreachable through search (findable only by paging `list_conclusions` or while recent enough to appear in context injection.)

- **`search`** now also queries the conclusion scope (same observer/observed selection as `list_conclusions`: unified user→user, directional aiPeer→user) in parallel with the message search, returning `{messages, conclusions}`. The conclusion leg degrades to `[]` on error so search never gets worse than before.
- **New `query_conclusions` tool** semantic search over saved conclusions with `query` + `top_k` (capped 50), returning IDs (so its possible to use in`delete_conclusion`). Makes finding a specific conclusion possible.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added semantic conclusion lookup with configurable result limits.
  * Expanded search to include workspace-wide conclusions alongside messages.
  * Search results now separate messages and conclusions.
  * Conclusion results include matching IDs, content, and timestamps.

* **Bug Fixes**
  * Searches continue returning message results when conclusion lookup is unavailable.
  * Updated conclusion deletion guidance to reference both lookup options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->