### PR TITLE
fix: keep the hook payload across the bundled entry point hop

### DIFF
--- a/plugins/honcho/scripts/smoke.sh
+++ b/plugins/honcho/scripts/smoke.sh
@@ -50,4 +50,26 @@ echo "smoke: dist/skills/setup-runner.js"
 echo "smoke: dist/skills/status-runner.js"
 bounded node dist/skills/status-runner.js </dev/null | grep -q "Not configured"
 
+# The hook payload must survive the entry point's initHook() -> handler hop.
+# The checks above all run with the plugin disabled, so they exit before the
+# handler ever reads stdin — a bundled entry that loses the payload passes them
+# regardless. Here the plugin is enabled and pointed at a closed port, so the
+# handler runs its pre-network work (which records session_id) and then fails
+# fast on connect. Seeing session_id land in the cache proves the payload
+# crossed the hop.
+PAYLOAD_HOME="$(mktemp -d)"
+mkdir -p "$PAYLOAD_HOME/.honcho"
+cat > "$PAYLOAD_HOME/.honcho/config.json" <<'JSON'
+{"apiKey":"smoke","peerName":"smoke-peer","workspace":"smoke-ws","baseUrl":"http://127.0.0.1:1","logging":false}
+JSON
+echo "smoke: dist/hooks/session-start.js sees the hook payload"
+HOME="$PAYLOAD_HOME" bounded node dist/hooks/session-start.js >/dev/null 2>&1 <<'JSON' || true
+{"session_id":"payload-probe","cwd":"/tmp","hook_event_name":"SessionStart","source":"startup"}
+JSON
+grep -q "payload-probe" "$PAYLOAD_HOME/.honcho/cache.json" 2>/dev/null || {
+  echo "FAIL: bundled session-start did not receive the hook payload (session_id missing from cache)" >&2
+  echo "      the entry point's cached stdin is not reaching the handler — see initHook/getCachedStdin" >&2
+  exit 1
+}
+
 echo "smoke: all entry points OK"

--- a/plugins/honcho/src/config.ts
+++ b/plugins/honcho/src/config.ts
@@ -257,14 +257,25 @@ export function coerceBoolean(value: unknown): boolean {
 
 // Stdin cache: entry points read stdin once via initHook(),
 // handlers consume from cache via getCachedStdin().
-let _stdinText: string | null = null;
+//
+// The cache is keyed on globalThis rather than held in a module binding
+// because the release bundle can instantiate this module more than once:
+// Bun's code splitting inlines a private copy of config.js into
+// dist/hooks/session-start.js while the other entry points share a chunk.
+// With module state, initHook() writes the payload into one copy and the
+// handler reads null from the other, falls back to re-reading an
+// already-drained stdin, and proceeds with an empty hook input — losing cwd,
+// session_id and source. Process-wide state also matches what this cache
+// actually means: the stdin of this process, read once.
+const STDIN_CACHE = Symbol.for("honcho.hookStdinText");
 
 export function cacheStdin(text: string): void {
-  _stdinText = text;
+  (globalThis as Record<symbol, unknown>)[STDIN_CACHE] = text;
 }
 
 export function getCachedStdin(): string | null {
-  return _stdinText;
+  const cached = (globalThis as Record<symbol, unknown>)[STDIN_CACHE];
+  return typeof cached === "string" ? cached : null;
 }
 
 /** Runtime-agnostic stdin read (hooks run under bun in dev, node when bundled). */


### PR DESCRIPTION

### What happens

In the bundled plugin (`.stage/` — what the npm package ships since #92), `dist/hooks/session-start.js` never sees the hook payload. `cwd` falls back to `process.cwd()`, and `session_id`, `source` and `workspace_roots` arrive `undefined`.

Running from source is unaffected, so this only reaches users installing the npm package.

### Why

`Bun.build({ splitting: true })` can instantiate a module more than once across entry points. Today it inlines a private copy of `config.js` into `dist/hooks/session-start.js`, while the other seven hooks share a chunk:

```
$ grep -c "var _stdinText = null" .stage/dist/hooks/*.js
session-start.js:1      <- own copy
post-tool-use.js:0      pre-compact.js:0       pre-tool-honcho.js:0
save-user-message.js:0  session-end.js:0       stop.js:0         user-prompt.js:0
```

The entry point does:

```ts
await initHook();            // reads stdin, cacheStdin(text)
await handleSessionStart();  // getCachedStdin() ?? await readStdinText()
```

With two copies of the module, `initHook()` writes `_stdinText` in one and the handler reads `null` from the other. It then falls back to `readStdinText()` — but stdin was already drained by `initHook()`, so it gets `""` and proceeds with `hookInput = {}`.

The bug is a property of the module-state assumption, not of `session-start` specifically: any entry the bundler decides to inline next inherits it.

### Reproducing on a clean checkout

```bash
cd plugins/honcho
bun install && bun run scripts/build.ts

HOME=$(mktemp -d); mkdir -p "$HOME/.honcho"
echo '{"apiKey":"x","peerName":"rafa","workspace":"w","baseUrl":"http://127.0.0.1:1"}' > "$HOME/.honcho/config.json"

echo '{"session_id":"probe","cwd":"/some/other/project","hook_event_name":"SessionStart","source":"startup"}' \
  | node .stage/dist/hooks/session-start.js
```

The spinner names the session after the **current** directory rather than `/some/other/project`, and `~/.honcho/cache.json` never records `probe`. The same payload through `bun run hooks/session-start.ts` behaves correctly.

### Why CI misses it

`smoke.sh` runs every entry point with `{"enabled":false}`, and each hook returns at the `isPluginEnabled()` check — before the handler reads stdin. The bundled entry passes those cases whether or not the payload survives.

### The fix

Key the stdin cache on `globalThis` (`Symbol.for("honcho.hookStdinText")`) so every copy of the module observes the same value. Process-wide state is also what the cache means: the stdin of this process, read once.

Alternatives considered:

- **`splitting: false`** — removes today's duplication but inflates every entry and doesn't stop the module-state assumption from breaking again if bundling changes.
- **Passing the text down** (`handleSessionStart(stdinText)`) — explicit and arguably cleanest, but it touches all 8 handlers plus their wrappers. Happy to switch to this if you prefer it; the fix is mechanical either way.

### Test

`smoke.sh` gains one case: plugin **enabled** and pointed at a closed port, so the handler runs its pre-network work (which records `session_id`) and then fails fast on connect. It asserts the payload's `session_id` reached the cache.

Verified on pristine `ff5f5b7`: the new case **fails** before the fix and **passes** after. `bunx tsc --noEmit` clean, `bun test` 20/20, `claude plugin validate` unaffected.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when processing hook payloads across bundled components.
  * Ensured session information is preserved during pre-network handling.
* **Tests**
  * Added a smoke test to verify that session identifiers are correctly recorded when network access is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
