### PR TITLE
feat: send X-Honcho-Host and X-Honcho-Plugin telemetry headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to claude-honcho will be documented in this file.
 
 ## [0.3.0] - unreleased
 
+### Added
+
+- Every Honcho request carries `X-Honcho-Host` and `X-Honcho-Plugin` headers (via `@honcho-ai/harness-plugin-core`) so server-side telemetry can attribute traffic to the plugin and host harness.
+
 ### Changed
 
 - The plugin is distributed as the npm package `@honcho-ai/claude-honcho` and the marketplace installs from it. Releases ship a self-contained bundle that runs under Node, so Bun is no longer a prerequisite for using the plugin — it remains the development toolchain.

--- a/plugins/honcho/bun.lock
+++ b/plugins/honcho/bun.lock
@@ -5,6 +5,7 @@
     "": {
       "name": "claude-honcho",
       "dependencies": {
+        "@honcho-ai/harness-plugin-core": "^0.1.0",
         "@honcho-ai/sdk": "^2.1.0",
         "@modelcontextprotocol/sdk": "^1.26.0",
       },
@@ -15,6 +16,8 @@
     },
   },
   "packages": {
+    "@honcho-ai/harness-plugin-core": ["@honcho-ai/harness-plugin-core@0.1.0", "", {}, "sha512-6xem7mPQMfYcXpn699BuelSOnIfugsj3kC3Mx7p4oK2xAp8PCkHyVFRkYOjSjTxDTMBowdQwCBu+494IC4xHvw=="],
+
     "@honcho-ai/sdk": ["@honcho-ai/sdk@2.1.0", "", { "dependencies": { "zod": "4.0.0" } }, "sha512-GPyeKTDRhg5jd77RAh63LwrxLxnbluLdYUF1gsI6g6CU4eTyv8s1+KJ3/OTCiBwJ/dhjznNvQUngkUjjnNzUTA=="],
 
     "@hono/node-server": ["@hono/node-server@1.19.9", "", { "peerDependencies": { "hono": "^4" } }, "sha512-vHL6w3ecZsky+8P5MD+eFfaGTyCeOHUIFYMGpQGbrBTSmNNoxv0if69rEZ5giu36weC5saFuznL411gRX7bJDw=="],

--- a/plugins/honcho/package.json
+++ b/plugins/honcho/package.json
@@ -15,6 +15,7 @@
   "author": "Plastic Labs",
   "license": "MIT",
   "dependencies": {
+    "@honcho-ai/harness-plugin-core": "^0.1.0",
     "@honcho-ai/sdk": "^2.1.0",
     "@modelcontextprotocol/sdk": "^1.26.0"
   },

--- a/plugins/honcho/src/config.ts
+++ b/plugins/honcho/src/config.ts
@@ -4,6 +4,7 @@ import { fileURLToPath } from "url";
 import { existsSync, mkdirSync, readFileSync, statSync, writeFileSync } from "fs";
 import { captureGitState } from "./git.js";
 import { getInstanceIdForCwd, getClaudeInstanceId } from "./cache.js";
+import { telemetryHeaders } from "@honcho-ai/harness-plugin-core";
 
 function sanitizeForSessionName(s: string): string {
   return s.toLowerCase().replace(/[^a-z0-9-_]/g, "-");
@@ -959,6 +960,7 @@ export interface HonchoClientOptions {
   workspaceId: string;
   timeout?: number;
   maxRetries?: number;
+  defaultHeaders?: Record<string, string>;
 }
 
 /** Get the base URL for Honcho API. Priority: baseUrl > environment > production */
@@ -978,6 +980,15 @@ export function getHonchoBaseUrl(config: HonchoCLAUDEConfig): string {
   return getHonchoBaseUrlForEndpoint(config.endpoint);
 }
 
+/** Client identity headers (`X-Honcho-Host`, `X-Honcho-Plugin`) for telemetry attribution. */
+export function getTelemetryHeaders(host: HonchoHost = getDetectedHost()): Record<string, string> {
+  return telemetryHeaders({
+    host: host.replace(/_/g, "-"),
+    plugin: "claude-honcho",
+    pluginVersion: getPluginVersion(),
+  });
+}
+
 export function getHonchoClientOptions(config: HonchoCLAUDEConfig): HonchoClientOptions {
   return {
     apiKey: config.apiKey,
@@ -985,6 +996,7 @@ export function getHonchoClientOptions(config: HonchoCLAUDEConfig): HonchoClient
     workspaceId: config.workspace,
     timeout: 120000,
     maxRetries: 1,
+    defaultHeaders: getTelemetryHeaders(),
   };
 }
 

--- a/plugins/honcho/tests/config-helpers.test.ts
+++ b/plugins/honcho/tests/config-helpers.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "bun:test";
 import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "fs";
 import { join } from "path";
 import { tmpdir } from "os";
-import { coerceBoolean, resolveWorktreeMainRoot, worktreeMainRootFor } from "../src/config";
+import { coerceBoolean, getHonchoClientOptions, getTelemetryHeaders, resolveWorktreeMainRoot, worktreeMainRootFor } from "../src/config";
 
 describe("coerceBoolean", () => {
   test("passes real booleans through", () => {
@@ -128,5 +128,19 @@ describe("worktree main-root resolution", () => {
     } finally {
       rmSync(tmp, { recursive: true, force: true });
     }
+  });
+});
+
+describe("telemetry headers", () => {
+  test("identify host and plugin, omit the agent model", () => {
+    const headers = getTelemetryHeaders("claude_code");
+    expect(headers["X-Honcho-Host"]).toBe(`claude-code (${process.platform})`);
+    expect(headers["X-Honcho-Plugin"]).toMatch(/^claude-honcho\/\d+\.\d+\.\d+/);
+    expect(headers["X-Honcho-Agent-Model"]).toBeUndefined();
+  });
+
+  test("ride along on every client's default headers", () => {
+    const opts = getHonchoClientOptions({ apiKey: "k", workspace: "w" } as never);
+    expect(opts.defaultHeaders).toEqual(getTelemetryHeaders());
   });
 });


### PR DESCRIPTION
Every Honcho client built via getHonchoClientOptions now carries the identity headers from @honcho-ai/harness-plugin-core, so server-side telemetry can attribute traffic to the plugin and host harness. Agent model and host version are omitted for now.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Honcho requests now include host and plugin identification headers, improving server-side telemetry and traffic attribution.
  * Client requests automatically include these headers in their default configuration.

* **Tests**
  * Added coverage to verify telemetry headers identify the host and plugin while excluding agent model information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->