### PR TITLE
feat: model-id attribution via message + session metadata

### DIFF
--- a/docs/adr/ADR-0001-model-id-as-message-metadata.md
+++ b/docs/adr/ADR-0001-model-id-as-message-metadata.md
@@ -1,0 +1,81 @@
+# ADR-0001: Model-id als message-metadata voor alle Honcho-clients
+
+**Status:** Accepted
+**Date:** 2026-08-29
+**Deciders:** Geert van Zoest
+
+## Context
+
+Honcho-sessies tonen als afzender alleen de stabiele AI-peer-naam (bv. `claude`,
+`opencode`, `hermes`). Voor Geert is het wezenlijk om te zien met welk model een
+bericht/sessie is geproduceerd (`claude-fable-5` vs `claude-opus-4-8`;
+`gemma-4-26b`/`gpt-oss-20b` bij Hermes/OpenCode). Drie clients schrijven naar
+dezelfde Honcho-instantie: het claude-honcho plugin (deze repo), de
+opencode-integratie en hermes-agent. Honcho biedt op workspace-, peer-, sessie-
+én message-niveau een user-facing `metadata` key-value store (`h_metadata`
+JSONB); de officiële SDK-docs gebruiken zelf applicatie-eigen metadata-keys als
+voorbeeld. Council-gereviewde research: zie sessie-synthese 2026-08-29
+(star-chamber: gpt-5.4/glm-5.2/kimi-k3, geen blockers).
+
+## Decision
+
+Elke client stuurt het model-id mee als **message-metadata onder de key
+`model`** (lowercase, het volledige model-id zoals de runtime het rapporteert).
+Secundair houdt de client **sessie-metadata** bij: `models` (array van geziene
+model-ids, volgorde van eerste optreden) en `last_model` — best-effort,
+additief via get-merge-set. De peer-naam blijft stabiel per client.
+
+## Options Considered
+
+### Option A: `metadata.model` per message + sessie-metadata (gekozen)
+
+| Dimension | Assessment |
+|-----------|------------|
+| Complexity | Low — bestaand metadata-mechanisme (naast `instance_id`, `type`, `session_affinity`) |
+| Cost | Verwaarloosbaar; sessie-update alleen bij modelwissel |
+| Scalability | Werkt per bericht, ook bij mid-sessie modelwissel (fast mode, subagents) |
+| Team familiarity | Hoog — zelfde patroon in alle drie clients |
+
+**Pros:** één representatie/werkgeheugen per peer blijft intact; per bericht
+exact; queryable; consistent over clients.
+**Cons:** panel moet metadata renderen (UI-wijziging in honcho-panel);
+historische berichten missen de key.
+
+### Option B: peer-naam = model-id (afgewezen)
+
+| Dimension | Assessment |
+|-----------|------------|
+| Complexity | Low in de client, High in de gevolgen |
+| Cost | Fragmentatie van representatie en werkgeheugen over N peers |
+| Scalability | Slecht — elke modelwissel/fast-mode/subagent splitst de peer |
+| Team familiarity | n.v.t. |
+
+**Pros:** direct zichtbaar in elke bestaande UI zonder panel-wijziging.
+**Cons:** Honcho bouwt per peer een representatie op; peer-per-model
+fragmenteert het AI-zelfbeeld en de dialectic-context; sessie-deelname en
+peer-config (SessionPeerConfig) verveelvoudigen; historie breekt bij elke
+modelbump.
+
+## Trade-off Analysis
+
+Zichtbaarheid (B) is met een kleine panel-wijziging ook via A te bereiken; de
+geheugen-fragmentatie van B is niet te repareren zonder datamigratie. Het
+sessie-metadata-deel van A is bewust best-effort: `PUT /sessions/{id}` vervangt
+het metadata-object, dus get-merge-set met alleen eigen keys; bij parallelle
+schrijvers geldt last-writer-wins — acceptabel voor observability, geen harde
+invariant.
+
+## Consequences
+
+- Makkelijker: model-attributie per bericht en per sessie, uniform over clients.
+- Moeilijker: honcho-panel moet `metadata.model` en `last_model`/`models`
+  renderen; afwezige key tonen als "onbekend".
+- Te herzien: zodra Honcho upstream een first-class model-/agent-attributieveld
+  introduceert, migreren we daarheen (upstream-first).
+
+## Action Items
+
+1. [ ] claude-honcho: `model` uit transcript-JSONL (`message.model`) → message-metadata + sessie-metadata (issue + PR, deze repo)
+2. [ ] hermes-agent: zelfde keys bij de message-flush (issue in hermes-agent-config-repo)
+3. [ ] opencode: zelfde keys in de opencode-Honcho-integratie (issue in opencode-config-repo)
+4. [ ] honcho-panel: model-badge per bericht + sessie-niveau weergave (issue in honcho-panel-repo)

--- a/plugins/honcho/src/cache.ts
+++ b/plugins/honcho/src/cache.ts
@@ -21,7 +21,7 @@ function ensureCacheDir(): void {
 interface IdCache {
   workspace?: { name: string; id: string };
   peers?: Record<string, string>; // peerName -> peerId
-  sessions?: Record<string, { name: string; id: string; updatedAt: string; instanceId?: string }>; // cwd -> session info
+  sessions?: Record<string, { name: string; id: string; updatedAt: string; instanceId?: string; lastModel?: string }>; // cwd -> session info
   claudeInstanceId?: string; // DEPRECATED: use per-cwd instanceId in sessions map instead
 }
 
@@ -77,6 +77,23 @@ export function setCachedSessionId(cwd: string, name: string, id: string, instan
   const cache = loadIdCache();
   if (!cache.sessions) cache.sessions = {};
   cache.sessions[cwd] = { name, id, updatedAt: new Date().toISOString(), instanceId };
+  saveIdCache(cache);
+}
+
+export function getCachedSessionModel(cwd: string, sessionName: string): string | null {
+  const cache = loadIdCache();
+  const entry = cache.sessions?.[cwd];
+  // A cached model only counts for the session it was recorded against;
+  // a rotated/renamed session must re-sync its metadata.
+  if (!entry || entry.name !== sessionName) return null;
+  return entry.lastModel || null;
+}
+
+export function setCachedSessionModel(cwd: string, sessionName: string, model: string): void {
+  const cache = loadIdCache();
+  const entry = cache.sessions?.[cwd];
+  if (!entry || entry.name !== sessionName) return; // only annotate sessions we already track
+  entry.lastModel = model;
   saveIdCache(cache);
 }
 

--- a/plugins/honcho/src/hooks/stop.ts
+++ b/plugins/honcho/src/hooks/stop.ts
@@ -1,7 +1,7 @@
 import { Honcho, Session, Peer } from "@honcho-ai/sdk";
 import { loadConfig, getSessionForPath, getSessionName, getHonchoClientOptions, isPluginEnabled, getCachedStdin, readStdinText } from "../config.js";
 import { existsSync, readFileSync } from "fs";
-import { getInstanceIdForCwd, chunkContent, addMessagesBatched } from "../cache.js";
+import { getInstanceIdForCwd, chunkContent, addMessagesBatched, getCachedSessionModel, setCachedSessionModel } from "../cache.js";
 import { logHook, logApiCall, setLogContext } from "../log.js";
 import { visStopMessage } from "../visual.js";
 
@@ -22,6 +22,7 @@ interface TranscriptEntry {
   origin?: { kind?: string };
   message?: {
     role?: string;
+    model?: string;
     content: string | Array<{ type: string; text?: string; name?: string; input?: any }>;
   };
   content?: string | Array<{ type: string; text?: string }>;
@@ -59,7 +60,7 @@ function assistantText(entry: TranscriptEntry): string {
 /** Assistant text blocks of the just-completed segment: everything since the last
  *  real user prompt OR wakeup boundary. Wakeup firings would otherwise re-collect
  *  the whole accumulated turn, duplicating blocks already uploaded. */
-export function getCurrentTurnAssistantMessages(transcriptPath: string): Array<{ text: string; timestamp?: string }> {
+export function getCurrentTurnAssistantMessages(transcriptPath: string): Array<{ text: string; timestamp?: string; model?: string }> {
   if (!transcriptPath || !existsSync(transcriptPath)) return [];
 
   let lines: string[];
@@ -85,13 +86,13 @@ export function getCurrentTurnAssistantMessages(transcriptPath: string): Array<{
   // return nothing if there's no last prompt
   if (lastPromptIdx === -1) return [];
 
-  const blocks: Array<{ text: string; timestamp?: string }> = [];
+  const blocks: Array<{ text: string; timestamp?: string; model?: string }> = [];
   for (let i = lastPromptIdx + 1; i < lines.length; i++) {
     try {
       const entry: TranscriptEntry = JSON.parse(lines[i]);
       if ((entry.type || entry.role) !== "assistant") continue;
       const text = assistantText(entry);
-      if (text && text.trim()) blocks.push({ text, timestamp: entry.timestamp });
+      if (text && text.trim()) blocks.push({ text, timestamp: entry.timestamp, model: entry.message?.model });
     } catch {
       continue;
     }
@@ -166,6 +167,7 @@ export async function handleStop(): Promise<void> {
             instance_id: instanceId || undefined,
             type: i === lastIdx ? "assistant_response" : "assistant_intermediate",
             session_affinity: sessionName,
+            model: block.model || undefined,
           },
         })
       )
@@ -180,6 +182,25 @@ export async function handleStop(): Promise<void> {
 
     logHook("stop", `Saved ${turnMessages.length} assistant message(s)`);
     visStopMessage("out", `saved ${turnMessages.length} assistant msg(s)`);
+
+    // Best-effort model attribution on session metadata (ADR-0001). The local
+    // cache gates the extra roundtrip to actual model changes; setMetadata
+    // overwrites the whole object, so merge onto a fresh read and only touch
+    // our own keys. Last-writer-wins across parallel sessions is acceptable.
+    let turnModel: string | undefined;
+    for (let i = turnMessages.length - 1; i >= 0 && !turnModel; i--) turnModel = turnMessages[i].model;
+    if (turnModel && getCachedSessionModel(cwd, sessionName) !== turnModel) {
+      try {
+        const current = await session.getMetadata();
+        const models = Array.isArray(current.models) ? (current.models as string[]) : [];
+        if (!models.includes(turnModel)) models.push(turnModel);
+        await session.setMetadata({ ...current, models, last_model: turnModel });
+        setCachedSessionModel(cwd, sessionName, turnModel);
+        logApiCall("session.setMetadata", "PUT", `last_model=${turnModel}`);
+      } catch (e) {
+        logHook("stop", `Session model metadata update failed: ${e}`);
+      }
+    }
   } catch (error) {
     logHook("stop", `Upload failed: ${error}`, { error: String(error) });
   }

--- a/plugins/honcho/tests/stop-boundary.test.ts
+++ b/plugins/honcho/tests/stop-boundary.test.ts
@@ -53,3 +53,23 @@ describe("getCurrentTurnAssistantMessages segment boundaries", () => {
     expect(getCurrentTurnAssistantMessages(path)).toEqual([]);
   });
 });
+
+describe("model attribution (ADR-0001)", () => {
+  test("model from the transcript entry is carried on each block", () => {
+    const withModel = { type: "assistant", timestamp: "t1", message: { model: "claude-fable-5", content: [{ type: "text", text: "hi" }] } };
+    const path = transcript([prompt, withModel]);
+    expect(getCurrentTurnAssistantMessages(path)).toEqual([{ text: "hi", timestamp: "t1", model: "claude-fable-5" }]);
+  });
+
+  test("entries without a model yield model undefined", () => {
+    const path = transcript([prompt, msgA]);
+    expect(getCurrentTurnAssistantMessages(path)[0]?.model).toBeUndefined();
+  });
+
+  test("mid-turn model switch keeps per-block attribution", () => {
+    const a = { type: "assistant", timestamp: "t1", message: { model: "claude-opus-4-8", content: [{ type: "text", text: "a" }] } };
+    const b = { type: "assistant", timestamp: "t2", message: { model: "claude-fable-5", content: [{ type: "text", text: "b" }] } };
+    const path = transcript([prompt, a, b]);
+    expect(getCurrentTurnAssistantMessages(path).map((x) => x.model)).toEqual(["claude-opus-4-8", "claude-fable-5"]);
+  });
+});


### PR DESCRIPTION
Fixes #123

Adds model attribution per ADR-0001 (docs/adr, included in this PR):

- message.model from the transcript JSONL is carried per assistant block and uploaded as metadata.model on every chunk (stop hook)
- Best-effort session metadata models[] + last_model via get-merge-set (setMetadata overwrites, so we merge onto a fresh read and only touch our own keys); a per-session local cache gates the extra roundtrip to actual model changes
- Peer name stays stable: peer-per-model was explicitly rejected because it fragments the peer representation and working memory across model switches (fast mode, subagents)

Tests: 3 new cases in stop-boundary.test.ts (per-block attribution, absent key, mid-turn model switch); full suite 33 pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Assistant messages now record the model used to generate each message.
  * Sessions maintain a best-effort history of models used and identify the most recently used model.
  * Model information is preserved when switching models during a conversation.

* **Documentation**
  * Added guidance describing model metadata handling and its impact across integrations and the user interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->