### PR TITLE
feat: allow extra HTTP headers on Honcho requests (self-hosting behind an authenticating proxy)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to claude-honcho will be documented in this file.
 
 ## [0.3.0] - unreleased
 
+### Added
+
+- `endpoint.headers` config key and `HONCHO_HEADERS` env var — extra HTTP headers sent on every request, so a self-hosted deployment behind an authenticating proxy (Cloudflare Access, oauth2-proxy, Authelia) can be reached. Omitted from the client entirely when unset.
+
 ### Changed
 
 - The plugin is distributed as the npm package `@honcho-ai/claude-honcho` and the marketplace installs from it. Releases ship a self-contained bundle that runs under Node, so Bun is no longer a prerequisite for using the plugin — it remains the development toolchain.

--- a/README.md
+++ b/README.md
@@ -384,6 +384,7 @@ Environment variables work for initial bootstrap (before a config file exists). 
 | `HONCHO_AI_PEER`       | No       | `claude`      | AI peer name                                                      |
 | `HONCHO_HOST`          | No       | auto-detected | Force host detection: `claude_code`, `cursor`, or `obsidian`      |
 | `HONCHO_ENDPOINT`      | No       | `production`  | `production`, `local`, or a full URL                              |
+| `HONCHO_HEADERS`       | No       | —             | JSON object of extra HTTP headers, for self-hosting behind an authenticating proxy |
 | `HONCHO_ENABLED`       | No       | `true`        | Set to `false` to disable                                         |
 | `HONCHO_SAVE_MESSAGES` | No       | `true`        | Set to `false` to stop saving messages                            |
 | `HONCHO_LOGGING`       | No       | `true`        | Set to `false` to disable file logging to `~/.honcho/`            |
@@ -460,6 +461,37 @@ export HONCHO_ENDPOINT="local"  # Uses localhost:8000
 # or
 export HONCHO_ENDPOINT="http://your-server:8000/v3"
 ```
+
+#### Behind an authenticating proxy
+
+If your deployment sits behind something that authenticates the request before
+Honcho ever sees it — Cloudflare Access, oauth2-proxy, Authelia — add the
+credential headers it expects. `apiKey` authenticates you to Honcho;
+`endpoint.headers` authenticates you to whatever stands in front of it.
+
+```json
+{
+  "endpoint": {
+    "baseUrl": "https://honcho.example.com",
+    "headers": {
+      "CF-Access-Client-Id": "<client-id>",
+      "CF-Access-Client-Secret": "<client-secret>"
+    }
+  }
+}
+```
+
+Or via env var, which keeps the secret out of the config file:
+
+```bash
+export HONCHO_HEADERS='{"CF-Access-Client-Id":"...","CF-Access-Client-Secret":"..."}'
+```
+
+Without this, the proxy answers every request with its own login page instead of
+passing it to Honcho, and the SDK fails parsing HTML as JSON:
+`SyntaxError: Unexpected token '<', "<!DOCTYPE "... is not valid JSON`. The
+hooks fail silently, so the first symptom is usually that nothing is being
+remembered.
 
 ### Temporarily disabling memory
 

--- a/plugins/honcho/src/config.ts
+++ b/plugins/honcho/src/config.ts
@@ -146,6 +146,16 @@ export interface HonchoEndpointConfig {
   environment?: HonchoEnvironment;
   /** Custom URL override (takes precedence over environment) */
   baseUrl?: string;
+  /**
+   * Extra HTTP headers sent on every request to Honcho.
+   *
+   * For self-hosted deployments sitting behind an authenticating proxy, which
+   * gates the request before Honcho ever sees it -- Cloudflare Access
+   * (`CF-Access-Client-Id` / `CF-Access-Client-Secret`), oauth2-proxy,
+   * Authelia. `apiKey` authenticates to Honcho; this authenticates to whatever
+   * stands in front of it. Ignored when unset.
+   */
+  headers?: Record<string, string>;
 }
 
 const HONCHO_BASE_URLS = {
@@ -564,7 +574,32 @@ export function loadConfigFromEnv(host?: HonchoHost): HonchoCLAUDEConfig | null 
     }
   }
 
+  if (process.env.HONCHO_HEADERS) {
+    const headers = parseHeaders(process.env.HONCHO_HEADERS);
+    if (headers) config.endpoint = { ...config.endpoint, headers };
+  }
+
   return config;
+}
+
+/**
+ * Parse a JSON object of header name -> value.
+ *
+ * Malformed input is ignored rather than fatal: a broken env var should not
+ * stop a hook whose output the user never sees.
+ */
+export function parseHeaders(raw: string): Record<string, string> | undefined {
+  try {
+    const parsed = JSON.parse(raw);
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return undefined;
+    const headers: Record<string, string> = {};
+    for (const [key, value] of Object.entries(parsed)) {
+      if (typeof value === "string") headers[key] = value;
+    }
+    return Object.keys(headers).length > 0 ? headers : undefined;
+  } catch {
+    return undefined;
+  }
 }
 
 /**
@@ -593,6 +628,10 @@ function mergeWithEnvVars(config: HonchoCLAUDEConfig): HonchoCLAUDEConfig {
   }
   if (process.env.HONCHO_SAVE_GIT_EVENTS !== undefined) {
     config.saveGitEvents = process.env.HONCHO_SAVE_GIT_EVENTS === "true";
+  }
+  if (process.env.HONCHO_HEADERS) {
+    const headers = parseHeaders(process.env.HONCHO_HEADERS);
+    if (headers) config.endpoint = { ...config.endpoint, headers };
   }
   return config;
 }
@@ -959,6 +998,8 @@ export interface HonchoClientOptions {
   workspaceId: string;
   timeout?: number;
   maxRetries?: number;
+  /** Extra headers merged into every SDK request. See HonchoEndpointConfig.headers. */
+  defaultHeaders?: Record<string, string>;
 }
 
 /** Get the base URL for Honcho API. Priority: baseUrl > environment > production */
@@ -979,13 +1020,20 @@ export function getHonchoBaseUrl(config: HonchoCLAUDEConfig): string {
 }
 
 export function getHonchoClientOptions(config: HonchoCLAUDEConfig): HonchoClientOptions {
-  return {
+  const options: HonchoClientOptions = {
     apiKey: config.apiKey,
     baseURL: getHonchoBaseUrl(config),
     workspaceId: config.workspace,
     timeout: 120000,
     maxRetries: 1,
   };
+  // Omitted entirely when unset, so the SDK request path is byte-identical for
+  // everyone not self-hosting behind a proxy.
+  const headers = config.endpoint?.headers;
+  if (headers && Object.keys(headers).length > 0) {
+    options.defaultHeaders = headers;
+  }
+  return options;
 }
 
 export function getEndpointInfo(config: HonchoCLAUDEConfig): { type: string; url: string } {

--- a/plugins/honcho/tests/config-helpers.test.ts
+++ b/plugins/honcho/tests/config-helpers.test.ts
@@ -2,7 +2,13 @@ import { describe, expect, test } from "bun:test";
 import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "fs";
 import { join } from "path";
 import { tmpdir } from "os";
-import { coerceBoolean, resolveWorktreeMainRoot, worktreeMainRootFor } from "../src/config";
+import {
+  coerceBoolean,
+  getHonchoClientOptions,
+  parseHeaders,
+  resolveWorktreeMainRoot,
+  worktreeMainRootFor,
+} from "../src/config";
 
 describe("coerceBoolean", () => {
   test("passes real booleans through", () => {
@@ -128,5 +134,48 @@ describe("worktree main-root resolution", () => {
     } finally {
       rmSync(tmp, { recursive: true, force: true });
     }
+  });
+});
+
+describe("parseHeaders", () => {
+  test("parses a JSON object of string values", () => {
+    expect(parseHeaders('{"CF-Access-Client-Id":"abc","CF-Access-Client-Secret":"def"}')).toEqual({
+      "CF-Access-Client-Id": "abc",
+      "CF-Access-Client-Secret": "def",
+    });
+  });
+
+  test("drops non-string values rather than sending them as headers", () => {
+    expect(parseHeaders('{"A":"1","B":2,"C":null}')).toEqual({ A: "1" });
+  });
+
+  test("malformed input is ignored, not fatal", () => {
+    // A broken env var must not take down a hook whose output nobody sees.
+    expect(parseHeaders("not json")).toBeUndefined();
+    expect(parseHeaders("[]")).toBeUndefined();
+    expect(parseHeaders("null")).toBeUndefined();
+    expect(parseHeaders("{}")).toBeUndefined();
+  });
+});
+
+describe("getHonchoClientOptions headers", () => {
+  const base = { apiKey: "k", workspace: "w", peerName: "p", aiPeer: "ai" };
+
+  test("omits defaultHeaders entirely when none are configured", () => {
+    const options = getHonchoClientOptions({ ...base });
+    expect("defaultHeaders" in options).toBe(false);
+  });
+
+  test("omits defaultHeaders when the map is empty", () => {
+    const options = getHonchoClientOptions({ ...base, endpoint: { headers: {} } });
+    expect("defaultHeaders" in options).toBe(false);
+  });
+
+  test("passes configured headers through to the client", () => {
+    const options = getHonchoClientOptions({
+      ...base,
+      endpoint: { baseUrl: "https://honcho.example.com", headers: { "CF-Access-Client-Id": "abc" } },
+    });
+    expect(options.defaultHeaders).toEqual({ "CF-Access-Client-Id": "abc" });
   });
 });


### PR DESCRIPTION
## What

Adds `endpoint.headers` (and a `HONCHO_HEADERS` env var) — extra HTTP headers sent on every request to Honcho.

## Why

A self-hosted Honcho behind an authenticating proxy — Cloudflare Access, oauth2-proxy, Authelia — rejects the request at the edge, before Honcho ever sees it. `apiKey` authenticates you to Honcho, but nothing authenticates you to what stands in front of it, so there is currently no way to reach such a deployment from the plugin at all.

The symptom is unhelpful: the proxy answers with its own HTML login page and the SDK fails parsing it as JSON —

```
SyntaxError: Unexpected token '<', "<!DOCTYPE "... is not valid JSON
```

Hooks fail quietly, so what the user actually notices is that nothing is being remembered.

## How

The SDK already accepts `defaultHeaders` and merges them into every request. The plugin just never passes them through, so this is plumbing:

```
config.endpoint.headers → getHonchoClientOptions() → new Honcho({ defaultHeaders })
```

All seven hooks and the MCP server construct their client through `getHonchoClientOptions`, so one change covers them.

Two deliberate choices:

- **`defaultHeaders` is omitted from the options object entirely when unset**, so the request path is byte-identical for everyone not self-hosting behind a proxy.
- **Malformed `HONCHO_HEADERS` is ignored, not fatal.** A broken env var should not take down a hook whose output the user never sees. `HONCHO_HEADERS` is handled in `mergeWithEnvVars` (like `HONCHO_API_KEY`) so it applies even when a config file exists — that is the case that matters, since it is how you keep the credential out of `config.json`.

## Testing

Verified end-to-end against a real Cloudflare Access gateway in front of a self-hosted Honcho, same client and API key both times:

```
WITHOUT headers: FAIL — SyntaxError: Unexpected token '<', "<!DOCTYPE "... is not valid JSON
WITH headers:    OK
```

Repo checks, from `plugins/honcho/`:

```
bunx tsc --noEmit             # clean
bun test                      # 36 pass, 0 fail
bun run scripts/build.ts      # staged 56 files
bash scripts/smoke.sh .stage  # all entry points OK
```

New unit tests cover `parseHeaders` (valid, non-string values dropped, malformed ignored) and that `getHonchoClientOptions` omits `defaultHeaders` when nothing is configured.

## Docs

- README: env var table row, plus a "Behind an authenticating proxy" subsection under self-hosting with both the config-file and env-var forms.
- CHANGELOG: entry under `[0.3.0] - unreleased`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for configuring extra HTTP headers on Honcho requests.
  - Headers can be set through configuration or the `HONCHO_HEADERS` environment variable.
  - Supports self-hosted deployments behind authenticating proxies.

- **Documentation**
  - Added setup guidance and troubleshooting information for authenticating proxy configurations.
  - Documented behavior when header configuration is missing or invalid.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->