### PR TITLE
feat: statusMessages config to silence inline hook status lines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to claude-honcho will be documented in this file.
 
 ## [0.3.0] - unreleased
 
+### Added
+
+- `statusMessages: "off"` silences the plugin's inline `[honcho] …` status lines — injection summaries, tool captures, skip notices, and the session link — across SessionStart, UserPromptSubmit, PostToolUse and Stop. Display only: what the hooks inject and save is unchanged, and the same detail still reaches the verbose log. Defaults to `"on"`. `injection.showContents` already dropped the payloads; this drops the summary lines too, for users who want the transcript quiet.
+
 ### Changed
 
 - The plugin is distributed as the npm package `@honcho-ai/claude-honcho` and the marketplace installs from it. Releases ship a self-contained bundle that runs under Node, so Bun is no longer a prerequisite for using the plugin — it remains the development toolchain.

--- a/plugins/honcho/skills/config/SKILL.md
+++ b/plugins/honcho/skills/config/SKILL.md
@@ -57,8 +57,8 @@ AskUserQuestion:
       description: "TTL, message threshold, dialectic settings"
     - label: "Message upload"
       description: "Token limits, summarization settings"
-    - label: "Statusline"
-      description: "Memory statusLine visibility — on / off (currently: {resolved.statusline})"
+    - label: "Display"
+      description: "Memory statusLine and inline hook status lines (currently: statusLine {resolved.statusline}, hook lines {resolved.statusMessages})"
 ```
 
 Always include current values in the description so the user can see what's set.
@@ -200,6 +200,8 @@ Pass the value as a JSON array (e.g. `["directives","summary","peerCard"]`). An 
 
 `showContents` is display-only. It never changes what reaches the model.
 
+`showContents: []` still prints the one-line summary — it drops the payload, not the line. A user who wants the terminal fully quiet wants `statusMessages: "off"` (see Display), which silences the summaries too.
+
 Retrieval tuning is intentionally NOT asked here. `injection.searchTopK` (default 10), `injection.maxConclusions` (15), `injection.searchMaxDistance` (0.6, cosine — lower is stricter), and `injection.searchQuerySource` ("prompt" | "topics", default "prompt") are all configurable via `set_config`, but keep the defaults; only mention they're tunable if the user brings it up, and never prompt for them.
 
 If the user enables "Dialectic recall", note the two knobs that shape it — `injection.dialecticTemplate` (the query, with a `%{user_query}` placeholder) and `injection.dialecticReasoning` (tier, default "low") — both via `set_config`. Flag the trade-off: it fires a `chat()` call every non-trivial turn (~12s at medium), on its own budget under the 30s hook ceiling, so it adds real per-turn latency. Keep it off unless the user wants it.
@@ -227,20 +229,37 @@ AskUserQuestion:
 
 Then ask for the new value and call `set_config`.
 
-### Statusline
+### Display
+
+Two independent indicators. Ask which one first:
 
 ```
 AskUserQuestion:
-  question: "Memory statusLine visibility?"
-  header: "Statusline"
+  question: "Which indicator?"
+  header: "Display"
+  options:
+    - label: "Memory statusLine"
+      description: "Sync status, clickable session link, live activity (currently: {resolved.statusline})"
+    - label: "Hook status lines"
+      description: "The [honcho] … lines above a turn (currently: {resolved.statusMessages})"
+```
+
+Then ask on / off for the chosen one:
+
+```
+AskUserQuestion:
+  question: "Visibility?"
+  header: "Visibility"
   options:
     - label: "on (Recommended)"
-      description: "Sync status, clickable session link, and live activity"
+      description: "Shown"
     - label: "off"
       description: "Hidden"
 ```
 
-Call `set_config` with field `statusline` and the chosen value. Takes effect on the next statusLine repaint.
+Call `set_config` with field `statusline` or `statusMessages` and the chosen value. `statusline` takes effect on the next statusLine repaint; `statusMessages` on the next turn — neither needs a restart.
+
+`statusMessages: "off"` silences *every* hook status line — injection summaries, tool captures, skip notices, the session link — across SessionStart, UserPromptSubmit, PostToolUse and Stop. Display only: what the hooks inject is unchanged, and the same detail still goes to `~/.honcho/verbose.log`.
 
 ### Message upload
 

--- a/plugins/honcho/src/config.ts
+++ b/plugins/honcho/src/config.ts
@@ -139,6 +139,16 @@ export type SessionStrategy = "per-directory" | "git-branch" | "chat-instance";
 
 export type StatuslineMode = "on" | "off";
 
+/**
+ * Visibility of the inline hook status lines — the `[honcho] <hook> ← …`
+ * systemMessages Claude Code renders above a turn. "off" silences every one of
+ * them (injection summaries, tool captures, skips) without touching what the
+ * hooks actually inject; the same information stays in the verbose log.
+ *
+ * Distinct from `statusline`, which controls the persistent memory indicator.
+ */
+export type StatusMessagesMode = "on" | "off";
+
 export type HonchoEnvironment = "production" | "local";
 
 export interface HonchoEndpointConfig {
@@ -190,6 +200,8 @@ export interface HostConfig {
    * "directional": this AI keeps its own view of the user (observer=aiPeer, observed=user).
    */
   observationMode?: ObservationMode;
+  /** Inline hook status line visibility: "on" (default) · "off" */
+  statusMessages?: StatusMessagesMode;
   messageUpload?: MessageUploadConfig;
   contextRefresh?: ContextRefreshConfig;
   /** Extra regex patterns redacted from tool summaries (additive to built-in defaults) */
@@ -316,6 +328,8 @@ interface HonchoFileConfig {
   observationMode?: ObservationMode;
   /** Memory statusLine visibility: "on" (default) · "off" */
   statusline?: StatuslineMode;
+  /** Inline hook status line visibility: "on" (default) · "off" */
+  statusMessages?: StatusMessagesMode;
   /** Composable injection config (session-start + per-turn component menus). */
   injection?: InjectionConfig;
   /** Register the on-demand `honcho_remember` MCP tool (default: false). */
@@ -365,6 +379,8 @@ export interface HonchoCLAUDEConfig {
   observationMode?: ObservationMode;
   /** Memory statusLine visibility: "on" (default) · "off" */
   statusline?: StatuslineMode;
+  /** Inline hook status line visibility: "on" (default) · "off" */
+  statusMessages?: StatusMessagesMode;
   /** Token-based upload limits */
   messageUpload?: MessageUploadConfig;
   /** Context retrieval settings */
@@ -510,6 +526,7 @@ function resolveConfig(raw: HonchoFileConfig, host: HonchoHost): HonchoCLAUDECon
     saveGitEvents: hostBlock?.saveGitEvents ?? raw.saveGitEvents,
     reasoningLevel: hostBlock?.reasoningLevel ?? raw.reasoningLevel,
     observationMode: hostBlock?.observationMode ?? raw.observationMode,
+    statusMessages: hostBlock?.statusMessages ?? raw.statusMessages,
     messageUpload: hostBlock?.messageUpload ?? raw.messageUpload,
     contextRefresh: hostBlock?.contextRefresh ?? raw.contextRefresh,
     endpoint: hostBlock?.endpoint ?? raw.endpoint,
@@ -910,6 +927,20 @@ export function getInjectionConfig(config?: HonchoCLAUDEConfig | null): Required
 export function isLoggingEnabled(): boolean {
   const config = loadConfig();
   return config?.logging !== false;
+}
+
+/**
+ * Whether the hooks may print their inline `[honcho] …` status lines. Opt-out
+ * (default "on"), so an absent field keeps today's behavior; anything other
+ * than an explicit "off" leaves them on, which keeps a typo from silently
+ * muting the plugin.
+ *
+ * Pass the already-loaded config where a hook has one in scope; omit it for a
+ * standalone lookup.
+ */
+export function areStatusMessagesEnabled(config?: HonchoCLAUDEConfig | null): boolean {
+  const resolved = config === undefined ? loadConfig() : config;
+  return resolved?.statusMessages !== "off";
 }
 
 export function isPluginEnabled(): boolean {

--- a/plugins/honcho/src/hooks/session-start.ts
+++ b/plugins/honcho/src/hooks/session-start.ts
@@ -14,7 +14,7 @@ import { setMemoryState, setSessionLink } from "../state.js";
 import { honchoSessionUrl } from "../styles.js";
 import { captureGitState } from "../git.js";
 import { logHook, logApiCall, logFlow, logAsync, setLogContext } from "../log.js";
-import { verboseApiResult, verboseList, clearVerboseLog, visComposedInjection } from "../visual.js";
+import { addSystemMessage, verboseApiResult, verboseList, clearVerboseLog, visComposedInjection } from "../visual.js";
 
 
 interface HookInput {
@@ -223,13 +223,12 @@ export async function handleSessionStart(): Promise<void> {
     setMemoryState("idle", undefined, claudeInstanceId);
 
     if (rendered.content) {
-      console.log(JSON.stringify({
+      console.log(JSON.stringify(addSystemMessage({
         hookSpecificOutput: {
           hookEventName: "SessionStart",
           additionalContext: `[Honcho Memory for ${config.peerName}]: ${rendered.content}`,
         },
-        systemMessage: visComposedInjection("session-start", rendered.labels),
-      }));
+      }, visComposedInjection("session-start", rendered.labels))));
     }
 
     logFlow("complete", `Cache warmed: ${successCount}/1 context · injected: ${rendered.labels.join(", ") || "none"}`);

--- a/plugins/honcho/src/mcp/server.ts
+++ b/plugins/honcho/src/mcp/server.ts
@@ -25,6 +25,7 @@ import {
   type HonchoEnvironment,
   type ObservationMode,
   type StatuslineMode,
+  type StatusMessagesMode,
   type SessionStartComponent,
   type PerTurnComponent,
   SESSION_START_COMPONENTS,
@@ -119,6 +120,7 @@ function handleGetConfig(cwd: string) {
     reasoningLevel: cfg.reasoningLevel ?? "medium",
     observationMode: cfg.observationMode ?? "unified",
     statusline: cfg.statusline ?? "on",
+    statusMessages: cfg.statusMessages ?? "on",
     redactPatterns: cfg.redactPatterns ?? [],
     injection: cfg.injection ?? {},
     rememberTool: cfg.rememberTool === true,
@@ -500,6 +502,21 @@ function handleSetConfig(args: Record<string, unknown>) {
       break;
     }
 
+    case "statusMessages": {
+      const mode = String(value).toLowerCase();
+      if (mode !== "on" && mode !== "off") {
+        return {
+          content: [{ type: "text", text: JSON.stringify({ success: false, error: "statusMessages must be one of: on, off" }, null, 2) }],
+          isError: true,
+        };
+      }
+      previousValue = cfg.statusMessages ?? "on";
+      cfg.statusMessages = mode as StatusMessagesMode;
+      // statusMessages is a global field — write to root (user-directed action)
+      saveRootField("statusMessages", cfg.statusMessages);
+      break;
+    }
+
     case "redactPatterns": {
       const arr = coerceStringArray(value);
       if (!arr) {
@@ -680,6 +697,7 @@ function handleSetConfig(args: Record<string, unknown>) {
     reasoningLevel: cfg.reasoningLevel ?? "medium",
     observationMode: cfg.observationMode ?? "unified",
     statusline: cfg.statusline ?? "on",
+    statusMessages: cfg.statusMessages ?? "on",
     redactPatterns: cfg.redactPatterns ?? [],
     injection: cfg.injection ?? {},
     rememberTool: cfg.rememberTool === true,
@@ -984,6 +1002,8 @@ export async function runMcpServer(): Promise<void> {
                   "contextRefresh.skipDialectic",
                   "reasoningLevel",
                   "observationMode",
+                  "statusline",
+                  "statusMessages",
                   "redactPatterns",
                   "injection.sessionStart",
                   "injection.perTurn",

--- a/plugins/honcho/src/visual.ts
+++ b/plugins/honcho/src/visual.ts
@@ -2,16 +2,22 @@
  * Visual logging for honcho hooks
  *
  * Only hooks that output JSON with `systemMessage` show inline indicators in Claude Code:
+ * - SessionStart — addSystemMessage() adds to existing JSON output
  * - UserPromptSubmit — addSystemMessage() adds to existing JSON output
  * - PostToolUse — visCapture() outputs JSON with systemMessage
  * - Stop — visStopMessage() outputs JSON with systemMessage
  *
- * SessionStart, SessionEnd, and PreCompact output plain text to stdout (context injection),
+ * SessionEnd and PreCompact output plain text to stdout (context injection),
  * so they cannot show inline indicators. Their activity is logged to the verbose log file only.
+ *
+ * `statusMessages: "off"` mutes every indicator at the two emission points
+ * below — visMessage() and addSystemMessage(). The builders above them stay
+ * pure formatters, so there is exactly one place to keep in sync when a new
+ * surface starts reporting.
  */
 
 import { arrows, symbols } from "./unicode.js";
-import { isLoggingEnabled } from "./config.js";
+import { areStatusMessagesEnabled, isLoggingEnabled } from "./config.js";
 
 // Plain text (no ANSI) for systemMessage — shown in Claude Code's UI
 const sym = {
@@ -23,6 +29,24 @@ const sym = {
 };
 
 type HookDirection = "in" | "out" | "info" | "ok" | "warn" | "error";
+
+/**
+ * Resolved once per hook process: every hook is a short-lived process, so the
+ * config file cannot change underneath us, and this sits on the per-turn path.
+ * A config that fails to load leaves the indicators on — muting is opt-in.
+ */
+let statusMessagesEnabled: boolean | undefined;
+
+function statusMessagesOn(): boolean {
+  if (statusMessagesEnabled === undefined) {
+    try {
+      statusMessagesEnabled = areStatusMessagesEnabled();
+    } catch {
+      statusMessagesEnabled = true;
+    }
+  }
+  return statusMessagesEnabled;
+}
 
 const directionSymbol: Record<HookDirection, string> = {
   in:    sym.left,
@@ -45,6 +69,7 @@ function formatLine(direction: HookDirection, hookName: string, message: string)
  * Use this for hooks that don't already write to stdout (PostToolUse, Stop)
  */
 export function visMessage(direction: HookDirection, hookName: string, message: string): void {
+  if (!statusMessagesOn()) return;
   const line = formatLine(direction, hookName, message);
   console.log(JSON.stringify({ systemMessage: line }));
 }
@@ -147,9 +172,12 @@ export function visStopMessage(direction: HookDirection, message: string): void 
 
 /**
  * Add systemMessage to an existing hookSpecificOutput JSON object
- * Used by UserPromptSubmit which already outputs JSON
+ * Used by SessionStart and UserPromptSubmit, which already output JSON.
+ * Returns the object untouched when status messages are muted, so the hook's
+ * own payload (additionalContext) is unaffected.
  */
 export function addSystemMessage(existingJson: any, message: string): any {
+  if (!statusMessagesOn()) return existingJson;
   return { ...existingJson, systemMessage: message };
 }
 

--- a/plugins/honcho/tests/status-messages.test.ts
+++ b/plugins/honcho/tests/status-messages.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, test } from "bun:test";
+import { areStatusMessagesEnabled, type HonchoCLAUDEConfig } from "../src/config";
+
+const config = (statusMessages?: unknown): HonchoCLAUDEConfig => ({
+  peerName: "user",
+  apiKey: "key",
+  workspace: "default",
+  aiPeer: "claude-code",
+  ...(statusMessages === undefined ? {} : { statusMessages }),
+} as HonchoCLAUDEConfig);
+
+describe("areStatusMessagesEnabled", () => {
+  test("unset keeps the status lines on", () => {
+    expect(areStatusMessagesEnabled(config())).toBe(true);
+  });
+
+  test('"off" mutes them', () => {
+    expect(areStatusMessagesEnabled(config("off"))).toBe(false);
+  });
+
+  test('"on" keeps them', () => {
+    expect(areStatusMessagesEnabled(config("on"))).toBe(true);
+  });
+
+  test("no config at all keeps them on", () => {
+    expect(areStatusMessagesEnabled(null)).toBe(true);
+  });
+
+  test("a hand-edited value that isn't exactly \"off\" keeps them on", () => {
+    // Muting is opt-in: a typo must not silently silence the plugin.
+    expect(areStatusMessagesEnabled(config("false"))).toBe(true);
+    expect(areStatusMessagesEnabled(config("OFF"))).toBe(true);
+    expect(areStatusMessagesEnabled(config(true))).toBe(true);
+  });
+});


### PR DESCRIPTION
## What

Adds a `statusMessages: "on" | "off"` config field (default `"on"`). With `"off"` the plugin stops emitting its inline `[honcho] …` systemMessage lines — injection summaries, tool captures, skip notices, the session link — across SessionStart, UserPromptSubmit, PostToolUse and Stop.

Display only. `additionalContext`, message saving and the verbose log are untouched.

## Why

`injection.showContents` (#96) fixed the loud half of this — per-turn components no longer dump their whole payload into the transcript. But it drops the *payload*, not the *line*: `visInjectionMessage()` / `visSessionContextMessage()` build the head unconditionally, so a non-trivial prompt still prints

```
UserPromptSubmit says: view your session in honcho GUI: https://app.honcho.dev/explore?...
UserPromptSubmit says: [honcho] user-prompt ← injected 12 conclusions
UserPromptSubmit says: [honcho] user-prompt ← injected 8 session messages (~992 tokens)
```

on every turn, and there is currently no way to turn that off:

- `showContents: []` is already the default — it's what produces the summary-only form.
- `injection.perTurn: []` doesn't help either: the hook then prints `• skipped (injection off)` instead, and disables recall as a side effect.

For someone who trusts the plugin and just wants a quiet transcript, that's three lines of chrome per turn with no opt-out. This adds one switch that costs them nothing else.

## How

Every systemMessage the plugin emits already funnels through two functions in `src/visual.ts` — `visMessage()` (PostToolUse, Stop, skips) and `addSystemMessage()` (UserPromptSubmit). The gate lives at those two points, so the builders above them stay pure formatters and there's exactly one place to keep in sync when a new surface starts reporting.

SessionStart was the one surface inlining `systemMessage:` into its own object literal; it now goes through `addSystemMessage()` like the rest. (The header comment in `visual.ts` still claimed SessionStart couldn't show inline indicators — stale since it started emitting one, so I updated it.)

The lookup resolves once per hook process — each hook is a short-lived process, so the file can't change underneath it — and stays **on** whenever config loading fails or the value isn't exactly `"off"`. Muting is opt-in; a typo shouldn't silently silence the plugin.

Wired through the usual places: host-block override (`hosts.<name>.statusMessages`), `resolveConfig`, `set_config`, the `get_config` / status payloads, and the `/honcho:config` skill. In the skill, the advanced "Statusline" entry became "Display" and now covers both indicators — `AskUserQuestion` caps at 4 options, so there was no room for a fifth top-level entry. I also added a line to the injection section pointing users who want silence at `statusMessages` rather than `showContents`, since that's the mix-up that prompted this.

## Drive-by

`statusline` was missing from `set_config`'s `field` enum even though the switch handles it and `skills/config/SKILL.md` instructs the model to set it. Added alongside `statusMessages`. Happy to split that into its own PR if you'd prefer it separate.

## Testing

- `bunx tsc --noEmit` — clean
- `bun test` — new `tests/status-messages.test.ts` covers unset / `"on"` / `"off"` / no-config / values that aren't exactly `"off"`
- `bun run scripts/build.ts` + A/B against the built bundle, isolated config per run:

```
--- statusMessages: on ---
addSystemMessage: {"hookSpecificOutput":{"additionalContext":"MEMORY PAYLOAD"},"systemMessage":"[honcho] session-start ← injected summary"}
visSkipMessage:   {"systemMessage":"[honcho] user-prompt • skipped (trivial prompt)"}

--- statusMessages: off ---
addSystemMessage: {"hookSpecificOutput":{"additionalContext":"MEMORY PAYLOAD"}}
visSkipMessage:

--- field absent (default) ---
addSystemMessage: {"hookSpecificOutput":{"additionalContext":"MEMORY PAYLOAD"},"systemMessage":"[honcho] session-start ← injected summary"}
visSkipMessage:   {"systemMessage":"[honcho] user-prompt • skipped (trivial prompt)"}
```

The payload survives muting; only the indicator goes.

Two things I hit running the suite locally on Windows, **both reproduced on unmodified `main`** and unrelated to this change, noting them in case they're useful:

- `tests/worktree-session.test.ts` (2 failures) reads the developer's real `~/.honcho/config.json`, so the local `peerName` and `sessions` map leak into its expectations (`peet-proj` vs the expected `t-proj`).
- The last two steps of `scripts/smoke.sh` isolate via `$HOME`, which Node ignores on Windows in favour of `%USERPROFILE%`, so `setup-runner` finds a real key instead of printing `No API key found`. Every bundled entry point still runs.

Both pass on `ubuntu-latest` CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a `statusMessages` display setting to show or hide plugin status summaries.
  * Status messages remain enabled by default and can be configured globally or per host.
  * Added display controls for independently managing memory indicators and hook status messages.
  * Added configuration support through the MCP interface.
* **Documentation**
  * Clarified how memory summaries, injected content, and status-message settings interact.
* **Bug Fixes**
  * Disabling status messages now consistently hides indicators while preserving injected content and saved data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->