### PR TITLE
fix(session-end): detect silent message-save failure

### DIFF
--- a/plugins/honcho/src/hooks/save-user-message.ts
+++ b/plugins/honcho/src/hooks/save-user-message.ts
@@ -62,7 +62,7 @@ export async function handleSaveUserMessage(): Promise<void> {
 
   try {
     await postUserMessage(config, prompt, instanceId || undefined, sessionName);
-    recordMessageSave(1, hookInput.session_id);
+    recordMessageSave("user", 1, hookInput.session_id);
   } catch (e) {
     logHook("save-user-message", `Upload failed: ${e}`);
   }

--- a/plugins/honcho/src/hooks/save-user-message.ts
+++ b/plugins/honcho/src/hooks/save-user-message.ts
@@ -2,6 +2,7 @@ import { Honcho, Session, Peer } from "@honcho-ai/sdk";
 import { loadConfig, getSessionName, getHonchoClientOptions, isPluginEnabled, getCachedStdin, readStdinText } from "../config.js";
 import { getInstanceIdForCwd, chunkContent, addMessagesBatched } from "../cache.js";
 import { logHook, logApiCall, setLogContext } from "../log.js";
+import { recordMessageSave } from "../state.js";
 import { isHarnessInjected, isTerseReply } from "./user-prompt.js";
 
 interface HookInput {
@@ -61,6 +62,7 @@ export async function handleSaveUserMessage(): Promise<void> {
 
   try {
     await postUserMessage(config, prompt, instanceId || undefined, sessionName);
+    recordMessageSave(1, hookInput.session_id);
   } catch (e) {
     logHook("save-user-message", `Upload failed: ${e}`);
   }

--- a/plugins/honcho/src/hooks/session-end.ts
+++ b/plugins/honcho/src/hooks/session-end.ts
@@ -1,7 +1,8 @@
 import { loadConfig, getSessionName, isPluginEnabled, getCachedStdin, readStdinText } from "../config.js";
 import { getInstanceIdForCwd } from "../cache.js";
-import { clearSessionFiles } from "../state.js";
-import { logHook, setLogContext } from "../log.js";
+import { clearSessionFiles, getMessageSaveCount } from "../state.js";
+import { logActivity, logHook, setLogContext } from "../log.js";
+import { existsSync, readFileSync } from "fs";
 
 
 interface HookInput {
@@ -13,11 +14,50 @@ interface HookInput {
 }
 
 /**
+ * Counts real user turns in the transcript. Deliberately a local copy of
+ * stop.ts's isRealUserPrompt rather than an import: this hook must return
+ * instantly, and importing stop.js would pull in the Honcho SDK at load time.
+ */
+function countUserTurns(transcriptPath: string): number {
+  if (!transcriptPath || !existsSync(transcriptPath)) return 0;
+  let turns = 0;
+  try {
+    for (const line of readFileSync(transcriptPath, "utf-8").split("\n")) {
+      if (!line.includes('"user"')) continue;
+      try {
+        const entry = JSON.parse(line);
+        if ((entry.type || entry.role) !== "user" || entry.isMeta) continue;
+        const mc = entry.message?.content ?? entry.content;
+        const text =
+          typeof mc === "string"
+            ? mc
+            : Array.isArray(mc)
+              ? mc.filter((b: any) => b.type === "text" && b.text).map((b: any) => b.text).join("")
+              : "";
+        const trimmed = text.trim();
+        if (trimmed.length > 0 && !trimmed.startsWith("<")) turns++;
+      } catch {
+        continue;
+      }
+    }
+  } catch {
+    return 0;
+  }
+  return turns;
+}
+
+/**
  * SessionEnd hook — must return instantly. On /exit the harness aborts slow
  * hooks and surfaces "SessionEnd hook failed: Hook cancelled", so nothing here
  * touches the network. Messages upload live from the other hooks, and the old
  * [Session ended] marker only ever derived lifecycle exhaust ("claude's
  * session ended at ...") — write-only telemetry, never read back.
+ *
+ * It does not upload, but it must not *claim* the live saves happened either:
+ * when the saving hooks are dead (e.g. a sub-second hook timeout kills them),
+ * the old unconditional "messages saved live" line turned total data loss into
+ * a success message. So we compare what actually landed against the user turns
+ * in the transcript and log an error when the two disagree.
  */
 export async function handleSessionEnd(): Promise<void> {
   const config = loadConfig();
@@ -47,7 +87,24 @@ export async function handleSessionEnd(): Promise<void> {
   setLogContext(cwd, sessionName);
   logHook("session-end", `Session ending`, { reason });
 
+  // Read the tally before clearSessionFiles deletes it.
+  const saved = getMessageSaveCount(hookInput.session_id);
+  const userTurns = countUserTurns(hookInput.transcript_path || "");
   clearSessionFiles(hookInput.session_id);
-  logHook("session-end", "Session ended — no upload (messages saved live)");
+
+  if (saved > 0) {
+    logHook("session-end", `Session ended — no upload (${saved} message(s) saved live)`);
+  } else if (userTurns > 0) {
+    logActivity(
+      "error",
+      "session-end",
+      `Session ended — NOTHING SAVED: 0 messages uploaded despite ${userTurns} user turn(s). ` +
+        `Live saving is broken — check that the UserPromptSubmit and Stop hooks still run ` +
+        `(see hooks.json timeouts) and back-fill with /honcho:import if needed.`,
+      { saved, userTurns },
+    );
+  } else {
+    logHook("session-end", "Session ended — nothing to save (no user turns)");
+  }
   process.exit(0);
 }

--- a/plugins/honcho/src/hooks/session-end.ts
+++ b/plugins/honcho/src/hooks/session-end.ts
@@ -1,6 +1,6 @@
 import { loadConfig, getSessionName, isPluginEnabled, getCachedStdin, readStdinText } from "../config.js";
 import { getInstanceIdForCwd } from "../cache.js";
-import { clearSessionFiles, getMessageSaveCount } from "../state.js";
+import { clearSessionFiles, getMessageSaveTally } from "../state.js";
 import { logActivity, logHook, setLogContext } from "../log.js";
 import { existsSync, readFileSync } from "fs";
 
@@ -14,11 +14,12 @@ interface HookInput {
 }
 
 /**
- * Counts real user turns in the transcript. Deliberately a local copy of
- * stop.ts's isRealUserPrompt rather than an import: this hook must return
- * instantly, and importing stop.js would pull in the Honcho SDK at load time.
+ * Counts real user turns this window contributed to the transcript.
+ * Deliberately a local copy of stop.ts's isRealUserPrompt rather than an
+ * import: this hook must return instantly, and importing stop.js would pull
+ * in the Honcho SDK at load time.
  */
-function countUserTurns(transcriptPath: string): number {
+function countUserTurns(transcriptPath: string, sessionId?: string): number {
   if (!transcriptPath || !existsSync(transcriptPath)) return 0;
   let turns = 0;
   try {
@@ -27,6 +28,9 @@ function countUserTurns(transcriptPath: string): number {
       try {
         const entry = JSON.parse(line);
         if ((entry.type || entry.role) !== "user" || entry.isMeta) continue;
+        // A resumed session carries the earlier window's turns in the same
+        // transcript; those were saved (or lost) by that window, not this one.
+        if (sessionId && entry.sessionId && entry.sessionId !== sessionId) continue;
         const mc = entry.message?.content ?? entry.content;
         const text =
           typeof mc === "string"
@@ -88,23 +92,46 @@ export async function handleSessionEnd(): Promise<void> {
   logHook("session-end", `Session ending`, { reason });
 
   // Read the tally before clearSessionFiles deletes it.
-  const saved = getMessageSaveCount(hookInput.session_id);
-  const userTurns = countUserTurns(hookInput.transcript_path || "");
+  const saved = getMessageSaveTally(hookInput.session_id);
+  const userTurns = countUserTurns(hookInput.transcript_path || "", hookInput.session_id);
   clearSessionFiles(hookInput.session_id);
 
-  if (saved > 0) {
-    logHook("session-end", `Session ended — no upload (${saved} message(s) saved live)`);
-  } else if (userTurns > 0) {
+  if (config.saveMessages === false) {
+    // Nothing was meant to land, so silence here is the configured outcome.
+    logHook("session-end", "Session ended — no upload (message saving is disabled)");
+  } else if (!hookInput.session_id) {
+    // Without a session_id the upload hooks keep no tally, so there is nothing
+    // to check against. Say so instead of reading a shared count.
+    logHook("session-end", "Session ended — save validation unavailable (no session_id)");
+  } else if (userTurns === 0) {
+    logHook("session-end", "Session ended — nothing to save (no user turns)");
+  } else if (saved.user === 0) {
+    // Checked against the user tally alone: a successful Stop upload must not
+    // vouch for the UserPromptSubmit hook, which fails independently.
     logActivity(
       "error",
       "session-end",
-      `Session ended — NOTHING SAVED: 0 messages uploaded despite ${userTurns} user turn(s). ` +
+      `Session ended — NOTHING SAVED: 0 user message(s) uploaded despite ${userTurns} user turn(s) ` +
+        `(${saved.assistant} assistant message(s) did land). ` +
         `Live saving is broken — check that the UserPromptSubmit and Stop hooks still run ` +
         `(see hooks.json timeouts) and back-fill with /honcho:import if needed.`,
       { saved, userTurns },
     );
+  } else if (saved.user < userTurns) {
+    // Not an error on its own: harness-injected turns are counted here but
+    // deliberately skipped by the upload hook. Logged so a real gap is visible.
+    logActivity(
+      "flow",
+      "session-end",
+      `Session ended — ${saved.user} of ${userTurns} user turn(s) uploaded ` +
+        `(${saved.assistant} assistant message(s) saved live)`,
+      { saved, userTurns },
+    );
   } else {
-    logHook("session-end", "Session ended — nothing to save (no user turns)");
+    logHook(
+      "session-end",
+      `Session ended — no upload (${saved.user} user + ${saved.assistant} assistant message(s) saved live)`,
+    );
   }
   process.exit(0);
 }

--- a/plugins/honcho/src/hooks/stop.ts
+++ b/plugins/honcho/src/hooks/stop.ts
@@ -180,7 +180,7 @@ export async function handleStop(): Promise<void> {
     });
 
     logHook("stop", `Saved ${turnMessages.length} assistant message(s)`);
-    recordMessageSave(turnMessages.length, hookInput.session_id);
+    recordMessageSave("assistant", turnMessages.length, hookInput.session_id);
     visStopMessage("out", `saved ${turnMessages.length} assistant msg(s)`);
   } catch (error) {
     logHook("stop", `Upload failed: ${error}`, { error: String(error) });

--- a/plugins/honcho/src/hooks/stop.ts
+++ b/plugins/honcho/src/hooks/stop.ts
@@ -3,6 +3,7 @@ import { loadConfig, getSessionForPath, getSessionName, getHonchoClientOptions, 
 import { existsSync, readFileSync } from "fs";
 import { getInstanceIdForCwd, chunkContent, addMessagesBatched } from "../cache.js";
 import { logHook, logApiCall, setLogContext } from "../log.js";
+import { recordMessageSave } from "../state.js";
 import { visStopMessage } from "../visual.js";
 
 interface HookInput {
@@ -179,6 +180,7 @@ export async function handleStop(): Promise<void> {
     });
 
     logHook("stop", `Saved ${turnMessages.length} assistant message(s)`);
+    recordMessageSave(turnMessages.length, hookInput.session_id);
     visStopMessage("out", `saved ${turnMessages.length} assistant msg(s)`);
   } catch (error) {
     logHook("stop", `Upload failed: ${error}`, { error: String(error) });

--- a/plugins/honcho/src/state.ts
+++ b/plugins/honcho/src/state.ts
@@ -7,7 +7,7 @@
 
 import { homedir } from "os";
 import { join } from "path";
-import { writeFileSync, unlinkSync } from "fs";
+import { writeFileSync, readFileSync, unlinkSync } from "fs";
 
 const DIR = join(homedir(), ".honcho");
 
@@ -20,6 +20,9 @@ function stateFile(sessionId?: string): string {
 }
 function sessionFile(sessionId?: string): string {
   return join(DIR, sessionId ? `session-${sessionId}.json` : "session.json");
+}
+function savesFile(sessionId?: string): string {
+  return join(DIR, sessionId ? `saves-${sessionId}.json` : "saves.json");
 }
 
 export type MemoryPhase =
@@ -47,10 +50,32 @@ export function setSessionLink(url: string, name: string | undefined, sessionId?
   }
 }
 
+// Tally of messages this window actually landed on the server. The upload hooks
+// bump it after a successful POST; session-end reads it so it can tell "nothing
+// to save" apart from "the saving hooks never ran" instead of assuming success.
+export function recordMessageSave(count: number = 1, sessionId?: string): void {
+  try {
+    writeFileSync(
+      savesFile(sessionId),
+      JSON.stringify({ saved: getMessageSaveCount(sessionId) + count, at: Date.now() }),
+    );
+  } catch {
+    // best-effort — a missing tally only costs us a false "broken" warning
+  }
+}
+
+export function getMessageSaveCount(sessionId?: string): number {
+  try {
+    return JSON.parse(readFileSync(savesFile(sessionId), "utf-8")).saved ?? 0;
+  } catch {
+    return 0;
+  }
+}
+
 // Clean up this window's files when its session ends, so they don't accumulate.
 export function clearSessionFiles(sessionId?: string): void {
   if (!sessionId) return;
-  for (const f of [stateFile(sessionId), sessionFile(sessionId)]) {
+  for (const f of [stateFile(sessionId), sessionFile(sessionId), savesFile(sessionId)]) {
     try { unlinkSync(f); } catch { /* already gone */ }
   }
 }

--- a/plugins/honcho/src/state.ts
+++ b/plugins/honcho/src/state.ts
@@ -7,7 +7,7 @@
 
 import { homedir } from "os";
 import { join } from "path";
-import { writeFileSync, readFileSync, unlinkSync, mkdirSync } from "fs";
+import { writeFileSync, readFileSync, appendFileSync, unlinkSync, mkdirSync } from "fs";
 
 const DIR = join(homedir(), ".honcho");
 
@@ -27,7 +27,7 @@ function sessionFile(sessionId?: string): string {
 // it, since clearSessionFiles needs a session_id). No key means no tally, and
 // session-end reports the validation as unavailable rather than guessing.
 function savesFile(sessionId: string): string {
-  return join(DIR, `saves-${sessionId}.json`);
+  return join(DIR, `saves-${sessionId}.jsonl`);
 }
 
 export type MemoryPhase =
@@ -68,17 +68,22 @@ export interface MessageSaveTally {
   assistant: number;
 }
 
+// Append-only, one event per line, because the two writers are separate
+// processes with no lock between them: Stop can still be posting a batch while
+// the next UserPromptSubmit fires. A read-modify-write of a single JSON object
+// would let one hook overwrite the other's increment, and a dropped user
+// increment is exactly what session-end reads as "nothing was saved". An
+// O_APPEND write of one short line does not interleave, so the events survive
+// and the reader sums them.
 export function recordMessageSave(role: MessageRole, count: number = 1, sessionId?: string): void {
   if (!sessionId) return;
   try {
     // The write has to survive a missing ~/.honcho: a silently dropped tally
     // would make session-end report a working save path as broken.
     mkdirSync(DIR, { recursive: true });
-    const tally = getMessageSaveTally(sessionId);
-    tally[role] += count;
-    writeFileSync(
+    appendFileSync(
       savesFile(sessionId),
-      JSON.stringify({ ...tally, at: Date.now() }),
+      `${JSON.stringify({ role, count, at: Date.now() })}\n`,
     );
   } catch {
     // best-effort — a missing tally only costs us a false "broken" warning
@@ -86,19 +91,34 @@ export function recordMessageSave(role: MessageRole, count: number = 1, sessionI
 }
 
 export function getMessageSaveTally(sessionId?: string): MessageSaveTally {
-  if (!sessionId) return { user: 0, assistant: 0 };
+  const tally: MessageSaveTally = { user: 0, assistant: 0 };
+  if (!sessionId) return tally;
   try {
-    const raw = JSON.parse(readFileSync(savesFile(sessionId), "utf-8"));
-    return { user: raw.user ?? 0, assistant: raw.assistant ?? 0 };
+    for (const line of readFileSync(savesFile(sessionId), "utf-8").split("\n")) {
+      if (!line) continue;
+      try {
+        const entry = JSON.parse(line) as { role?: string; count?: number };
+        // A torn or unknown line is skipped rather than failing the whole
+        // tally: undercounting costs a warning, discarding everything hides
+        // the saves that did land.
+        if (entry.role === "user" || entry.role === "assistant") {
+          tally[entry.role] += entry.count ?? 0;
+        }
+      } catch {
+        continue;
+      }
+    }
   } catch {
-    return { user: 0, assistant: 0 };
+    // no tally file — the hooks never got as far as a successful upload
   }
+  return tally;
 }
 
 // Clean up this window's files when its session ends, so they don't accumulate.
 export function clearSessionFiles(sessionId?: string): void {
   if (!sessionId) return;
-  for (const f of [stateFile(sessionId), sessionFile(sessionId), savesFile(sessionId)]) {
+  const legacyTally = join(DIR, `saves-${sessionId}.json`); // pre-JSONL tally
+  for (const f of [stateFile(sessionId), sessionFile(sessionId), savesFile(sessionId), legacyTally]) {
     try { unlinkSync(f); } catch { /* already gone */ }
   }
 }

--- a/plugins/honcho/src/state.ts
+++ b/plugins/honcho/src/state.ts
@@ -7,7 +7,7 @@
 
 import { homedir } from "os";
 import { join } from "path";
-import { writeFileSync, readFileSync, unlinkSync } from "fs";
+import { writeFileSync, readFileSync, unlinkSync, mkdirSync } from "fs";
 
 const DIR = join(homedir(), ".honcho");
 
@@ -21,8 +21,13 @@ function stateFile(sessionId?: string): string {
 function sessionFile(sessionId?: string): string {
   return join(DIR, sessionId ? `session-${sessionId}.json` : "session.json");
 }
-function savesFile(sessionId?: string): string {
-  return join(DIR, sessionId ? `saves-${sessionId}.json` : "saves.json");
+// Unlike the state/session files above there is no global fallback: a tally is
+// only meaningful for one window, and a shared file would let a session with no
+// session_id read a stale positive count left by an earlier one (nothing clears
+// it, since clearSessionFiles needs a session_id). No key means no tally, and
+// session-end reports the validation as unavailable rather than guessing.
+function savesFile(sessionId: string): string {
+  return join(DIR, `saves-${sessionId}.json`);
 }
 
 export type MemoryPhase =
@@ -53,22 +58,40 @@ export function setSessionLink(url: string, name: string | undefined, sessionId?
 // Tally of messages this window actually landed on the server. The upload hooks
 // bump it after a successful POST; session-end reads it so it can tell "nothing
 // to save" apart from "the saving hooks never ran" instead of assuming success.
-export function recordMessageSave(count: number = 1, sessionId?: string): void {
+// User and assistant saves are counted separately on purpose: Stop and
+// UserPromptSubmit fail independently, so a single total would let a successful
+// assistant upload hide the fact that the user's own message never landed.
+export type MessageRole = "user" | "assistant";
+
+export interface MessageSaveTally {
+  user: number;
+  assistant: number;
+}
+
+export function recordMessageSave(role: MessageRole, count: number = 1, sessionId?: string): void {
+  if (!sessionId) return;
   try {
+    // The write has to survive a missing ~/.honcho: a silently dropped tally
+    // would make session-end report a working save path as broken.
+    mkdirSync(DIR, { recursive: true });
+    const tally = getMessageSaveTally(sessionId);
+    tally[role] += count;
     writeFileSync(
       savesFile(sessionId),
-      JSON.stringify({ saved: getMessageSaveCount(sessionId) + count, at: Date.now() }),
+      JSON.stringify({ ...tally, at: Date.now() }),
     );
   } catch {
     // best-effort — a missing tally only costs us a false "broken" warning
   }
 }
 
-export function getMessageSaveCount(sessionId?: string): number {
+export function getMessageSaveTally(sessionId?: string): MessageSaveTally {
+  if (!sessionId) return { user: 0, assistant: 0 };
   try {
-    return JSON.parse(readFileSync(savesFile(sessionId), "utf-8")).saved ?? 0;
+    const raw = JSON.parse(readFileSync(savesFile(sessionId), "utf-8"));
+    return { user: raw.user ?? 0, assistant: raw.assistant ?? 0 };
   } catch {
-    return 0;
+    return { user: 0, assistant: 0 };
   }
 }
 

--- a/plugins/honcho/tests/message-save-tally.test.ts
+++ b/plugins/honcho/tests/message-save-tally.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, test } from "bun:test";
+import { mkdtempSync, existsSync, rmSync, readdirSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+
+// state.ts resolves ~/.honcho through a module-level homedir() const, so the
+// tally runs in a child process with HOME pointed at a throwaway directory.
+function runInSandbox(home: string, script: string): string {
+  const env = Object.fromEntries(
+    Object.entries(process.env).filter(([k]) => !k.startsWith("HONCHO_"))
+  ) as Record<string, string>;
+  const proc = Bun.spawnSync(["bun", "-e", script], {
+    env: { ...env, HOME: home },
+    cwd: join(import.meta.dir, ".."),
+  });
+  if (proc.exitCode !== 0) throw new Error(proc.stderr.toString());
+  return proc.stdout.toString().trim();
+}
+
+describe("message save tally", () => {
+  test("counts user and assistant saves separately and clears them", () => {
+    const home = mkdtempSync(join(tmpdir(), "honcho-tally-"));
+    try {
+      const out = runInSandbox(
+        home,
+        `const s = await import("./src/state.ts");
+         s.recordMessageSave("user", 1, "sess-a");
+         s.recordMessageSave("assistant", 3, "sess-a");
+         s.recordMessageSave("user", 1, "sess-a");
+         s.recordMessageSave("user", 5, "sess-b");
+         const a = s.getMessageSaveTally("sess-a");
+         const b = s.getMessageSaveTally("sess-b");
+         s.clearSessionFiles("sess-a");
+         console.log(JSON.stringify({ a, b, after: s.getMessageSaveTally("sess-a") }));`
+      );
+      const { a, b, after } = JSON.parse(out);
+      // A failed UserPromptSubmit must stay visible behind a successful Stop.
+      expect(a).toEqual({ user: 2, assistant: 3 });
+      // Windows do not bleed into each other.
+      expect(b).toEqual({ user: 5, assistant: 0 });
+      expect(after).toEqual({ user: 0, assistant: 0 });
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  test("keeps no tally without a session_id, so none can go stale", () => {
+    const home = mkdtempSync(join(tmpdir(), "honcho-tally-"));
+    try {
+      const out = runInSandbox(
+        home,
+        `const s = await import("./src/state.ts");
+         s.recordMessageSave("user", 1);
+         console.log(JSON.stringify(s.getMessageSaveTally()));`
+      );
+      expect(JSON.parse(out)).toEqual({ user: 0, assistant: 0 });
+      const dir = join(home, ".honcho");
+      const files = existsSync(dir) ? readdirSync(dir) : [];
+      expect(files.filter((f) => f.startsWith("saves"))).toEqual([]);
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+});

--- a/plugins/honcho/tests/message-save-tally.test.ts
+++ b/plugins/honcho/tests/message-save-tally.test.ts
@@ -17,6 +17,25 @@ function runInSandbox(home: string, script: string): string {
   return proc.stdout.toString().trim();
 }
 
+// Same sandbox, but the writers run at once: the tally has no lock, so a
+// read-modify-write implementation loses increments here.
+async function runParallel(home: string, scripts: string[]): Promise<void> {
+  const env = Object.fromEntries(
+    Object.entries(process.env).filter(([k]) => !k.startsWith("HONCHO_"))
+  ) as Record<string, string>;
+  const procs = scripts.map((script) =>
+    Bun.spawn(["bun", "-e", script], {
+      env: { ...env, HOME: home },
+      cwd: join(import.meta.dir, ".."),
+      stdout: "pipe",
+      stderr: "pipe",
+    })
+  );
+  const codes = await Promise.all(procs.map((p) => p.exited));
+  const bad = codes.findIndex((c) => c !== 0);
+  if (bad !== -1) throw new Error(await new Response(procs[bad].stderr).text());
+}
+
 describe("message save tally", () => {
   test("counts user and assistant saves separately and clears them", () => {
     const home = mkdtempSync(join(tmpdir(), "honcho-tally-"));
@@ -57,6 +76,29 @@ describe("message save tally", () => {
       const dir = join(home, ".honcho");
       const files = existsSync(dir) ? readdirSync(dir) : [];
       expect(files.filter((f) => f.startsWith("saves"))).toEqual([]);
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+  test("survives concurrent writers from separate hook processes", async () => {
+    const home = mkdtempSync(join(tmpdir(), "honcho-tally-"));
+    try {
+      // Three writers per role, 20 saves each: Stop can still be posting a
+      // batch when the next UserPromptSubmit fires, and neither may clobber
+      // the other's count.
+      const writer = (role: string) =>
+        `const s = await import("./src/state.ts");
+         for (let i = 0; i < 20; i++) s.recordMessageSave("${role}", 1, "sess-race");`;
+      await runParallel(home, [
+        ...Array(3).fill(writer("user")),
+        ...Array(3).fill(writer("assistant")),
+      ]);
+      const out = runInSandbox(
+        home,
+        `const s = await import("./src/state.ts");
+         console.log(JSON.stringify(s.getMessageSaveTally("sess-race")));`
+      );
+      expect(JSON.parse(out)).toEqual({ user: 60, assistant: 60 });
     } finally {
       rmSync(home, { recursive: true, force: true });
     }


### PR DESCRIPTION
## Summary

- Session-end unconditionally logged "messages saved live" regardless of whether the upload hooks actually ran. If `UserPromptSubmit`/`Stop` died silently (e.g. a sub-second hook timeout killing the process before the POST completed), a full turn's worth of memory was lost with **no signal** — the log line claimed success.
- Adds a per-window tally in `state.ts` (`recordMessageSave`/`getMessageSaveCount`) that the upload hooks bump after a successful POST.
- `session-end.ts` now compares the tally against real user turns counted from the transcript. If turns > 0 but nothing was tallied, it logs an error naming the likely cause and the recovery path (`/honcho:import`) instead of a false success line.

Found and running in production on a fork that pins to an older local build; porting forward since the underlying gap (no detection when the saving hooks silently die) is still present on `main`.

## Test plan

- [x] `bun x tsc --noEmit` — clean
- [x] `bun test` — 30/30 pass
- [ ] Maintainer review of the tally-file lifecycle (per-session-id file under `~/.honcho`, cleaned up in `clearSessionFiles`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tracking of successfully saved user and assistant messages by session.
  * Session-end checks now identify missing, partial, and complete message saves.
  * Sessions without user messages are distinguished from sessions with missing user saves.
  * Save-count data is isolated by session and cleaned up when sessions end.
  * Saves without a session identifier no longer create misleading tracking data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->