### PR TITLE
fix: stop PreCompact printing verbose dumps into model context

### DIFF
--- a/plugins/honcho/src/hooks/pre-compact.ts
+++ b/plugins/honcho/src/hooks/pre-compact.ts
@@ -3,7 +3,7 @@ import { loadConfig, getSessionForPath, getSessionName, getHonchoClientOptions, 
 import { Spinner } from "../spinner.js";
 import { setMemoryState } from "../state.js";
 import { logHook, logApiCall, setLogContext } from "../log.js";
-import { formatVerboseBlock, formatVerboseList } from "../visual.js";
+import { verboseApiResult, verboseList } from "../visual.js";
 
 
 interface HookInput {
@@ -177,12 +177,12 @@ export async function handlePreCompact(): Promise<void> {
     const userContext = userContextResult.status === "fulfilled" ? userContextResult.value : null;
     const summaries = summariesResult.status === "fulfilled" ? summariesResult.value : null;
 
-    // Build verbose output blocks — these will be appended to stdout after the
-    // memory card. PreCompact stdout is only shown in Ctrl+O, so verbose data
-    // is hidden by default and visible when the user presses Ctrl+O.
-    const verboseBlocks: string[] = [];
-    verboseBlocks.push(formatVerboseBlock(`pre-compact ${contextLabel}`, (userContext as any)?.representation));
-    verboseBlocks.push(formatVerboseList("pre-compact peerCard", (userContext as any)?.peerCard));
+    // Verbose API data goes to ~/.honcho/verbose.log, never to stdout. This
+    // hook's stdout is fed to the model as compaction input — that is how the
+    // memory card below reaches the summary — so anything printed here is
+    // charged to context on every request until the next compaction.
+    verboseApiResult(`pre-compact ${contextLabel}`, (userContext as any)?.representation);
+    verboseList("pre-compact peerCard", (userContext as any)?.peerCard);
 
     const userDialectic =
       userChatResult.status === "fulfilled"
@@ -209,21 +209,16 @@ export async function handlePreCompact(): Promise<void> {
     }
     setMemoryState("idle", undefined, hookInput.session_id);
 
-    // Add dialectic responses to verbose output
     if (userDialectic) {
-      verboseBlocks.push(formatVerboseBlock(`pre-compact peer.chat(user) → "${config.peerName}"`, userDialectic));
+      verboseApiResult(`pre-compact peer.chat(user) → "${config.peerName}"`, userDialectic);
     }
     if (claudeDialectic) {
-      verboseBlocks.push(formatVerboseBlock(`pre-compact peer.chat(claude) → "${config.aiPeer}"`, claudeDialectic));
+      verboseApiResult(`pre-compact peer.chat(claude) → "${config.aiPeer}"`, claudeDialectic);
     }
 
     logHook("pre-compact", `Memory anchored (${memoryCard.length} chars)`);
 
-    // Output memory card to stdout, followed by verbose API data.
-    // PreCompact stdout is only shown in Ctrl+O, so the verbose blocks
-    // are hidden by default and visible when the user presses Ctrl+O.
-    const verboseOutput = verboseBlocks.filter(Boolean).join("\n");
-    console.log(`[${config.aiPeer}/Honcho Memory Anchor]\n\n${memoryCard}${verboseOutput}`);
+    console.log(`[${config.aiPeer}/Honcho Memory Anchor]\n\n${memoryCard}`);
     process.exit(0);
   } catch (error) {
     logHook("pre-compact", `Error: ${error}`, { error: String(error) });

--- a/plugins/honcho/src/hooks/pre-compact.ts
+++ b/plugins/honcho/src/hooks/pre-compact.ts
@@ -177,10 +177,10 @@ export async function handlePreCompact(): Promise<void> {
     const userContext = userContextResult.status === "fulfilled" ? userContextResult.value : null;
     const summaries = summariesResult.status === "fulfilled" ? summariesResult.value : null;
 
-    // Verbose API data goes to ~/.honcho/verbose.log, never to stdout. This
-    // hook's stdout is fed to the model as compaction input — that is how the
-    // memory card below reaches the summary — so anything printed here is
-    // charged to context on every request until the next compaction.
+    // Verbose API data goes to ~/.honcho/verbose.log. This hook's stdout is fed
+    // to the model as compaction input — that is how the memory card below
+    // reaches the summary — so anything printed here is charged to context on
+    // every request until the next compaction.
     verboseApiResult(`pre-compact ${contextLabel}`, (userContext as any)?.representation);
     verboseList("pre-compact peerCard", (userContext as any)?.peerCard);
 

--- a/plugins/honcho/src/visual.ts
+++ b/plugins/honcho/src/visual.ts
@@ -157,11 +157,12 @@ export function addSystemMessage(existingJson: any, message: string): any {
 // Verbose output — written to ~/.honcho/verbose.log
 // Tail with: tail -f ~/.honcho/verbose.log
 //
-// NOTE: This file-based verbose output is used by SessionStart and
-// UserPromptSubmit hooks, where stdout is always visible to Claude
-// (not just in Ctrl+O). For hooks where stdout is only shown in
-// Ctrl+O (PreCompact, PostToolUse, Stop, SessionEnd), prefer
-// printing verbose data to stdout instead — use formatVerboseBlock().
+// NOTE: Whether a hook's stdout reaches the model is per hook event, so
+// verbose data is only safe on stdout for events that are confirmed
+// Ctrl+O-only. SessionStart, UserPromptSubmit and PreCompact all feed
+// stdout to the model — PreCompact by way of the compaction input — so
+// those hooks must use this file-based path. Reach for the stdout
+// formatters below only for an event confirmed not to be in that group.
 // ============================================
 
 import { homedir } from "os";
@@ -186,8 +187,8 @@ function writeVerbose(text: string): void {
 
 /**
  * Log detailed API response data to verbose log file (~/.honcho/verbose.log).
- * Used by SessionStart and UserPromptSubmit hooks where stdout is always
- * visible to Claude (so we can't use stdout for debug data).
+ * Used by SessionStart, UserPromptSubmit and PreCompact, whose stdout reaches
+ * the model (so we can't use stdout for debug data).
  * View with: tail -f ~/.honcho/verbose.log
  */
 export function verboseApiResult(label: string, data: string | null | undefined): void {
@@ -199,7 +200,7 @@ export function verboseApiResult(label: string, data: string | null | undefined)
 
 /**
  * Log a list of items (like peerCard) to verbose log file (~/.honcho/verbose.log).
- * Used by SessionStart and UserPromptSubmit hooks (stdout always visible).
+ * Used by SessionStart, UserPromptSubmit and PreCompact (stdout reaches the model).
  */
 export function verboseList(label: string, items: string[] | null | undefined): void {
   if (!items || items.length === 0) return;
@@ -226,15 +227,16 @@ export function getVerboseLogPath(): string {
 // ============================================
 // Stdout-based verbose output — for Ctrl+O visibility
 //
-// In Claude Code, Ctrl+O toggles visibility of hook stdout.
-// For hooks where stdout is only shown in Ctrl+O (PreCompact,
-// PostToolUse, Stop, SessionEnd), we can print verbose data
-// directly to stdout so it appears when the user presses Ctrl+O.
+// In Claude Code, Ctrl+O toggles visibility of hook stdout. Where an
+// event's stdout is genuinely Ctrl+O-only, verbose data can be printed
+// there so it surfaces on Ctrl+O without reaching the model. Confirm
+// that per event before using these: on an event whose stdout is model
+// context, they charge the payload to every request that follows.
 // ============================================
 
 /**
  * Format verbose API response data as a plain-text block for stdout.
- * Use in hooks where stdout is only visible in Ctrl+O (PreCompact, Stop, etc.).
+ * Use only in hooks whose stdout is confirmed not to reach the model.
  * Returns empty string if data is null/undefined.
  */
 export function formatVerboseBlock(label: string, data: string | null | undefined): string {
@@ -246,7 +248,7 @@ export function formatVerboseBlock(label: string, data: string | null | undefine
 
 /**
  * Format a list of items as a plain-text block for stdout.
- * Use in hooks where stdout is only visible in Ctrl+O (PreCompact, Stop, etc.).
+ * Use only in hooks whose stdout is confirmed not to reach the model.
  * Returns empty string if items is null/undefined/empty.
  */
 export function formatVerboseList(label: string, items: string[] | null | undefined): string {

--- a/plugins/honcho/src/visual.ts
+++ b/plugins/honcho/src/visual.ts
@@ -157,12 +157,10 @@ export function addSystemMessage(existingJson: any, message: string): any {
 // Verbose output — written to ~/.honcho/verbose.log
 // Tail with: tail -f ~/.honcho/verbose.log
 //
-// NOTE: Whether a hook's stdout reaches the model is per hook event, so
-// verbose data is only safe on stdout for events that are confirmed
-// Ctrl+O-only. SessionStart, UserPromptSubmit and PreCompact all feed
-// stdout to the model — PreCompact by way of the compaction input — so
-// those hooks must use this file-based path. Reach for the stdout
-// formatters below only for an event confirmed not to be in that group.
+// Whether a hook's stdout reaches the model varies by hook event.
+// SessionStart, UserPromptSubmit and PreCompact all feed stdout to the
+// model — PreCompact by way of the compaction input — so those hooks
+// use this file-based path.
 // ============================================
 
 import { homedir } from "os";
@@ -228,15 +226,15 @@ export function getVerboseLogPath(): string {
 // Stdout-based verbose output — for Ctrl+O visibility
 //
 // In Claude Code, Ctrl+O toggles visibility of hook stdout. Where an
-// event's stdout is genuinely Ctrl+O-only, verbose data can be printed
-// there so it surfaces on Ctrl+O without reaching the model. Confirm
-// that per event before using these: on an event whose stdout is model
-// context, they charge the payload to every request that follows.
+// event's stdout is Ctrl+O-only, verbose data can be printed there
+// rather than logged to file. Confirm that per event: on an event whose
+// stdout is model context, these charge the payload to every request
+// that follows.
 // ============================================
 
 /**
  * Format verbose API response data as a plain-text block for stdout.
- * Use only in hooks whose stdout is confirmed not to reach the model.
+ * Use in hooks whose stdout does not reach the model.
  * Returns empty string if data is null/undefined.
  */
 export function formatVerboseBlock(label: string, data: string | null | undefined): string {
@@ -248,7 +246,7 @@ export function formatVerboseBlock(label: string, data: string | null | undefine
 
 /**
  * Format a list of items as a plain-text block for stdout.
- * Use only in hooks whose stdout is confirmed not to reach the model.
+ * Use in hooks whose stdout does not reach the model.
  * Returns empty string if items is null/undefined/empty.
  */
 export function formatVerboseList(label: string, items: string[] | null | undefined): string {

--- a/plugins/honcho/tests/precompact-stdout.test.ts
+++ b/plugins/honcho/tests/precompact-stdout.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "fs";
+import { join } from "path";
+
+// PreCompact's stdout is the compaction input, so everything printed there is
+// charged to context on every request until the next compaction. The memory
+// card has to be there; verbose API dumps must not, and they duplicate the card
+// almost exactly when they are. The stdout formatters have no logging gate, so
+// the guard is that this hook never reaches for them in the first place.
+const preCompactSource = readFileSync(join(import.meta.dir, "..", "src", "hooks", "pre-compact.ts"), "utf-8");
+
+describe("pre-compact stdout stays free of verbose dumps", () => {
+  test("does not call the stdout verbose formatters", () => {
+    expect(preCompactSource).not.toMatch(/formatVerbose(Block|List)\s*\(/);
+  });
+
+  test("routes verbose data to the log file instead", () => {
+    expect(preCompactSource).toMatch(/verboseApiResult\s*\(/);
+    expect(preCompactSource).toMatch(/verboseList\s*\(/);
+  });
+
+  test("prints the memory card and nothing appended after it", () => {
+    const logged = preCompactSource.match(/console\.log\((.*)\);/g) ?? [];
+    expect(logged).toHaveLength(1);
+    expect(logged[0]).toContain("${memoryCard}`)");
+  });
+});

--- a/plugins/honcho/tests/precompact-stdout.test.ts
+++ b/plugins/honcho/tests/precompact-stdout.test.ts
@@ -2,11 +2,11 @@ import { describe, expect, test } from "bun:test";
 import { readFileSync } from "fs";
 import { join } from "path";
 
-// PreCompact's stdout is the compaction input, so everything printed there is
-// charged to context on every request until the next compaction. The memory
-// card has to be there; verbose API dumps must not, and they duplicate the card
-// almost exactly when they are. The stdout formatters have no logging gate, so
-// the guard is that this hook never reaches for them in the first place.
+// PreCompact's stdout is compaction input, and the stdout formatters carry no
+// logging gate, so the invariant is that this hook never reaches for them. The
+// runtime path needs a live Honcho client, so these assert against source text
+// instead — a rename or a reformat of the console.log will fail them with
+// nothing actually wrong. Read a failure as "check what moved" first.
 const preCompactSource = readFileSync(join(import.meta.dir, "..", "src", "hooks", "pre-compact.ts"), "utf-8");
 
 describe("pre-compact stdout stays free of verbose dumps", () => {


### PR DESCRIPTION
Fixes #121.

## What was wrong

`PreCompact` appended `[verbose]` blocks to the same stdout that carries the memory anchor. That stdout is compaction input — it is how the anchor reaches the summary at all — so each compaction shipped a second verbatim copy of the peerCard, the representation, and both dialectic answers. On one measured run that was 10,692 of 26,772 chars, about 40% of the payload, and because it lands in the post-compaction prefix it is re-read on every request until the next compaction rather than paid once.

`visual.ts` already splits the verbose helpers by whether a hook's stdout reaches the model, and it filed `PreCompact` on the Ctrl+O-only side:

```
// For hooks where stdout is only shown in Ctrl+O (PreCompact, PostToolUse,
// Stop, SessionEnd), prefer printing verbose data to stdout instead
```

That premise doesn't hold for `PreCompact`, and the evidence is in the hook itself — `memoryCard` and `verboseOutput` leave through one `console.log`, and `memoryCard` opens with *"These conclusions MUST be preserved in the summary."* Whatever channel carries the anchor carries the duplicate.

## What this does

- `pre-compact.ts` uses `verboseApiResult()` / `verboseList()` instead of `formatVerboseBlock()` / `formatVerboseList()`, so the same data lands in `~/.honcho/verbose.log` behind the existing `isLoggingEnabled()` gate. Nothing is lost — `tail -f ~/.honcho/verbose.log` shows it as it does for the other hooks.
- The `visual.ts` comments no longer file `PreCompact` under Ctrl+O-only, so the next person doesn't reach for the stdout formatters here again.

I have not tested `PostToolUse`, `Stop`, or `SessionEnd`, so I have left those alone and reworded the guidance to say "confirm per event" rather than asserting anything about them.

## Scope notes

The stdout formatters are now unused. I have left them exported rather than delete them in a bugfix — happy to drop them in a follow-up if you'd rather.

They also still have no `isLoggingEnabled()` gate of their own, which is why the regression test guards the call site rather than the rendered output. That unguarded-emission pattern is shared with #80 (different call site, and that one goes to the UI rather than into context), so it may be worth a single gate across both.

## Checks

`bun test` 33/33 (3 new), `bunx tsc --noEmit` clean, `bun run scripts/build.ts` stages fine and the formatters drop out of the bundle. The three new tests fail on `main` and pass here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Pre-compaction output now displays only the memory card, preventing verbose API details from being sent to the model.
  * Verbose diagnostic information is now recorded separately in the Honcho log file.

* **Documentation**
  * Clarified which hook events use file logging versus visible verbose output.

* **Tests**
  * Added coverage to verify clean pre-compaction output and proper verbose logging behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->